### PR TITLE
#25: `/toast` and seconding toasts

### DIFF
--- a/database.js
+++ b/database.js
@@ -26,20 +26,103 @@ exports.database.authenticate().then(() => {
 	initToastRecipient(exports.database);
 	initToastSeconding(exports.database);
 
-	GuildRank.Guild = GuildRank.belongsTo(Guild);
-	Hunter.User = Hunter.belongsTo(User);
-	Hunter.Guild = Hunter.belongsTo(Guild);
-	Bounty.User = Bounty.belongsTo(User);
-	Bounty.Guild = Bounty.belongsTo(Guild);
-	Completion.Bounty = Completion.belongsTo(Bounty);
-	Completion.User = Completion.belongsTo(User);
-	Completion.Guild = Completion.belongsTo(Guild);
-	Toast.Guild = Toast.belongsTo(Guild);
-	Toast.User = Toast.belongsTo(User);
-	ToastRecipient.Toast = ToastRecipient.belongsTo(Toast);
-	ToastRecipient.User = ToastRecipient.belongsTo(User);
-	ToastSeconding.Toast = ToastSeconding.belongsTo(Toast);
-	ToastSeconding.User = ToastSeconding.belongsTo(User);
+	Guild.GuildRank = Guild.hasMany(GuildRank, {
+		foreignKey: "guildId"
+	});
+	GuildRank.Guild = GuildRank.belongsTo(Guild, {
+		foreignKey: "guildId"
+	});
+
+	Hunter.User = Hunter.belongsTo(User, {
+		foreignKey: "userId"
+	});
+	User.Hunter = User.hasMany(Hunter, {
+		foreignKey: "userId"
+	});
+
+	Hunter.Guild = Hunter.belongsTo(Guild, {
+		foreignKey: "guildId"
+	});
+	Guild.Hunter = Guild.hasMany(Hunter, {
+		foreignKey: "guildId"
+	});
+
+	Bounty.User = Bounty.belongsTo(User, {
+		foreignKey: "userId"
+	});
+	User.Bounty = User.hasMany(Bounty, {
+		foreignKey: "userId"
+	});
+
+	Bounty.Guild = Bounty.belongsTo(Guild, {
+		foreignKey: "guildId"
+	});
+	Guild.Bounty = Guild.hasMany(Bounty, {
+		foreignKey: "guildId"
+	});
+
+	Completion.Bounty = Completion.belongsTo(Bounty, {
+		foreignKey: "bountyId"
+	});
+	Bounty.Completion = Bounty.hasMany(Completion, {
+		foreignKey: "bountyId"
+	});
+
+	Completion.User = Completion.belongsTo(User, {
+		foreignKey: "userId"
+	});
+	User.Completion = User.hasMany(Completion, {
+		foreignKey: "userId"
+	});
+
+	Completion.Guild = Completion.belongsTo(Guild, {
+		foreignKey: "guildId"
+	});
+	Guild.Completion = Guild.hasMany(Completion, {
+		foreignKey: "guildId"
+	});
+
+	Toast.Guild = Toast.belongsTo(Guild, {
+		foreignKey: "guildId"
+	});
+	Guild.Toast = Guild.hasMany(Toast, {
+		foreignKey: "guildId"
+	});
+
+	Toast.User = Toast.belongsTo(User, {
+		foreignKey: "senderId"
+	});
+	User.Toast = User.hasMany(Toast, {
+		foreignKey: "senderId"
+	});
+
+	ToastRecipient.Toast = ToastRecipient.belongsTo(Toast, {
+		foreignKey: "toastId"
+	});
+	Toast.ToastRecipient = Toast.hasMany(ToastRecipient, {
+		foreignKey: "toastId"
+	});
+
+	ToastRecipient.User = ToastRecipient.belongsTo(User, {
+		foreignKey: "recipientId"
+	});
+	User.ToastRecipient = User.hasMany(ToastRecipient, {
+		foreignKey: "recipientId"
+	});
+
+	ToastSeconding.Toast = ToastSeconding.belongsTo(Toast, {
+		foreignKey: "toastId"
+	});
+	Toast.ToastSeconding = Toast.hasMany(ToastSeconding, {
+		foreignKey: "toastId"
+	});
+
+	ToastSeconding.User = ToastSeconding.belongsTo(User, {
+		foreignKey: "seconderId"
+	});
+	User.ToastSeconding = User.hasMany(ToastSeconding, {
+		foreignKey: "seconderId"
+	});
 
 	exports.database.sync();
 })

--- a/database.js
+++ b/database.js
@@ -6,18 +6,40 @@ exports.database = new Sequelize({
 });
 
 exports.database.authenticate().then(() => {
-	require("./source/models/guilds/Guild.js").initModel(exports.database);
-	require("./source/models/guilds/GuildRank.js").initModel(exports.database);
+	const { Guild, initModel: initGuild } = require("./source/models/guilds/Guild.js")
+	const { GuildRank, initModel: initGuildRank } = require("./source/models/guilds/GuildRank.js")
+	const { User, initModel: initUser } = require("./source/models/users/User.js");
+	const { Hunter, initModel: initHunter } = require("./source/models/users/Hunter.js");
+	const { Bounty, initModel: initBounty } = require("./source/models/bounties/Bounty.js")
+	const { Completion, initModel: initCompletion } = require("./source/models/bounties/Completion.js")
+	const { Toast, initModel: initToast } = require("./source/models/toasts/Toast.js")
+	const { ToastRecipient, initModel: initToastRecipient } = require("./source/models/toasts/ToastRecipient.js")
+	const { ToastSeconding, initModel: initToastSeconding } = require("./source/models/toasts/ToastSeconding.js")
 
-	require("./source/models/users/User.js").initModel(exports.database);
-	require("./source/models/users/Hunter.js").initModel(exports.database);
+	initGuild(exports.database);
+	initGuildRank(exports.database);
+	initUser(exports.database);
+	initHunter(exports.database);
+	initBounty(exports.database);
+	initCompletion(exports.database);
+	initToast(exports.database);
+	initToastRecipient(exports.database);
+	initToastSeconding(exports.database);
 
-	require("./source/models/bounties/Bounty.js").initModel(exports.database);
-	require("./source/models/bounties/Completion.js").initModel(exports.database);
-
-	require("./source/models/toasts/Toast.js").initModel(exports.database);
-	require("./source/models/toasts/ToastRecipient.js").initModel(exports.database);
-	require("./source/models/toasts/ToastSeconding.js").initModel(exports.database);
+	GuildRank.Guild = GuildRank.belongsTo(Guild);
+	Hunter.User = Hunter.belongsTo(User);
+	Hunter.Guild = Hunter.belongsTo(Guild);
+	Bounty.User = Bounty.belongsTo(User);
+	Bounty.Guild = Bounty.belongsTo(Guild);
+	Completion.Bounty = Completion.belongsTo(Bounty);
+	Completion.User = Completion.belongsTo(User);
+	Completion.Guild = Completion.belongsTo(Guild);
+	Toast.Guild = Toast.belongsTo(Guild);
+	Toast.User = Toast.belongsTo(User);
+	ToastRecipient.Toast = ToastRecipient.belongsTo(Toast);
+	ToastRecipient.User = ToastRecipient.belongsTo(User);
+	ToastSeconding.Toast = ToastSeconding.belongsTo(Toast);
+	ToastSeconding.User = ToastSeconding.belongsTo(User);
 
 	exports.database.sync();
 })

