### PR TITLE
#15: port /stats

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -7,6 +7,7 @@ exports.commandFiles = [
 	"create-bounty-board.js",
 	"feedback.js",
 	"scoreboard.js",
+	"stats.js",
 	"version.js"
 ];
 /** @type {Record<string, CommandWrapper>} */

--- a/source/commands/feedback.js
+++ b/source/commands/feedback.js
@@ -17,7 +17,7 @@ const subcommands = [];
 module.exports = new CommandWrapper(customId, "Provide feedback on this bot to the developers", PermissionFlagsBits.SendMessages, false, true, 3000, options, subcommands,
 	/** Open the modal associated with the feedback type to prompt more specific information */
 	(interaction) => {
-		const feedbackType = interaction.options.getString("feedback-type");
+		const feedbackType = interaction.options.getString(options[0].name);
 		let modal = new ModalBuilder();
 		switch (feedbackType) {
 			case "bug":

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -19,7 +19,7 @@ const subcommands = [];
 module.exports = new CommandWrapper(customId, "View the XP scoreboard", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
 	/** View the XP scoreboard */
 	(interaction) => {
-		buildScoreboardEmbed(interaction.guild, interaction.options.getString("scoreboard-type") === "season").then(embed => {
+		buildScoreboardEmbed(interaction.guild, interaction.options.getString(options[0].name) === "season").then(embed => {
 			interaction.reply({
 				embeds: [embed],
 				ephemeral: true

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -47,7 +47,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 								.setAuthor(ihpAuthorPayload)
 								.setThumbnail(target.user.avatarURL())
 								.setTitle(`${target.displayName} is __Level ${hunter.level}__`)
-								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned * ${hunter.seasonXP} XP * this season.`)
+								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.seasonXP} XP* this season.`)
 								.addFields(
 									//TODO previous season placements
 									{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -1,0 +1,116 @@
+const { PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { buildGuildStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../embedHelpers');
+const { database } = require('../../database');
+const { generateTextBar } = require('../helpers');
+const { Hunter } = require('../models/users/Hunter');
+
+const customId = "stats";
+const options = [
+	{
+		type: "User",
+		name: "bounty-hunter",
+		description: "Whose stats to check, BountyBot for the guild's stats",
+		required: false,
+		choices: []
+	}
+];
+const subcommands = [];
+module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yourself or someone else", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
+	/** Get the BountyBot stats for yourself or someone else */
+	(interaction) => {
+		const target = interaction.options.getMember("user"); //TODO switch from magic string "user" to options[0].name
+		if (target && target.id !== interaction.user.id) {
+			if (target.id == interaction.client.user.id) {
+				// BountyBot
+				buildGuildStatsEmbed(interaction.guild).then(embed => {
+					interaction.reply({
+						embeds: [embed],
+						ephemeral: true
+					});
+				})
+			} else {
+				// Other Hunter
+				database.models.Hunter.findOne({ where: { userId: target.id, guildId: interaction.guildId } }).then(async hunter => {
+					if (!hunter) {
+						interaction.reply({ content: "The specified user doesn't seem to have a profile with this server's BountyBot yet. It'll be created when they gain XP.", ephemeral: true });
+						return;
+					}
+
+					const { xpCoefficient } = await database.models.Guild.findByPk(interaction.guildId);
+					const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
+					const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
+
+					interaction.reply({
+						embeds: [
+							new EmbedBuilder().setColor(target.displayColor)
+								.setAuthor(ihpAuthorPayload)
+								.setThumbnail(target.user.avatarURL())
+								.setTitle(`${target.displayName} is __Level ${hunter.level}__`)
+								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned * ${hunter.seasonXP} XP * this season.`)
+								.addFields(
+									//TODO previous season placements
+									{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
+									{ name: "Bounties Hunted", value: `${hunter.othersFinished} bount${hunter.othersFinished == 1 ? 'y' : 'ies'}`, inline: true },
+									{ name: "Bounty Postings", value: `${hunter.mineFinished} bount${hunter.mineFinished == 1 ? 'y' : 'ies'}`, inline: true },
+									{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
+									{ name: "\u200B", value: "\u200B" },
+									{ name: "Toasts Raised", value: `${hunter.toastsRaised} toast${hunter.toastsRaised == 1 ? "" : "s"}`, inline: true },
+									{ name: "Toasts Recieved", value: `${hunter.toastsReceived} toast${hunter.toastsReceived == 1 ? "" : "s"}`, inline: true },
+									{ name: "\u200B", value: "\u200B", inline: true }
+								)
+								.setFooter(randomFooterTip())
+								.setTimestamp()
+						],
+						ephemeral: true
+					});
+				})
+			}
+		} else {
+			// Self
+			database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(async hunter => {
+				if (!hunter) {
+					interaction.reply("You don't seem to have a profile with this server's BountyBot yet. It'll be created when you gain XP.");
+					return;
+				}
+
+				const { xpCoefficient, maxSimBounties } = await database.models.Guild.findByPk(interaction.guildId);
+				const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
+				const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
+				const bountySlots = hunter.maxSlots(maxSimBounties);
+
+				interaction.reply({
+					embeds: [
+						new EmbedBuilder().setColor(interaction.member.displayColor)
+							.setAuthor(ihpAuthorPayload)
+							.setThumbnail(interaction.user.avatarURL())
+							.setTitle(`You are __Level ${hunter.level}__ in ${interaction.guild.name}`)
+							.setDescription(
+								`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)} *Next Level:* ${nextLevelThreshold - hunter.xp} XP\n\
+								You have earned *${hunter.seasonXP} XP* this season${false /* TODO rankString */ ? ` which qualifies for the rank @${"" /* TODO rankString */}` : ""}.\n\n\
+								You have ${bountySlots} bounty slot${bountySlots == 1 ? '' : 's'}!`
+							)
+							.addFields(
+								//TODO previous season placements
+								{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
+								{ name: `Level ${hunter.level + 1} Reward`, value: hunter.levelUpReward(hunter.level + 1, maxSimBounties, true), inline: true },
+								{ name: `Level ${hunter.level + 2} Reward`, value: hunter.levelUpReward(hunter.level + 2, maxSimBounties, true), inline: true },
+								{ name: `Level ${hunter.level + 3} Reward`, value: hunter.levelUpReward(hunter.level + 3, maxSimBounties, true), inline: true },
+								{ name: "\u200B", value: "\u200B" },
+								{ name: "Bounties Hunted", value: `${hunter.othersFinished} bount${hunter.othersFinished == 1 ? 'y' : 'ies'}`, inline: true },
+								{ name: "Bounty Postings", value: `${hunter.mineFinished} bount${hunter.mineFinished == 1 ? 'y' : 'ies'}`, inline: true },
+								{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
+								{ name: "\u200B", value: "\u200B" },
+								{ name: "Toasts Raised", value: `${hunter.toastsRaised} toast${hunter.toastsRaised == 1 ? "" : "s"}`, inline: true },
+								{ name: "Toasts Recieved", value: `${hunter.toastsReceived} toast${hunter.toastsReceived == 1 ? "" : "s"}`, inline: true },
+								{ name: "\u200B", value: "\u200B", inline: true }
+							)
+							.setFooter(randomFooterTip())
+							.setTimestamp()
+					],
+					ephemeral: true
+				});
+			})
+		}
+	}
+);

--- a/source/constants.js
+++ b/source/constants.js
@@ -11,3 +11,5 @@ exports.announcementsChannelId = announcementsChannelId;
 exports.lastPostedVersion = lastPostedVersion;
 
 exports.MAX_EMBED_TITLE_LENGTH = 256;
+
+exports.GUILD_XP_COEFFICIENT = 3;

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,0 +1,17 @@
+/** Create a text-only ratio bar that fills left to right
+ * @param {number} numerator
+ * @param {number} denominator
+ * @param {number} barLength
+ */
+exports.generateTextBar = function (numerator, denominator, barLength) {
+	const filledBlocks = Math.floor(barLength * numerator / denominator);
+	let bar = "";
+	for (let i = 0; i < barLength; i++) {
+		if (filledBlocks > i) {
+			bar += "▰";
+		} else {
+			bar += "▱";
+		}
+	}
+	return bar;
+}

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -7,6 +7,10 @@ const guildModel = {
 		type: STRING,
 		allowNull: false
 	},
+	level: {
+		type: INTEGER,
+		defaultValue: 1
+	},
 	announcementPrefix: {
 		type: STRING,
 		defaultValue: '@here'

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -18,9 +18,6 @@ const hunterModel = {
 			model: 'Guild'
 		}
 	},
-	boardId: {
-		type: STRING
-	},
 	level: {
 		type: BIGINT,
 		defaultValue: 1
@@ -89,54 +86,26 @@ const hunterModel = {
 	}
 };
 exports.Hunter = class Hunter extends Model {
-	// static xpThreshold(level, xpCoefficient) {
-	// 	// xp = xpCoefficient*(level - 1)^2
-	// 	return xpCoefficient * (level - 1) ** 2;
-	// }
+	static xpThreshold(level, xpCoefficient) {
+		// xp = xpCoefficient*(level - 1)^2
+		return xpCoefficient * (level - 1) ** 2;
+	}
 
-	// maxSlots(maxSimBounties) {
-	// 	let slots = 1 + Math.floor(this.level / 12) * 2;
-	// 	let remainder = this.level % 12;
-	// 	if (remainder >= 3) {
-	// 		slots++;
-	// 		remainder -= 3;
-	// 	}
-	// 	if (remainder >= 7) {
-	// 		slots++;
-	// 	}
-	// 	return Math.min(slots, maxSimBounties);
-	// }
+	maxSlots(maxSimBounties) {
+		let slots = 1 + Math.floor(this.level / 12) * 2;
+		let remainder = this.level % 12;
+		if (remainder >= 3) {
+			slots++;
+			remainder -= 3;
+		}
+		if (remainder >= 7) {
+			slots++;
+		}
+		return Math.min(slots, maxSimBounties);
+	}
 
 	// slotWorth(slotNum) {
 	// 	return Math.floor(6 + 0.5 * this.level - 3 * slotNum + 0.5 * slotNum % 2);
-	// }
-
-	// xpBarBuilder(xpCoefficient, barLength) {
-	// 	const thisLevelThreshold = Hunter.xpThreshold(this.level, xpCoefficient);
-	// 	const filledBlocks = Math.floor((this.xp - thisLevelThreshold) / (Hunter.xpThreshold(this.level + 1, xpCoefficient) - thisLevelThreshold) * barLength);
-	// 	let bar = '';
-	// 	for (let i = 0; i < barLength; i++) {
-	// 		if (filledBlocks > i) {
-	// 			bar += "▰";
-	// 		} else {
-	// 			bar += "▱";
-	// 		}
-	// 	}
-	// 	return bar;
-	// }
-
-	// finalStats(embed, footerText, footerURL) {
-	// 	embed.addField("Bounties Hunted", `${this.othersFinished} bount${this.othersFinished == 1 ? 'y' : 'ies'}`, true)
-	// 		.addField("Bounty Postings", `${this.mineFinished} bount${this.mineFinished == 1 ? 'y' : 'ies'}`, true)
-	// 		.addField("Total XP Earned", `${this.xp} XP`, true)
-	// 		.addBlankField()
-	// 		.addField(`Toasts Raised`, `${this.toastsRaised} toast${this.toastsRaised == 1 ? "" : "s"}`, true)
-	// 		.addField(`Toasts Recieved`, `${this.toastsReceived} toast${this.toastsReceived == 1 ? "" : "s"}`, true)
-	// 		.setFooter({ text: footerText, iconURL: footerURL })
-	// 		.addBlankField(true)
-	// 		.setTimestamp();
-
-	// 	return embed;
 	// }
 
 	// myModDetails(guild, member, { maxSimBounties, pinChannelId }, lastFiveBounties) {
@@ -164,21 +133,21 @@ exports.Hunter = class Hunter extends Model {
 	// 	return embed.addField("Last 5 Completed Bounties Created by this User", bountyHistory);
 	// }
 
-	// levelUpReward(level, maxSlots, futureReward = true) {
-	// 	let text = "";
-	// 	if (level % 2) {
-	// 		text += `Your bounties in odd-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
-	// 	} else {
-	// 		text += `Your bounties in even-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
-	// 	}
-	// 	const currentSlots = this.maxSlots(maxSlots);
-	// 	if (currentSlots < maxSlots) {
-	// 		if (level == 3 + 12 * Math.floor((currentSlots - 2) / 2) + 7 * ((currentSlots - 2) % 2)) {
-	// 			text += ` You ${futureReward ? "will" : "have"} unlock${futureReward ? "" : "ed"} bounty slot #${currentSlots}.`;
-	// 		};
-	// 	}
-	// 	return text;
-	// }
+	levelUpReward(level, maxSlots, futureReward = true) {
+		let text = "";
+		if (level % 2) {
+			text += `Your bounties in odd-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
+		} else {
+			text += `Your bounties in even-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
+		}
+		const currentSlots = this.maxSlots(maxSlots);
+		if (currentSlots < maxSlots) {
+			if (level == 3 + 12 * Math.floor((currentSlots - 2) / 2) + 7 * ((currentSlots - 2) % 2)) {
+				text += ` You ${futureReward ? "will" : "have"} unlock${futureReward ? "" : "ed"} bounty slot #${currentSlots}.`;
+			};
+		}
+		return text;
+	}
 }
 
 exports.initModel = function (sequelize) {


### PR DESCRIPTION
Summary
-------
- ported /stats with following changes
   - added level property to Guild instead of reimplementing BotHunter
   - /stats shows the self-embed when a user specifies themself as an argument
   - guildstats embed is now blurple instead of user's color
   - implemented generateTextBar instead of buildXPBar (more general)
   - added 404 early outs, allowing lazier hunter generation

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /stats on self (no argument)
- [x] /stats on self (self as argument)
- [x] /stats on BountyBot
- [x] /stats on other hunter (could not find)
- [x] /stats on other hunter

Issue
-----
Closes #15