### PR TITLE
#2: port `/bounty post`

### DIFF
--- a/database.js
+++ b/database.js
@@ -7,9 +7,13 @@ exports.database = new Sequelize({
 
 exports.database.authenticate().then(() => {
 	require('./source/models/guilds/Guild.js').initModel(exports.database);
+	require('./source/models/guilds/GuildRank.js').initModel(exports.database);
 
 	require('./source/models/users/User.js').initModel(exports.database);
 	require('./source/models/users/Hunter.js').initModel(exports.database);
+
+	require('./source/models/bounties/Bounty.js').initModel(exports.database);
+	require('./source/models/bounties/Completion.js').initModel(exports.database);
 
 	exports.database.sync();
 })

--- a/source/classes/InteractionWrapper.js
+++ b/source/classes/InteractionWrapper.js
@@ -23,7 +23,7 @@ class CommandWrapper extends module.exports.InteractionWrapper {
 	/** Additional wrapper properties for command parsing
 	 * @param {string} customIdInput
 	 * @param {string} descriptionInput
-	 * @param {import("discord.js").PermissionFlags} defaultMemberPermission
+	 * @param {import("discord.js").PermissionFlags | null} defaultMemberPermission
 	 * @param {boolean} isPremiumCommand
 	 * @param {boolean} allowInDMsInput
 	 * @param {number} cooldownInMS
@@ -37,8 +37,10 @@ class CommandWrapper extends module.exports.InteractionWrapper {
 		this.data = new SlashCommandBuilder()
 			.setName(customIdInput)
 			.setDescription(descriptionInput)
-			.setDefaultMemberPermissions(defaultMemberPermission)
 			.setDMPermission(allowInDMsInput);
+		if (defaultMemberPermission) {
+			this.data.setDefaultMemberPermissions(defaultMemberPermission);
+		}
 		optionsInput.forEach(option => {
 			this.data[`add${option.type}Option`](built => {
 				built.setName(option.name).setDescription(option.description).setRequired(option.required);

--- a/source/classes/InteractionWrapper.js
+++ b/source/classes/InteractionWrapper.js
@@ -33,7 +33,6 @@ class CommandWrapper extends module.exports.InteractionWrapper {
 	 */
 	constructor(customIdInput, descriptionInput, defaultMemberPermission, isPremiumCommand, allowInDMsInput, cooldownInMS, optionsInput, subcommandsInput, executeFunction) {
 		super(customIdInput, cooldownInMS, executeFunction);
-		this.description = descriptionInput;
 		this.premiumCommand = isPremiumCommand;
 		this.data = new SlashCommandBuilder()
 			.setName(customIdInput)

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -3,6 +3,7 @@ const { CommandWrapper } = require('../classes');
 /** @type {string[]} */
 exports.commandFiles = [
 	"about.js",
+	"bounty.js",
 	"commands.js",
 	"create-bounty-board.js",
 	"feedback.js",

--- a/source/commands/about.js
+++ b/source/commands/about.js
@@ -4,7 +4,7 @@ const { CommandWrapper } = require('../classes');
 const customId = "about";
 const options = [];
 const subcommands = [];
-module.exports = new CommandWrapper(customId, "Get BountyBot's description and contributors", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "Get BountyBot's description and contributors", null, false, true, 3000, options, subcommands,
 	/** Get BountyBot's description and contributors */
 	(interaction) => {
 		const avatarURL = interaction.client.user.avatarURL();

--- a/source/commands/about.js
+++ b/source/commands/about.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, EmbedBuilder, Colors } = require('discord.js');
+const { EmbedBuilder, Colors } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 
 const customId = "about";

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -1,0 +1,65 @@
+const { PermissionFlagsBits, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { getNumberEmoji } = require('../helpers');
+
+const customId = "bounty";
+const options = [];
+const subcommands = [
+	{
+		name: "post",
+		description: "Post your own bounty (+1 XP)",
+		optionsInput: []
+	}
+];
+module.exports = new CommandWrapper(customId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+	(interaction) => {
+		switch (interaction.options.getSubcommand()) {
+			case subcommands[0].name: // Post
+				database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(async hunter => {
+					if (!hunter) { //TODO use findOrCreate after double-checking associations (may not cascade from hunter to user correctly)
+						const user = await database.models.User.findByPk(interaction.user.id);
+						if (!user) {
+							await database.models.User.create({ id: interaction.user.id });
+						}
+						hunter = await database.models.Hunter.create({ userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: !interaction.member.manageable });
+					}
+
+					const { maxSimBounties } = await database.models.Guild.findByPk(interaction.guildId);
+
+					const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, state: "open" } });
+					const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
+					const bountySlots = hunter.maxSlots(maxSimBounties);
+					const slotOptions = [];
+					for (let slotNumber = 1; slotNumber <= bountySlots; slotNumber++) {
+						if (!occupiedSlots.includes(slotNumber)) {
+							slotOptions.push({
+								emoji: getNumberEmoji(slotNumber),
+								label: `Slot ${slotNumber}`,
+								description: `Reward: ${hunter.slotWorth(slotNumber)} XP`,
+								value: slotNumber.toString()
+							})
+						}
+					}
+
+					if (slotOptions.length > 0) {
+						interaction.reply({
+							content: "You can post a bounty for other server members to help out with. Here's some examples:\n\t• __Party Up__ Get bounty hunters to join you for a game session\n\t• __WTB/WTS__ Get the word out your looking to trade\n\t• __Achievement Get__ Get help working toward an achievement\n\nTo make a bounty, you'll need:\n\t• a title\n\t• a description\nOptionally, you can also add:\n\t• a url for an image\n\t• a start and end time (to make an event to go with your bounty)\n\nKeep in mind that while you're in charge of adding completers and ending the bounty, the bounty is still subject to server rules and moderation.",
+							components: [
+								new ActionRowBuilder().addComponents(
+									new StringSelectMenuBuilder().setCustomId("bountypostselect")
+										.setPlaceholder("XP awarded depends on slot used...")
+										.setMaxValues(1)
+										.setOptions(slotOptions)
+								)
+							],
+							ephemeral: true
+						});
+					} else {
+						interaction.reply({ content: "You don't seem to have any open bounty slots at the moment.", ephemeral: true });
+					}
+				})
+				break;
+		}
+	}
+);

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -12,7 +12,7 @@ const subcommands = [
 		optionsInput: []
 	}
 ];
-module.exports = new CommandWrapper(customId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
 	(interaction) => {
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // Post

--- a/source/commands/commands.js
+++ b/source/commands/commands.js
@@ -1,4 +1,3 @@
-const { PermissionFlagsBits } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 
 const customId = "commands";

--- a/source/commands/commands.js
+++ b/source/commands/commands.js
@@ -4,7 +4,7 @@ const { CommandWrapper } = require('../classes');
 const customId = "commands";
 const options = [];
 const subcommands = [];
-module.exports = new CommandWrapper(customId, "Get a link to BountyBot's commands page", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "Get a link to BountyBot's commands page", null, false, true, 3000, options, subcommands,
 	/** Link the user to the repo Commands wiki page (automatically updated) */
 	(interaction) => {
 		interaction.reply({ content: "Here's a link to the BountyBot Commands page (automatically updated): https://github.com/Imaginary-Horizons-Productions/BountyBot/wiki/Commands", ephemeral: true });

--- a/source/commands/create-bounty-board.js
+++ b/source/commands/create-bounty-board.js
@@ -44,7 +44,7 @@ module.exports = new CommandWrapper(customId, "Create a new bounty board forum c
 			scoreboardPost.pin();
 			guildProfile.scoreId = scoreboardPost.id;
 
-			database.models.Bounty.findAll({ where: { guildId: interaction.guildId, state: "open" } }).then(bounties => {
+			database.models.Bounty.findAll({ where: { guildId: interaction.guildId, state: "open" }, order: [["createdAt", "DESC"]] }).then(bounties => {
 				for (const bounty of bounties) {
 					bounty.asEmbed(interaction.guild, undefined, guildProfile).then(bountyEmbed => {
 						return bountyBoard.threads.create({

--- a/source/commands/create-bounty-board.js
+++ b/source/commands/create-bounty-board.js
@@ -27,7 +27,7 @@ module.exports = new CommandWrapper(customId, "Create a new bounty board forum c
 			],
 			//TODO use "availableTags" to allow tagging bounties ("completed", "event", "open" as default tags?)
 			defaultSortOrder: SortOrderType.CreationDate,
-			defaultForumLayout: ForumLayoutType.GalleryView,
+			defaultForumLayout: ForumLayoutType.ListView,
 			reason: `/create-bounty-board by ${interaction.user}`
 		}).then(async bountyBoard => {
 			let guildProfile = await database.models.Guild.findByPk(interaction.guildId);
@@ -44,7 +44,19 @@ module.exports = new CommandWrapper(customId, "Create a new bounty board forum c
 			scoreboardPost.pin();
 			guildProfile.scoreId = scoreboardPost.id;
 
-			//TODO create posts for existing bounties
+			database.models.Bounty.findAll({ where: { guildId: interaction.guildId, state: "open" } }).then(bounties => {
+				for (const bounty of bounties) {
+					bounty.asEmbed(interaction.guild, undefined, guildProfile).then(bountyEmbed => {
+						return bountyBoard.threads.create({
+							name: bounty.title,
+							message: { embeds: [bountyEmbed] }
+						})
+					}).then(posting => {
+						bounty.postingId = posting.id;
+						bounty.save()
+					})
+				}
+			});
 
 			guildProfile.save();
 			interaction.reply({ content: `A new bounty board has been created: ${bountyBoard}`, ephemeral: true });

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -1,4 +1,3 @@
-const { PermissionFlagsBits } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { buildScoreboardEmbed } = require('../embedHelpers');
 

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -16,7 +16,7 @@ const options = [
 	}
 ];
 const subcommands = [];
-module.exports = new CommandWrapper(customId, "View the XP scoreboard", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "View the XP scoreboard", null, false, false, 3000, options, subcommands,
 	/** View the XP scoreboard */
 	(interaction) => {
 		buildScoreboardEmbed(interaction.guild, interaction.options.getString(options[0].name) === "season").then(embed => {

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { EmbedBuilder } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { buildGuildStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../embedHelpers');
 const { database } = require('../../database');

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -10,7 +10,7 @@ const options = [
 	{
 		type: "User",
 		name: "bounty-hunter",
-		description: "Whose stats to check, BountyBot for the guild's stats",
+		description: "Whose stats to check (defaults to yourself); input BountyBot for the server stats",
 		required: false,
 		choices: []
 	}

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -16,7 +16,7 @@ const options = [
 	}
 ];
 const subcommands = [];
-module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yourself or someone else", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yourself or someone else", null, false, false, 3000, options, subcommands,
 	/** Get the BountyBot stats for yourself or someone else */
 	(interaction) => {
 		const target = interaction.options.getMember("user"); //TODO switch from magic string "user" to options[0].name

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -10,7 +10,7 @@ const options = [
 	{
 		type: "User",
 		name: "bounty-hunter",
-		description: "Whose stats to check (defaults to yourself); input BountyBot for the server stats",
+		description: "Whose stats to check; BountyBot for the server stats, empty for yourself",
 		required: false,
 		choices: []
 	}

--- a/source/commands/version.js
+++ b/source/commands/version.js
@@ -7,7 +7,7 @@ const options = [
 	{ type: "Boolean", name: "get-recent-changes", description: "Otherwise get the full change log", required: true, choices: [] }
 ];
 const subcommands = [];
-module.exports = new CommandWrapper(customId, "Get the most recent changes or the full change log", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+module.exports = new CommandWrapper(customId, "Get the most recent changes or the full change log", null, false, true, 3000, options, subcommands,
 	/** Send the user the most recent set of patch notes or full change log */
 	(interaction) => {
 		if (interaction.options.getBoolean(options[0].name)) {

--- a/source/commands/version.js
+++ b/source/commands/version.js
@@ -1,4 +1,3 @@
-const { PermissionFlagsBits } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { buildVersionEmbed } = require('../embedHelpers');
 

--- a/source/constants.js
+++ b/source/constants.js
@@ -1,5 +1,6 @@
 exports.SAFE_DELIMITER = "→";
 exports.MAX_SET_TIMEOUT = 2 ** 31 - 1;
+exports.YEAR_IN_MS = 31556926000;
 
 exports.authPath = "../config/auth.json";
 const { testGuildId, feedbackChannelId } = require(exports.authPath);

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -28,16 +28,10 @@ exports.randomFooterTip = function () {
 }
 
 exports.buildGuildStatsEmbed = async function (guild) {
-	return database.models.Hunter.findAll({ where: { guildId: guild.id, seasonXP: { [Op.gt]: 0 } }, order: [["seasonXP", "DESC"]] }).then(async allHunters => {
-		const { level: guildLevel, seasonXP, lastSeasonXP, seasonBounties, bountiesLastSeason, seasonToasts, toastsLastSeason } = await database.models.Guild.findByPk(guild.id);
-		let seasonParticipants = [];
-		let hunterLevelsTotal = 0;
-		for (const hunter of allHunters) {
-			if (hunter.seasonXP > 0) {
-				seasonParticipants.push(hunter);
-			}
-			hunterLevelsTotal += hunter.level;
-		}
+	return database.models.Hunter.findAll({ where: { guildId: guild.id, seasonXP: { [Op.gt]: 0 } }, order: [["seasonXP", "DESC"]] }).then(async seasonParticipants => {
+		const { xp: guildXPPromise, level: guildLevel, seasonXP, lastSeasonXP, seasonBounties, bountiesLastSeason, seasonToasts, toastsLastSeason } = await database.models.Guild.findByPk(guild.id);
+		const guildXP = await guildXPPromise;
+
 		const currentLevelThreshold = Hunter.xpThreshold(guildLevel, GUILD_XP_COEFFICIENT);
 		const nextLevelThreshold = Hunter.xpThreshold(guildLevel + 1, GUILD_XP_COEFFICIENT);
 		const particpantPercentage = seasonParticipants.length / guild.memberCount * 100;
@@ -48,9 +42,9 @@ exports.buildGuildStatsEmbed = async function (guild) {
 			.setAuthor(exports.ihpAuthorPayload)
 			.setTitle(`${guild.name} is __Level ${guildLevel}__`)
 			.setThumbnail(guild.iconURL())
-			.setDescription(`${generateTextBar(hunterLevelsTotal - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - hunterLevelsTotal} Bounty Hunter Levels`)
+			.setDescription(`${generateTextBar(guildXP - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - guildXP} Bounty Hunter Levels`)
 			.addFields(
-				{ name: "Total Bounty Hunter Level", value: `${hunterLevelsTotal} levels`, inline: true },
+				{ name: "Total Bounty Hunter Level", value: `${guildXP} level${guildXP == 1 ? "" : "s"}`, inline: true },
 				{ name: "Participation", value: `${seasonParticipants.length} server members have interacted with BountyBot this season (${particpantPercentage.toPrecision(3)}% of server members)` },
 				{ name: `${seasonXP} XP Earned Total (${seasonXPDifference === 0 ? "same as last season" : `${seasonXPDifference > 0 ? `+${seasonXPDifference} more XP` : `${seasonXPDifference * -1} fewer XP`} than last season`})`, value: `${seasonBounties} bounties (${seasonBountyDifference === 0 ? "same as last season" : `${seasonBountyDifference > 0 ? `**+${seasonBountyDifference} more bounties**` : `**${seasonBountyDifference * -1} fewer bounties**`} than last season`})\n${seasonToasts} toasts (${seasonToastDifference === 0 ? "same as last season" : `${seasonToastDifference > 0 ? `**+${seasonToastDifference} more toasts**` : `**${seasonToastDifference * -1} fewer toasts**`} than last season`})` }
 			)

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -13,7 +13,8 @@ const discordTips = [
 	{ text: "Surround your message with || to mark it a spoiler (not shown until reader clicks on it).", iconURL: discordIconURL },
 	{ text: "Surround a part of your messag with ~~ to add strikethrough styling.", iconURL: discordIconURL },
 	{ text: "Don't forget to check slash commands for optional arguments.", iconURL: discordIconURL },
-	{ text: "Some slash commands can be used in DMs, others can't.", iconURL: discordIconURL }
+	{ text: "Some slash commands can be used in DMs, others can't.", iconURL: discordIconURL },
+	{ text: "Server subscriptions cost more on mobile because the mobile app stores take a cut.", iconURL: discordIconURL }
 ];
 /** @type {import("discord.js").EmbedFooterData[]} */
 const applicationSpecificTips = [];

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -118,7 +118,7 @@ exports.setRanks = async (participants, ranks) => {
  * @returns an array of rank and placement update strings
  */
 exports.getRankUpdates = async function (guild, force = false) {
-	const allHunters = await database.models.Hunter.findAll({ where: { guildId: guild.id, seasonXP: { [Op.gt]: 0 } }, order: [["seasonXP", "DESC"]] });
+	const allHunters = await database.models.Hunter.findAll({ where: { guildId: guild.id }, order: [["seasonXP", "DESC"]] });
 	const ranks = await database.models.GuildRank.findAll({ where: { guildId: guild.id }, order: [["varianceThreshold", "ASC"]] });
 	return exports.setRanks(allHunters, ranks).then(async (firstPlaceMessage) => {
 		const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -140,10 +140,12 @@ exports.getRankUpdates = async function (guild, force = false) {
 				let destinationRole;
 				if (member.manageable) {
 					await member.roles.remove(roleIds);
-					const rankRoleId = ranks[hunter.rank].roleId;
-					if (rankRoleId) {
-						await member.roles.add(rankRoleId);
-						destinationRole = await guild.roles.fetch(rankRoleId);
+					if (hunter.isRankEligible) { // Feature: remove rank roles from DQ'd users but don't give them new ones
+						const rankRoleId = ranks[hunter.rank].roleId;
+						if (rankRoleId) {
+							await member.roles.add(rankRoleId);
+							destinationRole = await guild.roles.fetch(rankRoleId);
+						}
 					}
 				}
 				if (hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -37,32 +37,24 @@ exports.generateTextBar = function (numerator, denominator, barLength) {
 	return bar;
 }
 
+const NUMBER_EMOJI = {
+	0: '0️⃣',
+	1: '1️⃣',
+	2: '2️⃣',
+	3: '3️⃣',
+	4: '4️⃣',
+	5: '5️⃣',
+	6: '6️⃣',
+	7: '7️⃣',
+	8: '8️⃣',
+	9: '9️⃣',
+	10: '🔟'
+};
 exports.getNumberEmoji = function (number) {
-	switch (Number(number)) {
-		case 0:
-			return '0️⃣';
-		case 1:
-			return '1️⃣';
-		case 2:
-			return '2️⃣';
-		case 3:
-			return '3️⃣';
-		case 4:
-			return '4️⃣';
-		case 5:
-			return '5️⃣';
-		case 6:
-			return '6️⃣';
-		case 7:
-			return '7️⃣';
-		case 8:
-			return '8️⃣';
-		case 9:
-			return '9️⃣';
-		case 10:
-			return '🔟';
-		default:
-			return '#️⃣';
+	if (number in NUMBER_EMOJI) {
+		return NUMBER_EMOJI[number];
+	} else {
+		return '#️⃣';
 	}
 }
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,3 +1,24 @@
+const { Op } = require("sequelize");
+const { database } = require("../database");
+const { Guild } = require("discord.js");
+const { Hunter } = require("./models/users/Hunter");
+const { GuildRank } = require("./models/guilds/GuildRank");
+
+const CONGRATULATORY_PHRASES = [
+	"Congratulations",
+	"Well done",
+	"You've done it",
+	"Nice",
+	"Awesome"
+];
+
+/** Return a random congragulatory phrase
+ * @returns {string}
+ */
+exports.congratulationBuilder = function () {
+	return CONGRATULATORY_PHRASES[Math.floor(CONGRATULATORY_PHRASES.length * Math.random())];
+}
+
 /** Create a text-only ratio bar that fills left to right
  * @param {number} numerator
  * @param {number} denominator
@@ -14,4 +35,122 @@ exports.generateTextBar = function (numerator, denominator, barLength) {
 		}
 	}
 	return bar;
+}
+
+exports.getNumberEmoji = function (number) {
+	switch (Number(number)) {
+		case 0:
+			return '0️⃣';
+		case 1:
+			return '1️⃣';
+		case 2:
+			return '2️⃣';
+		case 3:
+			return '3️⃣';
+		case 4:
+			return '4️⃣';
+		case 5:
+			return '5️⃣';
+		case 6:
+			return '6️⃣';
+		case 7:
+			return '7️⃣';
+		case 8:
+			return '8️⃣';
+		case 9:
+			return '9️⃣';
+		case 10:
+			return '🔟';
+		default:
+			return '#️⃣';
+	}
+}
+
+/** Recalculates the ranks (standard deviations from mean) and placements (ordinal) for the given participants
+ * @param {Hunter[]} participants
+ * @param {GuildRank[]} ranks
+ * @returns Promise of the message congratulating the hunter reaching first place (or `null` if no change)
+ */
+exports.setRanks = async (participants, ranks) => {
+	let previousFirstPlaceId;
+	let mean = 0;
+	const rankableHunters = [];
+	for (const hunter of participants) {
+		if (hunter.isRankEligible) {
+			if (hunter.seasonPlacement == 1) {
+				previousFirstPlaceId = hunter.userId;
+			}
+			hunter.lastRank = hunter.rank;
+			mean += hunter.seasonXP;
+			rankableHunters.push(hunter);
+		} else {
+			hunter.nextRankXP = 0;
+		}
+	}
+	const n = Math.max(rankableHunters.length, 2);
+	mean /= n;
+	const stdDev = Math.sqrt(rankableHunters.reduce((total, hunter) => total + (hunter.seasonXP - mean) ** 2, 0) / n);
+	for (const hunter of rankableHunters) {
+		let variance = (hunter.seasonXP - mean) / stdDev;
+		ranks.forEach((rank, index) => {
+			if (variance >= rank.varianceThreshold) {
+				hunter.rank = index;
+			}
+		});
+		hunter.nextRankXP = Math.ceil(stdDev * ranks[hunter.rank].varianceThreshold + mean - hunter.seasonXP);
+	}
+	let recentPlacement = participants.length - 1; // subtract 1 to adjust for array indexes starting from 0
+	let previousScore = 0;
+	let firstPlaceId;
+	for (let i = recentPlacement; i >= 0; i -= 1) {
+		let hunter = participants[i];
+		if (hunter.seasonXP > previousScore) {
+			previousScore = hunter.seasonXP;
+			recentPlacement = i + 1;
+			hunter.seasonPlacement = recentPlacement;
+		} else {
+			hunter.seasonPlacement = recentPlacement;
+			if (recentPlacement == 1 && hunter.id != previousFirstPlaceId) {
+				// Feature: No first place message on first season XP of season (no one to compete with)
+				firstPlaceId = hunter.id;
+			}
+		}
+		hunter.save();
+	}
+	return firstPlaceId ? `*<@${firstPlaceId}> has reached the #1 spot for this season!*` : null;
+}
+
+/** Update ranks for all hunters in the guild, then return rank up messages
+ * @param {Guild} guild
+ * @param {boolean} force
+ * @returns an array of rank and placement update strings
+ */
+exports.getRankUpdates = async function (guild, force = false) {
+	const allHunters = await database.models.Hunter.findAll({ where: { guildId: guild.id, seasonXP: { [Op.gt]: 0 } }, order: [["seasonXP", "DESC"]] });
+	const ranks = await database.models.GuildRank.findAll({ where: { guildId: guild.id }, order: [["varianceThreshold", "ASC"]] });
+	return exports.setRanks(allHunters, ranks).then(async (firstPlaceMessage) => {
+		const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);
+		const outMessages = [];
+		if (firstPlaceMessage) {
+			outMessages.push(firstPlaceMessage);
+		}
+		for (const hunter of allHunters) {
+			if (force || hunter.rank != hunter.lastRank) {
+				const member = await guild.members.fetch(hunter.userId);
+				let destinationRole;
+				if (member.manageable) {
+					await member.roles.remove(roleIds);
+					const rankRoleId = ranks[hunter.rank].roleId;
+					if (rankRoleId) {
+						await member.roles.add(rankRoleId);
+						destinationRole = await guild.roles.fetch(rankRoleId);
+					}
+				}
+				if (hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs
+					outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole ? destinationRole.name : `Rank ${hunter.rank + 1}`}!`);
+				}
+			}
+		}
+		return outMessages;
+	});
 }

--- a/source/modals/_modalDictionary.js
+++ b/source/modals/_modalDictionary.js
@@ -4,6 +4,7 @@ const { InteractionWrapper } = require("../classes");
 const modalDictionary = {};
 
 for (const file of [
+	"bountypostmodal.js",
 	"feedback-bugreport.js",
 	"feedback-featurerequest.js"
 ]) {

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -69,7 +69,6 @@ module.exports = new InteractionWrapper(customId, 3000,
 			const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
 			poster.addXP(interaction.guild, 1, true).then(() => {
 				getRankUpdates(interaction.guild);
-				//TODONOW not adding rank?
 			});
 
 			if (shouldMakeEvent) {
@@ -95,7 +94,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
 			const bountyEmbed = await bounty.asEmbed(interaction.guild, poster, hunterGuild);
 			if (hunterGuild.bountyBoardId) {
-				//TODONOW handle auto-mod catching phrases in bounty content
+				//TODO figure out how to trip auto-mod or re-add taboos
 				interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(bountyBoard => {
 					return bountyBoard.threads.create({
 						name: bounty.title,

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -1,0 +1,113 @@
+const { GuildScheduledEventEntityType } = require('discord.js');
+const { database } = require('../../database');
+const { InteractionWrapper } = require('../classes');
+const { YEAR_IN_MS } = require('../constants');
+const { getRankUpdates } = require('../helpers');
+
+const customId = "bountypostmodal";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Serialize data into a bounty, then announce with showcase embed */
+	async (interaction, [slotNumber, isEvergreen]) => {
+		const title = interaction.fields.getTextInputValue("title");
+		const description = interaction.fields.getTextInputValue("description");
+		const imageURL = interaction.fields.getTextInputValue("imageURL");
+		const startTimestamp = parseInt(interaction.fields.getTextInputValue("startTimestamp"));
+		const endTimestamp = parseInt(interaction.fields.getTextInputValue("endTimestamp"));
+		const shouldMakeEvent = startTimestamp && endTimestamp;
+
+		const rawBounty = {
+			userId: interaction.user.id,
+			guildId: interaction.guildId,
+			slotNumber: parseInt(slotNumber),
+			isEvergreen: isEvergreen === "true",
+			title,
+			description
+		};
+		const errors = [];
+
+		if (imageURL) {
+			try {
+				new URL(imageURL);
+				rawBounty.attachmentURL = imageURL;
+			} catch (error) {
+				errors.push(error.message);
+			}
+		}
+
+		if (shouldMakeEvent) {
+			if (!startTimestamp) {
+				errors.push("Start timestamp must be an integer.");
+			} else if (!endTimestamp) {
+				errors.push("End timestamp must be an integer.");
+			} else {
+				if (startTimestamp > endTimestamp) {
+					errors.push("End timestamp was before start timestamp.");
+				}
+
+				const nowTimestamp = Date.now() / 1000;
+				if (nowTimestamp >= startTimestamp) {
+					errors.push("Start timestamp must be in the future.");
+				}
+
+				if (nowTimestamp >= endTimestamp) {
+					errors.push("End timestamp must be in the future.");
+				}
+
+				if (startTimestamp >= nowTimestamp + (5 * YEAR_IN_MS)) {
+					errors.push("Start timestamp cannot be 5 years in the future or further.");
+				}
+
+				if (endTimestamp >= nowTimestamp + (5 * YEAR_IN_MS)) {
+					errors.push("End timestamp cannot be 5 years in the future or further.");
+				}
+			}
+		}
+
+		if (errors.length > 0) {
+			interaction.reply({ content: `The following errors were encountered while posting your bounty **${title}**:\n• ${errors.join("\n• ")}`, ephemeral: true });
+		} else {
+			const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+			poster.addXP(interaction.guild, 1, true).then(() => {
+				getRankUpdates(interaction.guild);
+				//TODONOW not adding rank?
+			});
+
+			if (shouldMakeEvent) {
+				const eventPayload = {
+					name: `Bounty: ${title}`,
+					description,
+					scheduledStartTime: startTimestamp * 1000,
+					scheduledEndTime: endTimestamp * 1000,
+					privacyLevel: 2,
+					entityType: GuildScheduledEventEntityType.External,
+					entityMetadata: { location: `${interaction.member.displayName}'s #${slotNumber} Bounty` }
+				};
+				if (imageURL) {
+					eventPayload.image = imageURL;
+				}
+				const event = await interaction.guild.scheduledEvents.create(eventPayload);
+				rawBounty.scheduledEventId = event.id;
+			}
+
+			const bounty = await database.models.Bounty.create(rawBounty);
+
+			// post in bounty board forum
+			const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
+			const bountyEmbed = await bounty.asEmbed(interaction.guild, poster, hunterGuild);
+			if (hunterGuild.bountyBoardId) {
+				//TODONOW handle auto-mod catching phrases in bounty content
+				interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(bountyBoard => {
+					return bountyBoard.threads.create({
+						name: bounty.title,
+						message: { embeds: [bountyEmbed] }
+					})
+				}).then(posting => {
+					bounty.postingId = posting.id;
+					bounty.save()
+				})
+			}
+
+			interaction.reply({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] });
+		}
+	}
+);

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -1,0 +1,124 @@
+﻿const { EmbedBuilder, Guild } = require('discord.js');
+const { DataTypes: { BIGINT, STRING, INTEGER, BOOLEAN }, Model } = require('sequelize');
+const { ihpAuthorPayload } = require('../../embedHelpers');
+const { Hunter } = require('../users/Hunter');
+const { Guild: HunterGuild } = require('../guilds/Guild');
+const { database } = require('../../../database');
+
+/** Bounties are user created objectives for other server members to complete */
+const bountyModel = {
+	id: {
+		primaryKey: true,
+		type: BIGINT,
+		autoIncrement: true
+	},
+	userId: {
+		type: STRING,
+		references: {
+			model: 'User',
+			key: 'id'
+		}
+	},
+	guildId: {
+		type: STRING,
+		references: {
+			model: 'Guild',
+			key: 'id'
+		}
+	},
+	postingId: {
+		type: STRING,
+	},
+	slotNumber: {
+		type: INTEGER,
+		allowNull: false
+	},
+	isEvergreen: {
+		type: BOOLEAN,
+		devaultValue: false
+	},
+	title: {
+		type: STRING,
+		allowNull: false,
+		defaultValue: "\u200B"
+	},
+	description: {
+		type: STRING,
+		allowNull: false,
+		defaultValue: "\u200B"
+	},
+	attachmentURL: {
+		type: STRING,
+		defaultValue: null
+	},
+	scheduledEventId: {
+		type: INTEGER,
+		defaultValue: null
+	},
+	state: { // Allowed values: "open", "completed", "deleted"
+		type: STRING,
+		defaultValue: "open"
+	},
+	completedAt: {
+		type: INTEGER,
+		defaultValue: null
+	},
+	deletedAt: {
+		type: INTEGER,
+		defaultValue: null
+	},
+	editCount: {
+		type: INTEGER,
+		defaultValue: 0
+	}
+};
+exports.Bounty = class Bounty extends Model {
+	/** Generate an embed for the given bounty
+	 * @param {Guild} guild
+	 * @param {Hunter?} hunter
+	 * @param {HunterGuild?} hunterGuild
+	 */
+	asEmbed(guild, hunter, hunterGuild) {
+		return guild.members.fetch(this.userId).then(async author => {
+			if (!hunter) {
+				hunter = await database.models.Hunter.findOne({ where: { userId: this.userId, guildId: this.guildId } });
+			}
+			if (!hunterGuild) {
+				hunterGuild = await database.models.Guild.findByPk(this.guildId);
+			}
+
+			const embed = new EmbedBuilder().setColor(author.displayColor)
+				.setAuthor(ihpAuthorPayload)
+				.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734093574031016006/bountyboard.png')
+				.setTitle(this.title)
+				.setDescription(this.description)
+				.addFields(
+					{ name: "Reward", value: `${hunter.slotWorth(this.slotNumber)} XP${hunterGuild.eventMultiplierString()}`, inline: true }
+				)
+				.setTimestamp();
+
+			if (this.attachmentURL) {
+				embed.setImage(this.attachmentURL);
+			}
+			if (this.state === "completed") {
+				const completions = await database.models.Completion.findAll({ where: { bountyId: this.id } });
+				embed.addField("Completed By", `<@${completions.map(reciept => reciept.userId).join(">, <@")}>`);
+			}
+			if (this.isEvergreen) {
+				embed.setFooter({ text: `Evergreen Bounty #${this.slotNumber}`, iconURL: author.user.displayAvatarURL() });
+			} else {
+				embed.setFooter({ text: `${author.displayName}'s #${this.slotNumber} Bounty`, iconURL: author.user.displayAvatarURL() });
+			}
+
+			return embed;
+		});
+	}
+}
+
+exports.initModel = function (sequelize) {
+	exports.Bounty.init(bountyModel, {
+		sequelize,
+		modelName: 'Bounty',
+		freezeTableName: true
+	});
+}

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -39,13 +39,11 @@ const bountyModel = {
 	},
 	title: {
 		type: STRING,
-		allowNull: false,
-		defaultValue: "\u200B"
+		allowNull: false
 	},
 	description: {
 		type: STRING,
-		allowNull: false,
-		defaultValue: "\u200B"
+		allowNull: false
 	},
 	attachmentURL: {
 		type: STRING,

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -1,5 +1,5 @@
 ﻿// Database Entity Class
-const { DataTypes: { BIGINT, STRING }, Model } = require('sequelize');
+const { DataTypes: { BIGINT, STRING, INTEGER }, Model } = require('sequelize');
 
 // Store receipt information of a bounty completion and relevant stats of that bounty
 const completionModel = {
@@ -26,6 +26,9 @@ const completionModel = {
 			model: 'Guild',
 			key: 'id'
 		}
+	},
+	xpAwarded: {
+		type: INTEGER
 	}
 };
 exports.Completion = class Completion extends Model { }

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -1,0 +1,39 @@
+﻿// Database Entity Class
+const { DataTypes: { BIGINT, STRING }, Model } = require('sequelize');
+
+// Store receipt information of a bounty completion and relevant stats of that bounty
+const completionModel = {
+	bountyId: {
+		primaryKey: true,
+		type: BIGINT,
+		references: {
+			model: 'Bounty',
+			key: 'id'
+		}
+	},
+	userId: {
+		primaryKey: true,
+		type: STRING,
+		references: {
+			model: 'User',
+			key: 'id'
+		}
+	},
+	guildId: {
+		primaryKey: true,
+		type: STRING,
+		references: {
+			model: 'Guild',
+			key: 'id'
+		}
+	}
+};
+exports.Completion = class Completion extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.Completion.init(completionModel, {
+		sequelize,
+		modelName: 'Completion',
+		freezeTableName: true
+	});
+}

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -1,81 +1,6 @@
-const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT }, Model } = require('sequelize');
+const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT, VIRTUAL }, Model, QueryTypes } = require('sequelize');
 
 /** Guild information and bot settings */
-const guildModel = {
-	id: {
-		primaryKey: true,
-		type: STRING,
-		allowNull: false
-	},
-	level: {
-		type: INTEGER,
-		defaultValue: 1
-	},
-	announcementPrefix: {
-		type: STRING,
-		defaultValue: '@here'
-	},
-	disableBoostXP: {
-		type: BOOLEAN,
-		defaultValue: true
-	},
-	maxSimBounties: {
-		type: INTEGER,
-		defaultValue: 5
-	},
-	backupTimer: {
-		type: BIGINT,
-		defaultValue: 3600000
-	},
-	bountyBoardId: {
-		type: STRING,
-		defaultValue: ''
-	},
-	scoreId: {
-		type: STRING,
-		defaultValue: ''
-	},
-	raffleDate: {
-		type: STRING,
-		defaultValue: ''
-	},
-	eventMultiplier: {
-		type: INTEGER,
-		defaultValue: 1
-	},
-	xpCoefficient: {
-		type: INTEGER,
-		defaultValue: 3
-	},
-	seasonXP: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	seasonBounties: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	seasonToasts: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	resetSchedulerId: {
-		type: STRING,
-		defaultValue: ""
-	},
-	lastSeasonXP: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	bountiesLastSeason: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	toastsLastSeason: {
-		type: BIGINT,
-		defaultValue: 0
-	}
-};
 exports.Guild = class Guild extends Model {
 	eventMultiplierString = () => {
 		if (this.eventMultiplier != 1) {
@@ -136,7 +61,91 @@ exports.Guild = class Guild extends Model {
 }
 
 exports.initModel = function (sequelize) {
-	exports.Guild.init(guildModel, {
+	exports.Guild.init({
+		id: {
+			primaryKey: true,
+			type: STRING,
+			allowNull: false
+		},
+		xp: {
+			type: VIRTUAL,
+			async get() {
+				const [hunterLevels] = await sequelize.query("SELECT SUM(level) FROM Hunter WHERE guildId = :guildId", {
+					replacements: { guildId: this.id },
+					type: QueryTypes.SELECT
+				});
+				return hunterLevels["SUM(level)"];
+			}
+		},
+		level: {
+			type: INTEGER,
+			defaultValue: 1
+		},
+		announcementPrefix: {
+			type: STRING,
+			defaultValue: '@here'
+		},
+		disableBoostXP: {
+			type: BOOLEAN,
+			defaultValue: true
+		},
+		maxSimBounties: {
+			type: INTEGER,
+			defaultValue: 5
+		},
+		backupTimer: {
+			type: BIGINT,
+			defaultValue: 3600000
+		},
+		bountyBoardId: {
+			type: STRING,
+			defaultValue: ''
+		},
+		scoreId: {
+			type: STRING,
+			defaultValue: ''
+		},
+		raffleDate: {
+			type: STRING,
+			defaultValue: ''
+		},
+		eventMultiplier: {
+			type: INTEGER,
+			defaultValue: 1
+		},
+		xpCoefficient: {
+			type: INTEGER,
+			defaultValue: 3
+		},
+		seasonXP: {
+			type: BIGINT,
+			defaultValue: 0
+		},
+		seasonBounties: {
+			type: BIGINT,
+			defaultValue: 0
+		},
+		seasonToasts: {
+			type: BIGINT,
+			defaultValue: 0
+		},
+		resetSchedulerId: {
+			type: STRING,
+			defaultValue: ""
+		},
+		lastSeasonXP: {
+			type: BIGINT,
+			defaultValue: 0
+		},
+		bountiesLastSeason: {
+			type: BIGINT,
+			defaultValue: 0
+		},
+		toastsLastSeason: {
+			type: BIGINT,
+			defaultValue: 0
+		}
+	}, {
 		sequelize,
 		modelName: 'Guild',
 		freezeTableName: true

--- a/source/models/guilds/GuildRank.js
+++ b/source/models/guilds/GuildRank.js
@@ -1,0 +1,33 @@
+﻿const { DataTypes: { STRING, REAL }, Model } = require('sequelize');
+
+/** Ranks, individual per guild, include a variance threshold (difficulty to achieve) and optionally a role to give hunters and emoji for the scoreboard */
+const guildRankModel = {
+	guildId: {
+		primaryKey: true,
+		type: STRING,
+		allowNull: false,
+		references: {
+			model: 'Guild'
+		}
+	},
+	varianceThreshold: {
+		primaryKey: true,
+		type: REAL,
+		allowNull: false
+	},
+	roleId: {
+		type: STRING
+	},
+	rankMoji: {
+		type: STRING
+	}
+};
+exports.GuildRank = class GuildRank extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.GuildRank.init(guildRankModel, {
+		sequelize,
+		modelName: 'GuildRank',
+		freezeTableName: true
+	});
+}

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -137,9 +137,7 @@ exports.Hunter = class Hunter extends Model {
 		this.level = Math.floor(Math.sqrt(this.xp / guildProfile.xpCoefficient) + 1);
 		this.save();
 
-		// Guild XP is the total Hunter levels
-		const guildXP = await database.models.Hunter.sum("level", { where: { guildId: guild.id } });
-		guildProfile.level = Math.floor(Math.sqrt(guildXP / 3) + 1);
+		guildProfile.level = Math.floor(Math.sqrt(await guildProfile.xp / 3) + 1);
 		guildProfile.save();
 
 		let levelText = "";

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -1,4 +1,7 @@
 const { DataTypes: { STRING, BIGINT, INTEGER, BOOLEAN }, Model } = require('sequelize');
+const { database } = require('../../../database');
+const { congratulationBuilder } = require('../../helpers');
+const { Guild } = require('discord.js');
 
 /** This class stores information for bot users on a specific guild */
 const hunterModel = {
@@ -30,11 +33,17 @@ const hunterModel = {
 		type: BIGINT,
 		defaultValue: 0
 	},
+	isRankEligible: {
+		type: BOOLEAN,
+		allowNull: false
+	},
 	rank: {
-		type: STRING
+		type: INTEGER,
+		defaultValue: null
 	},
 	lastRank: {
-		type: STRING
+		type: INTEGER,
+		defaultValue: null
 	},
 	seasonPlacement: {
 		type: INTEGER,
@@ -104,9 +113,50 @@ exports.Hunter = class Hunter extends Model {
 		return Math.min(slots, maxSimBounties);
 	}
 
-	// slotWorth(slotNum) {
-	// 	return Math.floor(6 + 0.5 * this.level - 3 * slotNum + 0.5 * slotNum % 2);
-	// }
+	slotWorth(slotNum) {
+		return Math.floor(6 + 0.5 * this.level - 3 * slotNum + 0.5 * slotNum % 2);
+	}
+
+	/**
+	 * @param {Guild} guild
+	 * @param {number} points
+	 * @param {boolean} ignoreMultiplier
+	 * @returns {string} level-up text
+	 */
+	async addXP(guild, points, ignoreMultiplier) {
+		const guildProfile = await database.models.Guild.findByPk(guild.id);
+		const totalPoints = points * (!ignoreMultiplier ? guildProfile.eventMultiplier : 1);
+
+		const previousLevel = this.level;
+		const previousGuildLevel = guildProfile.level;
+
+		this.xp += totalPoints;
+		this.seasonXP += totalPoints;
+		guildProfile.seasonXP += totalPoints;
+
+		this.level = Math.floor(Math.sqrt(this.xp / guildProfile.xpCoefficient) + 1);
+		this.save();
+
+		// Guild XP is the total Hunter levels
+		const guildXP = await database.models.Hunter.sum("level", { where: { guildId: guild.id } });
+		guildProfile.level = Math.floor(Math.sqrt(guildXP / 3) + 1);
+		guildProfile.save();
+
+		let levelText = "";
+		if (this.level > previousLevel) {
+			const rewards = [];
+			for (let level = previousLevel + 1; level <= this.level; level++) {
+				rewards.push(this.levelUpReward(level, guildProfile.maxSimBounties, false));
+			}
+			levelText += `${congratulationBuilder()}, <@${userId}>! You have leveled up to level **${this.level}**!\n${rewards.join('\n')}`;
+		}
+
+		if (guildProfile.level > previousGuildLevel) {
+			levelText += `*${guild.name} is now level ${guildProfile.level}! Evergreen bounties are now worth more XP!*\n`;
+		}
+
+		return levelText;
+	}
 
 	// myModDetails(guild, member, { maxSimBounties, pinChannelId }, lastFiveBounties) {
 	// 	const { prefix, text, url } = tipBuilder(maxSimBounties, guild.channels.resolve(pinChannelId), true);

--- a/source/models/users/User.js
+++ b/source/models/users/User.js
@@ -1,7 +1,7 @@
 const { DataTypes: { STRING, BOOLEAN }, Model } = require('sequelize');
 
 /** This class stores global information for bot users */
-let userModel = {
+const userModel = {
 	id: {
 		primaryKey: true,
 		type: STRING,

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -8,7 +8,7 @@ let text = "";
 commandFiles.forEach(filename => {
 	/** @type {CommandWrapper} */
 	const command = require(`./../commands/${filename}`);
-	text += `### /${command.customId}\n> Permission Level: ${new PermissionsBitField(command.data.default_member_permissions).toArray().join(", ")}\n\n> Usable in DMs: ${command.data.dm_permission}\n\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.description}\n`;
+	text += `### /${command.customId}\n> Permission Level: ${new PermissionsBitField(command.data.default_member_permissions).toArray().join(", ")}\n\n> Usable in DMs: ${command.data.dm_permission}\n\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.data.description}\n`;
 	for (const optionData of command.data.options) {
 		let optionName = "#### ";
 		if (optionData instanceof SlashCommandSubcommandBuilder) {

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -8,7 +8,7 @@ let text = "";
 commandFiles.forEach(filename => {
 	/** @type {CommandWrapper} */
 	const command = require(`./../commands/${filename}`);
-	text += `### /${command.customId}\n> Permission Level: ${new PermissionsBitField(command.data.default_member_permissions).toArray().join(", ")}\n\n> Usable in DMs: ${command.data.dm_permission}\n\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.data.description}\n`;
+	text += `### /${command.customId}\n${command.data.default_member_permissions ? `> Permission Level: ${new PermissionsBitField(command.data.default_member_permissions).toArray().join(", ")}\n` : ""}\n> Usable in DMs: ${command.data.dm_permission}\n\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.data.description}\n`;
 	for (const optionData of command.data.options) {
 		let optionName = "#### ";
 		if (optionData instanceof SlashCommandSubcommandBuilder) {

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -4,6 +4,7 @@ const { InteractionWrapper } = require("../classes");
 const selectDictionary = {};
 
 for (const file of [
+	"bountypostselect.js"
 ]) {
 	const select = require(`./${file}`);
 	selectDictionary[select.customId] = select;

--- a/source/selects/bountypostselect.js
+++ b/source/selects/bountypostselect.js
@@ -1,0 +1,49 @@
+const { ModalBuilder, TextInputBuilder, ActionRowBuilder, TextInputStyle } = require('discord.js');
+const { InteractionWrapper } = require('../classes');
+const { SAFE_DELIMITER } = require('../constants');
+
+const customId = "bountypostselect";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Recieve remaining bounty configurations from the user */
+	(interaction, args) => {
+		const slotNumber = interaction.values[0];
+		interaction.showModal(
+			new ModalBuilder().setCustomId(`bountypostmodal${SAFE_DELIMITER}${slotNumber}${SAFE_DELIMITER}false`)
+				.setTitle(`New Bounty (Slot ${slotNumber})`)
+				.addComponents(
+					new ActionRowBuilder().addComponents(
+						new TextInputBuilder().setCustomId("title")
+							.setLabel("Title")
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder("Discord markdown allowed...")
+					),
+					new ActionRowBuilder().addComponents(
+						new TextInputBuilder().setCustomId("description")
+							.setLabel("Description")
+							.setStyle(TextInputStyle.Paragraph)
+							.setPlaceholder("Bounties with clear instructions are easier to complete...")
+					),
+					new ActionRowBuilder().addComponents(
+						new TextInputBuilder().setCustomId("imageURL")
+							.setLabel("Image URL")
+							.setRequired(false)
+							.setStyle(TextInputStyle.Short)
+					),
+					new ActionRowBuilder().addComponents(
+						new TextInputBuilder().setCustomId("startTimestamp")
+							.setLabel("Event Start (Unix Timestamp)")
+							.setRequired(false)
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder("Required if making an event with the bounty")
+					),
+					new ActionRowBuilder().addComponents(
+						new TextInputBuilder().setCustomId("endTimestamp")
+							.setLabel("Event End (Unix Timestamp)")
+							.setRequired(false)
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder("Required if making an event with the bounty")
+					)
+				)
+		);
+	}
+);

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -6,6 +6,16 @@
 > Cooldown: 3 second(s)
 
 Get BountyBot's description and contributors
+### /bounty
+> Permission Level: ViewChannel
+
+> Usable in DMs: false
+
+> Cooldown: 3 second(s)
+
+Bounties are user-created objectives for other server members to complete
+#### /bounty post
+Post your own bounty (+1 XP)
 ### /commands
 > Permission Level: ViewChannel
 
@@ -55,7 +65,7 @@ The Season Scoreboard only includes hunters with XP this season
 
 Get the BountyBot stats for yourself or someone else
 #### bounty-hunter (optional)
-Whose stats to check, BountyBot for the guild's stats
+Whose stats to check; BountyBot for the server stats, empty for yourself
 ### /version
 > Permission Level: ViewChannel
 


### PR DESCRIPTION
Summary
-------
- ported `/bounty post`
   - includes slash command, bounty slot select, and input modal
- added models for Bounty, GuildRank, and Completion
   - GuildRank now uses a composite primary key of guildId + varianceThreshold
   - Completion is the combination of PendingCompleter and BountyCompletion
- `/create-bounty-board` now populates with posts for existing bounties
- `/create-bounty-board` now creates a forum in ListView as default (shows bounty posts better than GalleryView)
- split `hunter.isRankEligible` from `hunter.rank` (now `INTEGER | NULL` from `STRING | NULL`)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested bounty post flow, excluding placement calculation due to lack of way to increment other users' XP

Issue
-----
Closes #2