--- a/database.js
+++ b/database.js
@@ -6,14 +6,18 @@ exports.database = new Sequelize({
 });
 
 exports.database.authenticate().then(() => {
-	require('./source/models/guilds/Guild.js').initModel(exports.database);
-	require('./source/models/guilds/GuildRank.js').initModel(exports.database);
+	require("./source/models/guilds/Guild.js").initModel(exports.database);
+	require("./source/models/guilds/GuildRank.js").initModel(exports.database);
 
-	require('./source/models/users/User.js').initModel(exports.database);
-	require('./source/models/users/Hunter.js').initModel(exports.database);
+	require("./source/models/users/User.js").initModel(exports.database);
+	require("./source/models/users/Hunter.js").initModel(exports.database);
 
-	require('./source/models/bounties/Bounty.js').initModel(exports.database);
-	require('./source/models/bounties/Completion.js').initModel(exports.database);
+	require("./source/models/bounties/Bounty.js").initModel(exports.database);
+	require("./source/models/bounties/Completion.js").initModel(exports.database);
+
+	require("./source/models/toasts/Toast.js").initModel(exports.database);
+	require("./source/models/toasts/ToastRecipient.js").initModel(exports.database);
+	require("./source/models/toasts/ToastSeconding.js").initModel(exports.database);
 
 	exports.database.sync();
 })

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -4,6 +4,7 @@ const { InteractionWrapper } = require("../classes");
 const buttonDictionary = {};
 
 for (const file of [
+	"secondtoast.js"
 ]) {
 	const button = require(`./${file}`);
 	buttonDictionary[button.customId] = button;

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -1,9 +1,103 @@
+const { EmbedBuilder } = require('@discordjs/builders');
 const { InteractionWrapper } = require('../classes');
+const { database } = require('../../database');
+const { Op } = require('sequelize');
+const { DAY_IN_MS } = require('../constants');
+const { getRankUpdates } = require('../helpers');
 
-const customId = "secondtoast"; //TODONOW finish
+const customId = "secondtoast";
 module.exports = new InteractionWrapper(customId, 3000,
-	/** Specs */
-	(interaction, [toastId]) => {
-		//TODONOW limit seconded crits per day
+	/** Provide each recipient of a toast an extra XP, roll crit toast for author, and update embed */
+	async (interaction, [toastId]) => {
+		const originalToast = await database.models.Toast.findByPk(toastId);
+		if (originalToast.userId == interaction.user.id) {
+			interaction.reply({ content: "You cannot second your own toast.", ephemeral: true });
+			return;
+		}
+
+		const secondReciept = await database.models.ToastSeconding.findOne({ where: { toastId, seconderId: interaction.user.id } });
+		if (secondReciept) {
+			interaction.reply({ content: "You've already seconded this toast.", ephemeral: true });
+			return;
+		}
+
+		const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
+		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable } });
+		seconder.toastSeconded++;
+
+		const recipientIds = (await originalToast.recipients).map(reciept => reciept.recipientId);
+		const levelTexts = [];
+		for (const userId of recipientIds) {
+			const hunter = await database.models.Hunter.findOne({ where: { userId, guildId: interaction.guildId } });
+			levelTexts.concat(await hunter.addXP(interaction.guild, 1, true));
+		}
+
+		const recentToasts = await database.models.ToastSeconding.findAll({ where: { seconderId: interaction.user.id, createdAt: { [Op.gt]: new Date(new Date() - 2 * DAY_IN_MS) } } });
+		let critSecondsAvailable = 2;
+		for (const seconding of recentToasts) {
+			if (seconding.wasCrit) {
+				critSecondsAvailable--;
+				if (critSecondsAvailable < 1) {
+					break;
+				}
+			}
+		}
+
+		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
+		const staleToastees = lastFiveToasts.reduce(async (list, toast) => {
+			return (await list).concat((await toast.rewardedRecipients).map(recipient => recipient.userId));
+		}, []);
+
+		const wasCrit = false;
+		if (critSecondsAvailable > 0) {
+			let lowestEffectiveToastLevel = seconder.level + 2;
+			for (const userId of recipientIds) {
+				// Calculate crit
+				let effectiveToastLevel = seconder.level + 2;
+				for (const staleId of staleToastees) {
+					if (userId == staleId) {
+						effectiveToastLevel--;
+						if (effectiveToastLevel < 2) {
+							break;
+						}
+					}
+				};
+				if (effectiveToastLevel < lowestEffectiveToastLevel) {
+					lowestEffectiveToastLevel = effectiveToastLevel;
+				}
+			}
+
+			// f(x) = 150/(x+2)^(1/3)
+			const critRoll = Math.random() * 100;
+			if (critRoll * critRoll * critRoll > 3375000 / lowestEffectiveToastLevel) {
+				wasCrit = true;
+				levelTexts.concat(seconder.addXP(interaction.guild, 1, true));
+			}
+		}
+
+		database.models.ToastSeconding.create({ toastId: originalToast.id, seconderId: interaction.user.id, wasCrit });
+		seconder.save();
+
+		const embed = new EmbedBuilder(interaction.message.embeds[0].data);
+		if (interaction.message.embeds[0].data.fields?.length > 0) {
+			embed.spliceFields(0, 1, { name: "Seconded by", value: `${interaction.message.embeds[0].data.fields[0].value}, ${interaction.member.toString()}` });
+		} else {
+			embed.addFields({ name: "Seconded by", value: interaction.member.toString() });
+		}
+		interaction.update({ embeds: [embed] });
+		getRankUpdates(interaction.guild).then(rankUpdates => {
+			let text = "";
+			if (rankUpdates.length > 0) {
+				text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+			}
+			text += `__**XP Gained**__\n${recipientIds.map(id => `<@${id}> + 1 XP`).join("\n")}${wasCrit ? `\n${interaction.member} + 1 XP` : ""}`;
+			if (levelTexts.length > 0) {
+				text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
+			}
+			if (text.length > 2000) {
+				text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+			}
+			interaction.message.thread.send(text);
+		})
 	}
 );

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -1,0 +1,9 @@
+const { InteractionWrapper } = require('../classes');
+
+const customId = "secondtoast"; //TODONOW finish
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Specs */
+	(interaction, [toastId]) => {
+		//TODONOW limit seconded crits per day
+	}
+);

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -9,6 +9,7 @@ exports.commandFiles = [
 	"feedback.js",
 	"scoreboard.js",
 	"stats.js",
+	"toast.js",
 	"version.js"
 ];
 /** @type {Record<string, CommandWrapper>} */

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -18,7 +18,8 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // Post
 				database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
-					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable }, include: [User] });
+					const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
+					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable } });
 					const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, state: "open" } });
 					const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
 					const bountySlots = hunter.maxSlots(maxSimBounties);

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -2,6 +2,7 @@ const { PermissionFlagsBits, ActionRowBuilder, StringSelectMenuBuilder } = requi
 const { CommandWrapper } = require('../classes');
 const { database } = require('../../database');
 const { getNumberEmoji } = require('../helpers');
+const { User } = require('../models/users/User');
 
 const customId = "bounty";
 const options = [];
@@ -16,17 +17,8 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 	(interaction) => {
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // Post
-				database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(async hunter => {
-					if (!hunter) { //TODO use findOrCreate after double-checking associations (may not cascade from hunter to user correctly)
-						const user = await database.models.User.findByPk(interaction.user.id);
-						if (!user) {
-							await database.models.User.create({ id: interaction.user.id });
-						}
-						hunter = await database.models.Hunter.create({ userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: !interaction.member.manageable });
-					}
-
-					const { maxSimBounties } = await database.models.Guild.findByPk(interaction.guildId);
-
+				database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
+					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable }, include: [User] });
 					const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, state: "open" } });
 					const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
 					const bountySlots = hunter.maxSlots(maxSimBounties);
@@ -58,7 +50,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 					} else {
 						interaction.reply({ content: "You don't seem to have any open bounty slots at the moment.", ephemeral: true });
 					}
-				})
+				});
 				break;
 		}
 	}

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -41,6 +41,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 					const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 					const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 
+					//TODO add "most seconded toast"
 					interaction.reply({
 						embeds: [
 							new EmbedBuilder().setColor(target.displayColor)
@@ -56,8 +57,8 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 									{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
 									{ name: "\u200B", value: "\u200B" },
 									{ name: "Toasts Raised", value: `${hunter.toastsRaised} toast${hunter.toastsRaised == 1 ? "" : "s"}`, inline: true },
+									{ name: "Toasts Seconded", value: `${hunter.toastsSeconded} toast${hunter.toastsSeconded == 1 ? "" : "s"}`, inline: true },
 									{ name: "Toasts Recieved", value: `${hunter.toastsReceived} toast${hunter.toastsReceived == 1 ? "" : "s"}`, inline: true },
-									{ name: "\u200B", value: "\u200B", inline: true }
 								)
 								.setFooter(randomFooterTip())
 								.setTimestamp()
@@ -79,6 +80,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 				const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 				const bountySlots = hunter.maxSlots(maxSimBounties);
 
+				//TODO add "most seconded toast"
 				interaction.reply({
 					embeds: [
 						new EmbedBuilder().setColor(interaction.member.displayColor)
@@ -102,8 +104,8 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 								{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
 								{ name: "\u200B", value: "\u200B" },
 								{ name: "Toasts Raised", value: `${hunter.toastsRaised} toast${hunter.toastsRaised == 1 ? "" : "s"}`, inline: true },
+								{ name: "Toasts Seconded", value: `${hunter.toastsSeconded} toast${hunter.toastsSeconded == 1 ? "" : "s"}`, inline: true },
 								{ name: "Toasts Recieved", value: `${hunter.toastsReceived} toast${hunter.toastsReceived == 1 ? "" : "s"}`, inline: true },
-								{ name: "\u200B", value: "\u200B", inline: true }
 							)
 							.setFooter(randomFooterTip())
 							.setTimestamp()

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -183,23 +183,25 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 			],
 			fetchReply: true
 		}).then(message => {
-			return message.startThread({ name: "Rewards" });
-		}).then(thread => {
-			getRankUpdates(interaction.guild).then(rankUpdates => {
-				const multiplierString = guildProfile.eventMultiplierString();
-				let text = "";
-				if (rankUpdates.length > 0) {
-					text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+			message.startThread({ name: "Rewards" }).then(thread => {
+				if (rewardedRecipients.length > 0) {
+					getRankUpdates(interaction.guild).then(rankUpdates => {
+						const multiplierString = guildProfile.eventMultiplierString();
+						let text = "";
+						if (rankUpdates.length > 0) {
+							text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+						}
+						text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString}` : ""}`;
+						if (levelTexts.length > 0) {
+							text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
+						}
+						if (text.length > 2000) {
+							text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+						}
+						thread.send(text);
+					})
 				}
-				text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString}` : ""}`;
-				if (levelTexts.length > 0) {
-					text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
-				}
-				if (text.length > 2000) {
-					text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
-				}
-				thread.send(text);
-			})
+			});
 		});
 	}
 );

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -102,7 +102,7 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 			return list;
 		}, new Set());
 
-		const lastFiveToasts = await database.models.Toast.findAll({ order: [["createdAt", "DESC"]], limit: 5 });
+		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, userId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
 		//TODONOW prevent flushing rewarded staleToastees with trash toasts
 		const staleToastees = lastFiveToasts.reduce(async (list, toast) => {
 			return (await list).concat((await toast.recipients).map(recipient => recipient.userId));

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -192,7 +192,10 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		}).then(thread => {
 			getRankUpdates(interaction.guild).then(rankUpdates => {
 				const multiplierString = guildProfile.eventMultiplierString();
-				let text = `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+				let text = "";
+				if (rankUpdates.length > 0) {
+					text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+				}
 				text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + 1 XP${multiplierString}` : ""}`;
 				if (levelTexts.length > 0) {
 					text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -1,0 +1,207 @@
+const { PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { SAFE_DELIMITER } = require('../constants');
+const { getNumberEmoji, getRankUpdates } = require('../helpers');
+const { database } = require('../../database');
+const { Op } = require('sequelize');
+
+const DAY_IN_MS = 86400000;
+
+const customId = "toast";
+const options = [
+	{
+		type: "String",
+		name: "toastees",
+		description: "The mention(s) of the bounty hunter(s) to whom you are raising a toast",
+		required: true,
+		choices: []
+	},
+	{
+		type: "String",
+		name: "message",
+		description: "The text of the toast to raise",
+		required: true,
+		choices: []
+	},
+	{
+		type: "String",
+		name: "image-url",
+		description: "The URL to the image to add to the toast",
+		required: false,
+		choices: []
+	}
+];
+const subcommands = [];
+module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hunter(s), usually granting +1 XP", PermissionFlagsBits.SendMessages, false, false, 30000, options, subcommands,
+	/** Provide 1 XP to mentioned hunters up to author's quota (10/48 hours), roll for crit toast (grants author XP) */
+	async (interaction) => {
+		const errors = [];
+
+		// Find valid toastees
+		const idRegExp = RegExp(/<@(\d+)>/, "g");
+		const toasteeIds = [];
+		let results;
+		while ((results = idRegExp.exec(interaction.options.getString(options[0].name))) != null) {
+			const id = results[1];
+			if (id != interaction.user.id) {
+				toasteeIds.push(id);
+			}
+		}
+
+		if (toasteeIds.length < 1) { //TODONOW filter out bots
+			errors.push("Could not parse any user mentions from `toastees`.");
+		}
+
+		const embed = new EmbedBuilder();
+
+		// Validate image-url is a URL
+		const imageURL = interaction.options.getString(options[2].name);
+		try {
+			if (imageURL) {
+				new URL(imageURL);
+				embed.setImage(imageURL);
+			}
+		} catch (error) {
+			errors.push(error.message);
+		}
+
+		// Early-out if any errors
+		if (errors.length > 0) {
+			interaction.reply({ content: `The following errors were encountered while raising your toast:\n- ${errors.join("\n- ")}`, ephemeral: true });
+			return;
+		}
+
+		// Build rest of embed
+		const toastText = interaction.options.getString(options[1].name);
+		embed.setColor("e5b271")
+			.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
+			.setTitle(toastText)
+			.setDescription(`A toast to <@${toasteeIds.join(">, <@")}>!`)
+			.setFooter({ text: interaction.member.displayName, iconURL: interaction.user.avatarURL() });
+
+		// Make database entities
+		const recentToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id, createdAt: { [Op.gt]: new Date(new Date() - 2 * DAY_IN_MS) } } });
+		let rewardsAvailable = 10;
+		let critToastsAvailable = 2;
+		for (const toast of recentToasts) {
+			rewardsAvailable -= (await toast.rewardedRecipients).length;
+			for (const reciept of await toast.recipients) {
+				if (reciept.wasCrit) {
+					critToastsAvailable--;
+				}
+			}
+		}
+		const toastsInLastDay = recentToasts.filter(toast => new Date(toast.createdAt) > new Date(new Date() - DAY_IN_MS));
+		const hunterIdsToastedInLastDay = await toastsInLastDay.reduce(async (list, toast) => {
+			(await toast.recipients).forEach(recipient => {
+				if (!list.has(recipient.recipientId)) {
+					list.add(recipient.recipientId);
+				}
+			})
+			return list;
+		}, new Set());
+
+		const lastFiveToasts = await database.models.Toast.findAll({ order: [["createdAt", "DESC"]], limit: 5 });
+		//TODONOW prevent flushing rewarded staleToastees with trash toasts
+		const staleToastees = lastFiveToasts.reduce(async (list, toast) => {
+			return (await list).concat((await toast.recipients).map(recipient => recipient.recipientId));
+		}, []);
+
+		const recipientPayloads = []; //TODONOW look up technical term for object used to build entity
+		let rewardedRecipients = [];
+		let critValue = 0;
+		let guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+		if (!guildProfile) {
+			//TODO use findOrCreate after double-checking associations (may not cascade from hunter to user correctly)
+			guildProfile = database.models.Guild.create({ id: interaction.guildId });
+		}
+		let sender = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+		if (!sender) {
+			//TODO use findOrCreate after double-checking associations (may not cascade from hunter to user correctly)
+			const user = await database.models.User.findByPk(interaction.user.id);
+			if (!user) {
+				await database.models.User.create({ id: interaction.user.id });
+			}
+			sender = await database.models.Hunter.create({ userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: !interaction.member.manageable });
+		}
+		sender.toastsRaised++;
+		const toast = await database.models.Toast.create({ guildId: interaction.guildId, senderId: interaction.user.id, text: toastText, imageURL });
+		for (const id of toasteeIds) {
+			//TODONOW look up technical term for object used to build entity
+			const payload = { toastId: toast.id, recipientId: id, isRewarded: !hunterIdsToastedInLastDay.has(id) && rewardsAvailable > 0, wasCrit: false };
+			if (payload.isRewarded) {
+				rewardedRecipients.push(id);
+
+				// Calculate crit
+				if (critToastsAvailable > 0) {
+					const critRoll = Math.random() * 100;
+
+					let effectiveToastLevel = sender.level + 2;
+					for (const recipientId of staleToastees) {
+						if (id == recipientId) {
+							effectiveToastLevel--;
+							if (effectiveToastLevel < 2) {
+								break;
+							}
+						}
+					};
+
+					// f(x) = 150/(x+2)^(1/3)
+					if (critRoll * critRoll * critRoll > 3375000 / effectiveToastLevel) {
+						payload.wasCrit = true;
+						critValue += 1;
+					}
+				}
+
+				rewardsAvailable--;
+			}
+			recipientPayloads.push(payload);
+		}
+		database.models.ToastRecipient.bulkCreate(recipientPayloads);
+
+		// Add XP and update ranks
+		const levelTexts = [];
+		levelTexts.concat(await sender.addXP(interaction.guild, critValue, false));
+		for (const recipientId of rewardedRecipients) {
+			let hunter = await database.models.Hunter.findOne({ where: { userId: recipientId, guildId: interaction.guildId } });
+			if (!hunter) {
+				//TODO use findOrCreate after double-checking associations (may not cascade from hunter to user correctly)
+				const user = await database.models.User.findByPk(recipientId);
+				if (!user) {
+					await database.models.User.create({ id: recipientId });
+				}
+				const member = await interaction.guild.members.fetch(recipientId);
+				hunter = await database.models.Hunter.create({ userId: recipientId, guildId: interaction.guildId, isRankEligible: !member.manageable });
+			}
+			levelTexts.concat(await hunter.addXP(interaction.guild, 1, false));
+		}
+
+		interaction.reply({
+			embeds: [embed],
+			components: [
+				new ActionRowBuilder().addComponents(
+					new ButtonBuilder().setCustomId(`secondtoast${SAFE_DELIMITER}${"toastId"}`)
+						.setLabel("I second this toast!")
+						.setEmoji(getNumberEmoji(2))
+						.setStyle(ButtonStyle.Primary)
+				)
+			],
+			fetchReply: true
+		}).then(message => {
+			return message.startThread({ name: "Rewards" });
+		}).then(thread => {
+			getRankUpdates(interaction.guild).then(rankUpdates => {
+				const multiplierString = guildProfile.eventMultiplierString();
+				let text = `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+				text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + 1 XP${multiplierString}` : ""}`;
+				if (levelTexts.length > 0) {
+					text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
+				}
+				if (text.length > 2000) {
+					text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+				}
+				thread.send(text);
+			})
+		});
+	}
+);

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -102,14 +102,15 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 			}
 		}
 		const toastsInLastDay = recentToasts.filter(toast => new Date(toast.createdAt) > new Date(new Date() - DAY_IN_MS));
-		const hunterIdsToastedInLastDay = await toastsInLastDay.reduce(async (list, toast) => {
+		const hunterIdsToastedInLastDay = await toastsInLastDay.reduce(async (listPromise, toast) => {
+			const list = await listPromise;
 			(await toast.recipients).forEach(reciept => {
 				if (!list.has(reciept.recipientId)) {
 					list.add(reciept.recipientId);
 				}
 			})
 			return list;
-		}, new Set());
+		}, new Promise((resolve) => { resolve(new Set()) }));
 
 		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
 		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -112,9 +112,9 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		}, new Set());
 
 		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
-		const staleToastees = lastFiveToasts.reduce(async (list, toast) => {
+		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {
 			return (await list).concat((await toast.rewardedRecipients).map(reciept => reciept.recipientId));
-		}, []);
+		}, new Promise((resolve) => { resolve([]) }));
 
 		const recipientRecords = [];
 		let rewardedRecipients = [];

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -130,8 +130,8 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		for (const id of nonBotToasteeIds) {
 			//TODO move to bulkCreate when create by association is working
 			const [user] = await database.models.User.findOrCreate({ where: { id } });
-			const record = { toastId: toast.id, recipientId: id, isRewarded: !hunterIdsToastedInLastDay.has(id) && rewardsAvailable > 0, wasCrit: false };
-			if (record.isRewarded) {
+			const rawToast = { toastId: toast.id, recipientId: id, isRewarded: !hunterIdsToastedInLastDay.has(id) && rewardsAvailable > 0, wasCrit: false };
+			if (rawToast.isRewarded) {
 				rewardedRecipients.push(id);
 
 				// Calculate crit
@@ -150,7 +150,7 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 
 					// f(x) = 150/(x+2)^(1/3)
 					if (critRoll * critRoll * critRoll > 3375000 / effectiveToastLevel) {
-						record.wasCrit = true;
+						rawToast.wasCrit = true;
 						critValue += 1;
 						critToastsAvailable--;
 					}
@@ -158,7 +158,7 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 
 				rewardsAvailable--;
 			}
-			recipientRecords.push(record);
+			recipientRecords.push(rawToast);
 		}
 		database.models.ToastRecipient.bulkCreate(recipientRecords);
 
@@ -189,9 +189,9 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 						const multiplierString = guildProfile.eventMultiplierString();
 						let text = "";
 						if (rankUpdates.length > 0) {
-							text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}`;
+							text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}\n`;
 						}
-						text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString}` : ""}`;
+						text += `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString}` : ""}\n`;
 						if (levelTexts.length > 0) {
 							text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
 						}

--- a/source/constants.js
+++ b/source/constants.js
@@ -1,5 +1,6 @@
 exports.SAFE_DELIMITER = "→";
 exports.MAX_SET_TIMEOUT = 2 ** 31 - 1;
+exports.DAY_IN_MS = 86400000;
 exports.YEAR_IN_MS = 31556926000;
 
 exports.authPath = "../config/auth.json";

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -68,9 +68,9 @@ exports.generateScorelines = async function (guild, isSeasonScoreboard) {
 
 	const hunters = await database.models.Hunter.findAll(queryParams);
 	const hunterMembers = await guild.members.fetch(hunters.map(hunter => hunter.userId));
+	const rankMojiArray = (await database.models.GuildRank.findAll({ where: { guildId: guild.id }, order: [["varianceThreshold", "DESC"]] })).map(rank => rank.rankMoji);
 
-	//TODO guild rankmoji
-	const scorelines = hunters.map(hunter => `#${hunter.seasonPlacement} **${hunterMembers.get(hunter.userId).displayName}** __Level ${hunter.level}__ *${isSeasonScoreboard ? `${hunter.seasonXP} season XP` : `${hunter.xp} XP`}*`).join("\n");
+	const scorelines = hunters.map(hunter => `${hunter.rank ? `${rankMojiArray[hunter.rank]} ` : ""}#${hunter.seasonPlacement} **${hunterMembers.get(hunter.userId).displayName}** __Level ${hunter.level}__ *${isSeasonScoreboard ? `${hunter.seasonXP} season XP` : `${hunter.xp} XP`}*`).join("\n");
 	return scorelines || "No Bounty Hunters yet..."; //TODO handle character overflow
 }
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -149,8 +149,8 @@ exports.getRankUpdates = async function (guild, force = false) {
 						}
 					}
 				}
-				if (hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs
-					outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole ? destinationRole.name : `Rank ${hunter.rank + 1}`}!`);
+				if (destinationRole && hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs
+					outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole.name}!`);
 				}
 			}
 		}

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -138,19 +138,19 @@ exports.getRankUpdates = async function (guild, force = false) {
 		for (const hunter of allHunters) {
 			if (force || hunter.rank != hunter.lastRank) {
 				const member = await guild.members.fetch(hunter.userId);
-				let destinationRole;
 				if (member.manageable) {
 					await member.roles.remove(roleIds);
 					if (hunter.isRankEligible) { // Feature: remove rank roles from DQ'd users but don't give them new ones
+						let destinationRole;
 						const rankRoleId = ranks[hunter.rank]?.roleId;
 						if (rankRoleId) {
 							await member.roles.add(rankRoleId);
 							destinationRole = await guild.roles.fetch(rankRoleId);
 						}
+						if (destinationRole && hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs
+							outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole.name}!`);
+						}
 					}
-				}
-				if (destinationRole && hunter.rank > hunter.lastRank) { // Feature: don't comment on rank downs
-					outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole.name}!`);
 				}
 			}
 		}

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -96,6 +96,7 @@ exports.setRanks = async (participants, ranks) => {
 				hunter.rank = index;
 			}
 		});
+		//TODO fix crash if no GuildRanks
 		hunter.nextRankXP = Math.ceil(stdDev * ranks[hunter.rank].varianceThreshold + mean - hunter.seasonXP);
 	}
 	let recentPlacement = participants.length - 1; // subtract 1 to adjust for array indexes starting from 0

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -89,15 +89,16 @@ exports.setRanks = async (participants, ranks) => {
 
 	mean /= rankableHunters.length;
 	const stdDev = Math.sqrt(rankableHunters.reduce((total, hunter) => total + (hunter.seasonXP - mean) ** 2, 0) / rankableHunters.length);
-	for (const hunter of rankableHunters) {
-		let variance = (hunter.seasonXP - mean) / stdDev;
-		ranks.forEach((rank, index) => {
-			if (variance >= rank.varianceThreshold) {
-				hunter.rank = index;
-			}
-		});
-		//TODO fix crash if no GuildRanks
-		hunter.nextRankXP = Math.ceil(stdDev * ranks[hunter.rank].varianceThreshold + mean - hunter.seasonXP);
+	if (ranks?.length > 0) {
+		for (const hunter of rankableHunters) {
+			let variance = (hunter.seasonXP - mean) / stdDev;
+			ranks.forEach((rank, index) => {
+				if (variance >= rank.varianceThreshold) {
+					hunter.rank = index;
+				}
+			});
+			hunter.nextRankXP = Math.ceil(stdDev * ranks[hunter.rank].varianceThreshold + mean - hunter.seasonXP);
+		}
 	}
 	let recentPlacement = participants.length - 1; // subtract 1 to adjust for array indexes starting from 0
 	let previousScore = 0;

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,7 +1,5 @@
-const { Op } = require("sequelize");
 const { database } = require("../database");
 const { Guild } = require("discord.js");
-const { Hunter } = require("./models/users/Hunter");
 const { GuildRank } = require("./models/guilds/GuildRank");
 
 const CONGRATULATORY_PHRASES = [
@@ -59,7 +57,7 @@ exports.getNumberEmoji = function (number) {
 }
 
 /** Recalculates the ranks (standard deviations from mean) and placements (ordinal) for the given participants
- * @param {Hunter[]} participants
+ * @param {database.models.Hunter[]} participants
  * @param {GuildRank[]} ranks
  * @returns Promise of the message congratulating the hunter reaching first place (or `null` if no change)
  */

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -1,76 +1,12 @@
 ﻿const { EmbedBuilder, Guild } = require('discord.js');
-const { DataTypes: { BIGINT, STRING, INTEGER, BOOLEAN }, Model } = require('sequelize');
+const { DataTypes, Model } = require('sequelize');
 const { ihpAuthorPayload } = require('../../embedHelpers');
 const { Hunter } = require('../users/Hunter');
 const { Guild: HunterGuild } = require('../guilds/Guild');
 const { database } = require('../../../database');
 
 /** Bounties are user created objectives for other server members to complete */
-const bountyModel = {
-	id: {
-		primaryKey: true,
-		type: BIGINT,
-		autoIncrement: true
-	},
-	userId: {
-		type: STRING,
-		references: {
-			model: 'User',
-			key: 'id'
-		}
-	},
-	guildId: {
-		type: STRING,
-		references: {
-			model: 'Guild',
-			key: 'id'
-		}
-	},
-	postingId: {
-		type: STRING,
-	},
-	slotNumber: {
-		type: INTEGER,
-		allowNull: false
-	},
-	isEvergreen: {
-		type: BOOLEAN,
-		devaultValue: false
-	},
-	title: {
-		type: STRING,
-		allowNull: false
-	},
-	description: {
-		type: STRING,
-		allowNull: false
-	},
-	attachmentURL: {
-		type: STRING,
-		defaultValue: null
-	},
-	scheduledEventId: {
-		type: INTEGER,
-		defaultValue: null
-	},
-	state: { // Allowed values: "open", "completed", "deleted"
-		type: STRING,
-		defaultValue: "open"
-	},
-	completedAt: {
-		type: INTEGER,
-		defaultValue: null
-	},
-	deletedAt: {
-		type: INTEGER,
-		defaultValue: null
-	},
-	editCount: {
-		type: INTEGER,
-		defaultValue: 0
-	}
-};
-exports.Bounty = class Bounty extends Model {
+exports.Bounty = class extends Model {
 	/** Generate an embed for the given bounty
 	 * @param {Guild} guild
 	 * @param {Hunter?} hunter
@@ -114,7 +50,56 @@ exports.Bounty = class Bounty extends Model {
 }
 
 exports.initModel = function (sequelize) {
-	exports.Bounty.init(bountyModel, {
+	exports.Bounty.init({
+		id: {
+			primaryKey: true,
+			type: DataTypes.BIGINT,
+			autoIncrement: true
+		},
+		postingId: {
+			type: DataTypes.STRING,
+		},
+		slotNumber: {
+			type: DataTypes.INTEGER,
+			allowNull: false
+		},
+		isEvergreen: {
+			type: DataTypes.BOOLEAN,
+			devaultValue: false
+		},
+		title: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		description: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		attachmentURL: {
+			type: DataTypes.STRING,
+			defaultValue: null
+		},
+		scheduledEventId: {
+			type: DataTypes.INTEGER,
+			defaultValue: null
+		},
+		state: { // Allowed values: "open", "completed", "deleted"
+			type: DataTypes.STRING,
+			defaultValue: "open"
+		},
+		completedAt: {
+			type: DataTypes.INTEGER,
+			defaultValue: null
+		},
+		deletedAt: {
+			type: DataTypes.INTEGER,
+			defaultValue: null
+		},
+		editCount: {
+			type: DataTypes.INTEGER,
+			defaultValue: 0
+		}
+	}, {
 		sequelize,
 		modelName: 'Bounty',
 		freezeTableName: true

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -56,8 +56,17 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BIGINT,
 			autoIncrement: true
 		},
+		userId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		guildId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
 		postingId: {
 			type: DataTypes.STRING,
+			allowNull: false
 		},
 		slotNumber: {
 			type: DataTypes.INTEGER,
@@ -91,7 +100,7 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.INTEGER,
 			defaultValue: null
 		},
-		deletedAt: {
+		deletedAt: { //TODO convert to paranoid
 			type: DataTypes.INTEGER,
 			defaultValue: null
 		},

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -65,8 +65,7 @@ exports.initModel = function (sequelize) {
 			allowNull: false
 		},
 		postingId: {
-			type: DataTypes.STRING,
-			allowNull: false
+			type: DataTypes.STRING
 		},
 		slotNumber: {
 			type: DataTypes.INTEGER,

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -1,40 +1,14 @@
-﻿// Database Entity Class
-const { DataTypes: { BIGINT, STRING, INTEGER }, Model } = require('sequelize');
+﻿const { DataTypes, Model } = require('sequelize');
 
-// Store receipt information of a bounty completion and relevant stats of that bounty
-const completionModel = {
-	bountyId: {
-		primaryKey: true,
-		type: BIGINT,
-		references: {
-			model: 'Bounty',
-			key: 'id'
-		}
-	},
-	userId: {
-		primaryKey: true,
-		type: STRING,
-		references: {
-			model: 'User',
-			key: 'id'
-		}
-	},
-	guildId: {
-		primaryKey: true,
-		type: STRING,
-		references: {
-			model: 'Guild',
-			key: 'id'
-		}
-	},
-	xpAwarded: {
-		type: INTEGER
-	}
-};
-exports.Completion = class Completion extends Model { }
+/** Store receipt information of a bounty completion and relevant stats of that bounty */
+exports.Completion = class extends Model { }
 
 exports.initModel = function (sequelize) {
-	exports.Completion.init(completionModel, {
+	exports.Completion.init({
+		xpAwarded: {
+			type: DataTypes.INTEGER
+		}
+	}, {
 		sequelize,
 		modelName: 'Completion',
 		freezeTableName: true

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -5,6 +5,18 @@ exports.Completion = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.Completion.init({
+		bountyId: {
+			primaryKey: true,
+			type: DataTypes.BIGINT
+		},
+		userId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
+		guildId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
 		xpAwarded: {
 			type: DataTypes.INTEGER
 		}

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -2,7 +2,7 @@ const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT, VIRTUAL }, Model } = requ
 
 /** Guild information and bot settings */
 exports.Guild = class Guild extends Model {
-	eventMultiplierString = () => {
+	eventMultiplierString() {
 		if (this.eventMultiplier != 1) {
 			return ` ***x${this.eventMultiplier}***`;
 		} else {

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -1,7 +1,7 @@
-const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT, VIRTUAL }, Model } = require('sequelize');
+const { DataTypes, Model } = require('sequelize');
 
 /** Guild information and bot settings */
-exports.Guild = class Guild extends Model {
+exports.Guild = class extends Model {
 	eventMultiplierString() {
 		if (this.eventMultiplier != 1) {
 			return ` ***x${this.eventMultiplier}***`;
@@ -64,81 +64,81 @@ exports.initModel = function (sequelize) {
 	exports.Guild.init({
 		id: {
 			primaryKey: true,
-			type: STRING,
+			type: DataTypes.STRING,
 			allowNull: false
 		},
 		xp: {
-			type: VIRTUAL,
+			type: DataTypes.VIRTUAL,
 			async get() {
 				return await sequelize.models.Hunter.sum("level", { where: { guildId: this.id } });
 			}
 		},
 		level: {
-			type: INTEGER,
+			type: DataTypes.INTEGER,
 			defaultValue: 1
 		},
 		announcementPrefix: {
-			type: STRING,
+			type: DataTypes.STRING,
 			defaultValue: '@here'
 		},
 		disableBoostXP: {
-			type: BOOLEAN,
+			type: DataTypes.BOOLEAN,
 			defaultValue: true
 		},
 		maxSimBounties: {
-			type: INTEGER,
+			type: DataTypes.INTEGER,
 			defaultValue: 5
 		},
 		backupTimer: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 3600000
 		},
 		bountyBoardId: {
-			type: STRING,
+			type: DataTypes.STRING,
 			defaultValue: ''
 		},
 		scoreId: {
-			type: STRING,
+			type: DataTypes.STRING,
 			defaultValue: ''
 		},
 		raffleDate: {
-			type: STRING,
+			type: DataTypes.STRING,
 			defaultValue: ''
 		},
 		eventMultiplier: {
-			type: INTEGER,
+			type: DataTypes.INTEGER,
 			defaultValue: 1
 		},
 		xpCoefficient: {
-			type: INTEGER,
+			type: DataTypes.INTEGER,
 			defaultValue: 3
 		},
 		seasonXP: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
 		seasonBounties: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
 		seasonToasts: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
 		resetSchedulerId: {
-			type: STRING,
+			type: DataTypes.STRING,
 			defaultValue: ""
 		},
 		lastSeasonXP: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
 		bountiesLastSeason: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
 		toastsLastSeason: {
-			type: BIGINT,
+			type: DataTypes.BIGINT,
 			defaultValue: 0
 		}
 	}, {

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -70,11 +70,7 @@ exports.initModel = function (sequelize) {
 		xp: {
 			type: VIRTUAL,
 			async get() {
-				const [hunterLevels] = await sequelize.query("SELECT SUM(level) FROM Hunter WHERE guildId = :guildId", {
-					replacements: { guildId: this.id },
-					type: QueryTypes.SELECT
-				});
-				return hunterLevels["SUM(level)"];
+				return await sequelize.models.Hunter.sum("level", { where: { guildId: this.id } });
 			}
 		},
 		level: {

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -64,8 +64,7 @@ exports.initModel = function (sequelize) {
 	exports.Guild.init({
 		id: {
 			primaryKey: true,
-			type: DataTypes.STRING,
-			allowNull: false
+			type: DataTypes.STRING
 		},
 		xp: {
 			type: DataTypes.VIRTUAL,

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -1,4 +1,4 @@
-const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT, VIRTUAL }, Model, QueryTypes } = require('sequelize');
+const { DataTypes: { STRING, BOOLEAN, INTEGER, BIGINT, VIRTUAL }, Model } = require('sequelize');
 
 /** Guild information and bot settings */
 exports.Guild = class Guild extends Model {

--- a/source/models/guilds/GuildRank.js
+++ b/source/models/guilds/GuildRank.js
@@ -1,31 +1,22 @@
-﻿const { DataTypes: { STRING, REAL }, Model } = require('sequelize');
+﻿const { DataTypes, Model } = require('sequelize');
 
 /** Ranks, individual per guild, include a variance threshold (difficulty to achieve) and optionally a role to give hunters and emoji for the scoreboard */
-const guildRankModel = {
-	guildId: {
-		primaryKey: true,
-		type: STRING,
-		allowNull: false,
-		references: {
-			model: 'Guild'
-		}
-	},
-	varianceThreshold: {
-		primaryKey: true,
-		type: REAL,
-		allowNull: false
-	},
-	roleId: {
-		type: STRING
-	},
-	rankMoji: {
-		type: STRING
-	}
-};
-exports.GuildRank = class GuildRank extends Model { }
+exports.GuildRank = class extends Model { }
 
 exports.initModel = function (sequelize) {
-	exports.GuildRank.init(guildRankModel, {
+	exports.GuildRank.init({
+		varianceThreshold: {
+			primaryKey: true,
+			type: DataTypes.REAL,
+			allowNull: false
+		},
+		roleId: {
+			type: DataTypes.STRING
+		},
+		rankMoji: {
+			type: DataTypes.STRING
+		}
+	}, {
 		sequelize,
 		modelName: 'GuildRank',
 		freezeTableName: true

--- a/source/models/guilds/GuildRank.js
+++ b/source/models/guilds/GuildRank.js
@@ -5,10 +5,13 @@ exports.GuildRank = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.GuildRank.init({
+		guildId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
 		varianceThreshold: {
 			primaryKey: true,
-			type: DataTypes.REAL,
-			allowNull: false
+			type: DataTypes.REAL
 		},
 		roleId: {
 			type: DataTypes.STRING

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -10,6 +10,14 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BIGINT,
 			autoIncrement: true
 		},
+		guildId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		senderId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
 		recipients: {
 			type: DataTypes.VIRTUAL,
 			async get() {

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -1,0 +1,51 @@
+const { DataTypes, Model } = require('sequelize');
+
+/** This model represents a toast raised for a group of bounty hunters */
+exports.Toast = class Toast extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.Toast.init({
+		id: {
+			primaryKey: true,
+			type: DataTypes.BIGINT,
+			autoIncrement: true
+		},
+		guildId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		senderId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		recipients: {
+			type: DataTypes.VIRTUAL,
+			async get() {
+				return await sequelize.models.ToastRecipient.findAll({ where: { toastId: this.id } });
+			}
+		},
+		rewardedRecipients: {
+			type: DataTypes.VIRTUAL,
+			async get() {
+				return await sequelize.models.ToastRecipient.findAll({ where: { toastId: this.id, isRewarded: true } });
+			}
+		},
+		seconders: {
+			type: DataTypes.VIRTUAL,
+			async get() {
+				return await sequelize.models.ToastSeconding.findAll({ where: { toastId: this.id } });
+			}
+		},
+		text: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		imageURL: {
+			type: DataTypes.STRING,
+		}
+	}, {
+		sequelize,
+		modelName: 'Toast',
+		freezeTableName: true
+	});
+}

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -22,12 +22,6 @@ exports.initModel = function (sequelize) {
 				return await sequelize.models.ToastRecipient.findAll({ where: { toastId: this.id, isRewarded: true } });
 			}
 		},
-		seconders: {
-			type: DataTypes.VIRTUAL,
-			async get() {
-				return await sequelize.models.ToastSeconding.findAll({ where: { toastId: this.id } });
-			}
-		},
 		text: {
 			type: DataTypes.STRING,
 			allowNull: false

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -1,7 +1,7 @@
 const { DataTypes, Model } = require('sequelize');
 
 /** This model represents a toast raised for a group of bounty hunters */
-exports.Toast = class Toast extends Model { }
+exports.Toast = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.Toast.init({
@@ -9,14 +9,6 @@ exports.initModel = function (sequelize) {
 			primaryKey: true,
 			type: DataTypes.BIGINT,
 			autoIncrement: true
-		},
-		guildId: {
-			type: DataTypes.STRING,
-			allowNull: false
-		},
-		senderId: {
-			type: DataTypes.STRING,
-			allowNull: false
 		},
 		recipients: {
 			type: DataTypes.VIRTUAL,

--- a/source/models/toasts/ToastRecipient.js
+++ b/source/models/toasts/ToastRecipient.js
@@ -1,18 +1,10 @@
 const { DataTypes, Model } = require('sequelize');
 
 /** This class stores receipts of toast transactions */
-exports.ToastRecipient = class ToastRecipient extends Model { }
+exports.ToastRecipient = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.ToastRecipient.init({
-		toastId: {
-			primaryKey: true,
-			type: DataTypes.BIGINT
-		},
-		recipientId: {
-			primaryKey: true,
-			type: DataTypes.STRING
-		},
 		isRewarded: {
 			type: DataTypes.BOOLEAN,
 			allowNull: false

--- a/source/models/toasts/ToastRecipient.js
+++ b/source/models/toasts/ToastRecipient.js
@@ -1,0 +1,29 @@
+const { DataTypes, Model } = require('sequelize');
+
+/** This class stores receipts of toast transactions */
+exports.ToastRecipient = class ToastRecipient extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.ToastRecipient.init({
+		toastId: {
+			primaryKey: true,
+			type: DataTypes.BIGINT
+		},
+		recipientId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
+		isRewarded: {
+			type: DataTypes.BOOLEAN,
+			allowNull: false
+		},
+		wasCrit: {
+			type: DataTypes.BOOLEAN,
+			allowNull: false
+		}
+	}, {
+		sequelize,
+		modelName: 'ToastRecipient',
+		freezeTableName: true
+	});
+}

--- a/source/models/toasts/ToastRecipient.js
+++ b/source/models/toasts/ToastRecipient.js
@@ -5,6 +5,14 @@ exports.ToastRecipient = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.ToastRecipient.init({
+		toastId: {
+			primaryKey: true,
+			type: DataTypes.BIGINT
+		},
+		recipientId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
 		isRewarded: {
 			type: DataTypes.BOOLEAN,
 			allowNull: false

--- a/source/models/toasts/ToastSeconding.js
+++ b/source/models/toasts/ToastSeconding.js
@@ -5,6 +5,14 @@ exports.ToastSeconding = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.ToastSeconding.init({
+		toastId: {
+			primaryKey: true,
+			type: DataTypes.BIGINT
+		},
+		seconderId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
 		wasCrit: {
 			type: DataTypes.BOOLEAN,
 			allowNull: false

--- a/source/models/toasts/ToastSeconding.js
+++ b/source/models/toasts/ToastSeconding.js
@@ -1,0 +1,25 @@
+const { DataTypes, Model } = require('sequelize');
+
+/** This class stores receipts of a toast seconding */
+exports.ToastSeconding = class ToastSeconding extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.ToastSeconding.init({
+		toastId: {
+			primaryKey: true,
+			type: DataTypes.BIGINT
+		},
+		seconderId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
+		wasCrit: {
+			type: DataTypes.BOOLEAN,
+			allowNull: false
+		}
+	}, {
+		sequelize,
+		modelName: 'ToastSeconding',
+		freezeTableName: true
+	});
+}

--- a/source/models/toasts/ToastSeconding.js
+++ b/source/models/toasts/ToastSeconding.js
@@ -1,18 +1,10 @@
 const { DataTypes, Model } = require('sequelize');
 
 /** This class stores receipts of a toast seconding */
-exports.ToastSeconding = class ToastSeconding extends Model { }
+exports.ToastSeconding = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.ToastSeconding.init({
-		toastId: {
-			primaryKey: true,
-			type: DataTypes.BIGINT
-		},
-		seconderId: {
-			primaryKey: true,
-			type: DataTypes.STRING
-		},
 		wasCrit: {
 			type: DataTypes.BOOLEAN,
 			allowNull: false

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -1,100 +1,10 @@
-const { DataTypes: { STRING, BIGINT, INTEGER, BOOLEAN }, Model } = require('sequelize');
+const { DataTypes, Model } = require('sequelize');
 const { database } = require('../../../database');
 const { congratulationBuilder } = require('../../helpers');
 const { Guild } = require('discord.js');
 
-/** This class stores information for bot users on a specific guild */
-const hunterModel = {
-	userId: {
-		primaryKey: true,
-		type: STRING,
-		allowNull: false,
-		references: {
-			model: 'User'
-		}
-	},
-	guildId: {
-		primaryKey: true,
-		type: STRING,
-		allowNull: false,
-		references: {
-			model: 'Guild'
-		}
-	},
-	level: {
-		type: BIGINT,
-		defaultValue: 1
-	},
-	xp: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	seasonXP: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	isRankEligible: {
-		type: BOOLEAN,
-		allowNull: false
-	},
-	rank: {
-		type: INTEGER,
-		defaultValue: null
-	},
-	lastRank: {
-		type: INTEGER,
-		defaultValue: null
-	},
-	seasonPlacement: {
-		type: INTEGER,
-		defaultValue: 0
-	},
-	mineFinished: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	othersFinished: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	toastsRaised: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	toastsReceived: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	tabooCount: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	isBanned: {
-		type: BOOLEAN,
-		defaultValue: false
-	},
-	hasBeenBanned: {
-		type: BOOLEAN,
-		defaultValue: false
-	},
-	isDQ: {
-		type: BOOLEAN,
-		defaultValue: false
-	},
-	seasonDQCount: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	penaltyCount: {
-		type: BIGINT,
-		defaultValue: 0
-	},
-	penaltyPointTotal: {
-		type: BIGINT,
-		defaultValue: 0
-	}
-};
-exports.Hunter = class Hunter extends Model {
+/** This class stores information for users on a specific guild */
+exports.Hunter = class extends Model {
 	static xpThreshold(level, xpCoefficient) {
 		// xp = xpCoefficient*(level - 1)^2
 		return xpCoefficient * (level - 1) ** 2;
@@ -199,7 +109,80 @@ exports.Hunter = class Hunter extends Model {
 }
 
 exports.initModel = function (sequelize) {
-	exports.Hunter.init(hunterModel, {
+	exports.Hunter.init({
+		level: {
+			type: DataTypes.BIGINT,
+			defaultValue: 1
+		},
+		xp: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		seasonXP: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		isRankEligible: {
+			type: DataTypes.BOOLEAN,
+			allowNull: false
+		},
+		rank: {
+			type: DataTypes.INTEGER,
+			defaultValue: null
+		},
+		lastRank: {
+			type: DataTypes.INTEGER,
+			defaultValue: null
+		},
+		seasonPlacement: {
+			type: DataTypes.INTEGER,
+			defaultValue: 0
+		},
+		mineFinished: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		othersFinished: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		toastsRaised: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		toastsReceived: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		tabooCount: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		isBanned: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false
+		},
+		hasBeenBanned: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false
+		},
+		isDQ: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false
+		},
+		seasonDQCount: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		penaltyCount: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		penaltyPointTotal: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		}
+	}, {
 		sequelize,
 		modelName: 'Hunter',
 		freezeTableName: true

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -158,6 +158,10 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
+		toastsSeconded: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
 		toastsReceived: {
 			type: DataTypes.BIGINT,
 			defaultValue: 0

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -110,6 +110,14 @@ exports.Hunter = class extends Model {
 
 exports.initModel = function (sequelize) {
 	exports.Hunter.init({
+		userId: {
+			primaryKey: true,
+			type: DataTypes.STRING,
+		},
+		guildId: {
+			primaryKey: true,
+			type: DataTypes.STRING
+		},
 		level: {
 			type: DataTypes.BIGINT,
 			defaultValue: 1

--- a/source/models/users/User.js
+++ b/source/models/users/User.js
@@ -7,8 +7,7 @@ exports.initModel = function (sequelize) {
 	exports.User.init({
 		id: {
 			primaryKey: true,
-			type: DataTypes.STRING,
-			allowNull: false
+			type: DataTypes.STRING
 		},
 		isPremium: {
 			type: DataTypes.BOOLEAN,

--- a/source/models/users/User.js
+++ b/source/models/users/User.js
@@ -1,21 +1,20 @@
-const { DataTypes: { STRING, BOOLEAN }, Model } = require('sequelize');
+const { DataTypes, Model } = require('sequelize');
 
 /** This class stores global information for bot users */
-const userModel = {
-	id: {
-		primaryKey: true,
-		type: STRING,
-		allowNull: false
-	},
-	isPremium: {
-		type: BOOLEAN,
-		defaultValue: false
-	}
-};
-exports.User = class User extends Model { }
+exports.User = class extends Model { }
 
 exports.initModel = function (sequelize) {
-	exports.User.init(userModel, {
+	exports.User.init({
+		id: {
+			primaryKey: true,
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		isPremium: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false
+		}
+	}, {
 		sequelize,
 		modelName: 'User',
 		freezeTableName: true


### PR DESCRIPTION
Summary
-------
- added /toast
- added seconding toasts
- implemented `findOrCreate`
- improved foreignKey configuration of database models
- added rankmoji to scoreboard

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested the following flow
   - /toast from empty database
   - second toast

Issue
-----
Closes #25