### PR TITLE
#4: Port `/edit` as `/bounty edit` flow

### DIFF
--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -22,7 +22,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		}
 
 		const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable } });
+		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId }, defaults: { isRankEligible: interaction.member.manageable } });
 		seconder.toastSeconded++;
 
 		const recipientIds = (await originalToast.recipients).map(reciept => reciept.recipientId);

--- a/source/classes/InteractionWrapper.js
+++ b/source/classes/InteractionWrapper.js
@@ -28,7 +28,7 @@ class CommandWrapper extends module.exports.InteractionWrapper {
 	 * @param {boolean} allowInDMsInput
 	 * @param {number} cooldownInMS
 	 * @param {{type: "Attachment" | "Boolean" | "Channel" | "Integer" | "Mentionable" | "Number" | "Role" | "String" | "User", name: string, description: string, required: boolean, choices: { name: string, value }[]}[]} optionsInput
-	 * @param {{name: string, description: string, optionsInput: {type: "Attachment" | "Boolean" | "Channel" | "Integer" | "Mentionable" | "Number" | "Role" | "String" | "User", name: string, description: string, required: boolean, choices: { name: string, value }[]}}[]} subcommandsInput
+	 * @param {{name: string, description: string, optionsInput?: {type: "Attachment" | "Boolean" | "Channel" | "Integer" | "Mentionable" | "Number" | "Role" | "String" | "User", name: string, description: string, required: boolean, choices: { name: string, value }[]}}[]} subcommandsInput
 	 * @param {(interaction: CommandInteraction) => void} executeFunction
 	 */
 	constructor(customIdInput, descriptionInput, defaultMemberPermission, isPremiumCommand, allowInDMsInput, cooldownInMS, optionsInput, subcommandsInput, executeFunction) {
@@ -56,7 +56,7 @@ class CommandWrapper extends module.exports.InteractionWrapper {
 		subcommandsInput.forEach(subcommand => {
 			this.data.addSubcommand(built => {
 				built.setName(subcommand.name).setDescription(subcommand.description);
-				subcommand.optionsInput.forEach(option => {
+				subcommand.optionsInput?.forEach(option => {
 					built[`add${option.type}Option`](subBuilt => {
 						subBuilt.setName(option.name).setDescription(option.description).setRequired(option.required);
 						if (option.choices === null || option.choices === undefined) {

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -19,7 +19,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 			case subcommands[0].name: // Post
 				database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
 					const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable } });
+					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId }, defaults: { isRankEligible: interaction.member.manageable } });
 					const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, state: "open" } });
 					const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
 					const bountySlots = hunter.maxSlots(maxSimBounties);

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -124,7 +124,7 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		const [guildProfile] = await database.models.Guild.findOrCreate({ where: { id: interaction.guildId } });
 		guildProfile.increment({ "seasonToasts": 1 });
 		const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-		const [sender] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId, isRankEligible: interaction.member.manageable } });
+		const [sender] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId }, defaults: { isRankEligible: interaction.member.manageable } });
 		sender.toastsRaised++;
 		const toast = await database.models.Toast.create({ guildId: interaction.guildId, senderId: interaction.user.id, text: toastText, imageURL });
 		for (const id of nonBotToasteeIds) {
@@ -167,7 +167,7 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		levelTexts.concat(await sender.addXP(interaction.guild, critValue, false));
 		for (const recipientId of rewardedRecipients) {
 			const member = await interaction.guild.members.fetch(recipientId);
-			const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: recipientId, guildId: interaction.guildId, isRankEligible: member.manageable } });
+			const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: recipientId, guildId: interaction.guildId }, defaults: { isRankEligible: member.manageable } });
 			levelTexts.concat(await hunter.addXP(interaction.guild, 1, false));
 		}
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -48,6 +48,10 @@ const NUMBER_EMOJI = {
 	9: '9️⃣',
 	10: '🔟'
 };
+/**
+ * @param {number} number
+ * @returns {string}
+ */
 exports.getNumberEmoji = function (number) {
 	if (number in NUMBER_EMOJI) {
 		return NUMBER_EMOJI[number];

--- a/source/modals/_modalDictionary.js
+++ b/source/modals/_modalDictionary.js
@@ -4,6 +4,7 @@ const { InteractionWrapper } = require("../classes");
 const modalDictionary = {};
 
 for (const file of [
+	"bountyeditmodal.js",
 	"bountypostmodal.js",
 	"feedback-bugreport.js",
 	"feedback-featurerequest.js"

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -95,6 +95,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			interaction.guild.scheduledEvents.delete(bounty.scheduledEventId);
 			bounty.scheduledEventId = null;
 		}
+		bounty.editCount++;
 		bounty.save();
 
 		// update bounty board

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -67,6 +67,8 @@ module.exports = new InteractionWrapper(customId, 3000,
 		}
 		if (imageURL) {
 			bounty.attachmentURL = imageURL;
+		} else if (bounty.attachmentURL) {
+			bounty.attachmentURL = null;
 		}
 
 

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -1,0 +1,115 @@
+const { GuildScheduledEventEntityType } = require('discord.js');
+const { database } = require('../../database');
+const { InteractionWrapper } = require('../classes');
+const { YEAR_IN_MS } = require('../constants');
+const { addAnnouncementPrefix } = require('../helpers');
+
+const customId = "bountyeditmodal";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Serialize data into a bounty, then announce with showcase embed */
+	async (interaction, [slotNumber]) => {
+		const title = interaction.fields.getTextInputValue("title");
+		const description = interaction.fields.getTextInputValue("description");
+		const imageURL = interaction.fields.getTextInputValue("imageURL");
+		const startTimestamp = parseInt(interaction.fields.getTextInputValue("startTimestamp"));
+		const endTimestamp = parseInt(interaction.fields.getTextInputValue("endTimestamp"));
+		const shouldMakeEvent = startTimestamp && endTimestamp;
+
+		const errors = [];
+
+		if (imageURL) {
+			try {
+				new URL(imageURL);
+			} catch (error) {
+				errors.push(error.message);
+			}
+		}
+
+		if (!isNaN(startTimestamp) || !isNaN(endTimestamp)) {
+			if (!startTimestamp) {
+				errors.push("Start timestamp must be an integer.");
+			} else if (!endTimestamp) {
+				errors.push("End timestamp must be an integer.");
+			} else {
+				if (startTimestamp > endTimestamp) {
+					errors.push("End timestamp was before start timestamp.");
+				}
+
+				const nowTimestamp = Date.now() / 1000;
+				if (nowTimestamp >= startTimestamp) {
+					errors.push("Start timestamp must be in the future.");
+				}
+
+				if (nowTimestamp >= endTimestamp) {
+					errors.push("End timestamp must be in the future.");
+				}
+
+				if (startTimestamp >= nowTimestamp + (5 * YEAR_IN_MS)) {
+					errors.push("Start timestamp cannot be 5 years in the future or further.");
+				}
+
+				if (endTimestamp >= nowTimestamp + (5 * YEAR_IN_MS)) {
+					errors.push("End timestamp cannot be 5 years in the future or further.");
+				}
+			}
+		}
+
+		if (errors.length > 0) {
+			interaction.reply({ content: `The following errors were encountered while posting your bounty **${title}**:\n• ${errors.join("\n• ")}`, ephemeral: true });
+			return;
+		}
+
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		if (title) {
+			bounty.title = title;
+		}
+		if (description) {
+			bounty.description = description;
+		}
+		if (imageURL) {
+			bounty.attachmentURL = imageURL;
+		}
+
+
+		if (shouldMakeEvent) {
+			const eventPayload = {
+				name: `Bounty: ${title}`,
+				description,
+				scheduledStartTime: startTimestamp * 1000,
+				scheduledEndTime: endTimestamp * 1000,
+				privacyLevel: 2,
+				entityType: GuildScheduledEventEntityType.External,
+				entityMetadata: { location: `${interaction.member.displayName}'s #${slotNumber} Bounty` }
+			};
+			if (imageURL) {
+				eventPayload.image = imageURL;
+			}
+			if (bounty.scheduledEventId) {
+				interaction.guild.scheduledEvents.edit(bounty.scheduledEventId, eventPayload);
+			} else {
+				const event = await interaction.guild.scheduledEvents.create(eventPayload);
+				bounty.scheduledEventId = event.id;
+			}
+		} else if (bounty.scheduledEventId) {
+			interaction.guild.scheduledEvents.delete(bounty.scheduledEventId);
+			bounty.scheduledEventId = null;
+		}
+		bounty.save();
+
+		// update bounty board
+		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
+		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster, hunterGuild);
+		if (hunterGuild.bountyBoardId) {
+			//TODO figure out how to trip auto-mod or re-add taboos
+			interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(bountyBoard => {
+				bountyBoard.threads.fetch(bounty.postingId);
+			}).then(posting => {
+				posting.edit({ embeds: [bountyEmbed] });
+			})
+		}
+
+		interaction.update({ content: "Bounty edited!", components: [] });
+		interaction.channel.send(hunterGuild.sendAnnouncement({ content: `${interaction.member} has edited one of their bounties:`, embeds: [bountyEmbed] }));
+	}
+);

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -2,7 +2,6 @@ const { GuildScheduledEventEntityType } = require('discord.js');
 const { database } = require('../../database');
 const { InteractionWrapper } = require('../classes');
 const { YEAR_IN_MS } = require('../constants');
-const { addAnnouncementPrefix } = require('../helpers');
 
 const customId = "bountyeditmodal";
 module.exports = new InteractionWrapper(customId, 3000,
@@ -25,7 +24,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		if (!isNaN(startTimestamp) || !isNaN(endTimestamp)) {
+		if (startTimestamp || endTimestamp) {
 			if (!startTimestamp) {
 				errors.push("Start timestamp must be an integer.");
 			} else if (!endTimestamp) {

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -34,7 +34,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		if (shouldMakeEvent) {
+		if (!isNaN(startTimestamp) || !isNaN(endTimestamp)) {
 			if (!startTimestamp) {
 				errors.push("Start timestamp must be an integer.");
 			} else if (!endTimestamp) {

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -108,6 +108,6 @@ module.exports = new InteractionWrapper(customId, 3000,
 			})
 		}
 
-		interaction.reply({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] });
+		interaction.reply({ content: `${hunterGuild.announcementPrefix ? `${hunterGuild.announcementPrefix} ` : ""}${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] });
 	}
 );

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -34,7 +34,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		if (!isNaN(startTimestamp) || !isNaN(endTimestamp)) {
+		if (startTimestamp || endTimestamp) {
 			if (!startTimestamp) {
 				errors.push("Start timestamp must be an integer.");
 			} else if (!endTimestamp) {

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -108,6 +108,6 @@ module.exports = new InteractionWrapper(customId, 3000,
 			})
 		}
 
-		interaction.reply({ content: `${hunterGuild.announcementPrefix ? `${hunterGuild.announcementPrefix} ` : ""}${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] });
+		interaction.reply(hunterGuild.sendAnnouncement({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] }));
 	}
 );

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -88,7 +88,7 @@ exports.initModel = function (sequelize) {
 			defaultValue: null
 		},
 		scheduledEventId: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.STRING,
 			defaultValue: null
 		},
 		state: { // Allowed values: "open", "completed", "deleted"

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const { DataTypes, Model } = require('sequelize');
 
 /** Guild information and bot settings */
@@ -8,6 +9,18 @@ exports.Guild = class extends Model {
 		} else {
 			return '';
 		}
+	}
+
+	/** Apply the guild's announcement prefix to the message (bots suppress notifications through flags instead of starting with "@silent")
+	 * @param {import('discord.js').MessageCreateOptions} messageOptions
+	 */
+	sendAnnouncement(messageOptions) {
+		if (this.announcementPrefix == "@silent") {
+			messageOptions.flags = MessageFlags.SuppressNotifications;
+		} else if (this.announcementPrefix != "") {
+			messageOptions.content = `${this.announcementPrefix} ${messageOptions.content}`;
+		}
+		return messageOptions;
 	}
 
 	// eventInfoBuilder(channel, guild, useManagerTips = false) {
@@ -76,7 +89,7 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.INTEGER,
 			defaultValue: 1
 		},
-		announcementPrefix: {
+		announcementPrefix: { // allowed values: "@here", "@everyone", "@silent", ""
 			type: DataTypes.STRING,
 			defaultValue: '@here'
 		},

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -16,7 +16,11 @@ exports.Guild = class extends Model {
 	 */
 	sendAnnouncement(messageOptions) {
 		if (this.announcementPrefix == "@silent") {
-			messageOptions.flags = MessageFlags.SuppressNotifications;
+			if ("flags" in messageOptions) {
+				messageOptions.flags |= MessageFlags.SuppressNotifications;
+			} else {
+				messageOptions.flags = MessageFlags.SuppressNotifications;
+			}
 		} else if (this.announcementPrefix != "") {
 			messageOptions.content = `${this.announcementPrefix} ${messageOptions.content}`;
 		}

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -4,6 +4,7 @@ const { InteractionWrapper } = require("../classes");
 const selectDictionary = {};
 
 for (const file of [
+	"bountyeditselect.js",
 	"bountypostselect.js"
 ]) {
 	const select = require(`./${file}`);

--- a/source/selects/bountyeditselect.js
+++ b/source/selects/bountyeditselect.js
@@ -1,0 +1,65 @@
+const { ModalBuilder, TextInputBuilder, ActionRowBuilder, TextInputStyle } = require('discord.js');
+const { InteractionWrapper } = require('../classes');
+const { SAFE_DELIMITER } = require('../constants');
+const { database } = require('../../database');
+
+const customId = "bountyeditselect";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Recieve bounty reconfigurations from the user */
+	(interaction, args) => {
+		const slotNumber = interaction.values[0];
+		database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+			const eventStartComponent = new TextInputBuilder().setCustomId("startTimestamp")
+				.setLabel("Event Start (Unix Timestamp)")
+				.setRequired(false)
+				.setStyle(TextInputStyle.Short)
+				.setPlaceholder("Required if making an event with the bounty");
+			const eventEndComponent = new TextInputBuilder().setCustomId("endTimestamp")
+				.setLabel("Event End (Unix Timestamp)")
+				.setRequired(false)
+				.setStyle(TextInputStyle.Short)
+				.setPlaceholder("Required if making an event with the bounty");
+
+			if (bounty.scheduledEventId) {
+				const scheduledEvent = await interaction.guild.scheduledEvents.fetch(bounty.scheduledEventId);
+				eventStartComponent.setValue((scheduledEvent.scheduledStartTimestamp / 1000).toString());
+				eventEndComponent.setValue((scheduledEvent.scheduledEndTimestamp / 1000).toString());
+			}
+			interaction.showModal(
+				new ModalBuilder().setCustomId(`bountyeditmodal${SAFE_DELIMITER}${slotNumber}`)
+					.setTitle(`Editing Bounty (${bounty.title})`)
+					.addComponents(
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("title")
+								.setLabel("Title")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Short)
+								.setPlaceholder("Discord markdown allowed...")
+								.setValue(bounty.title)
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("description")
+								.setLabel("Description")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Paragraph)
+								.setPlaceholder("Bounties with clear instructions are easier to complete...")
+								.setValue(bounty.description)
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("imageURL")
+								.setLabel("Image URL")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Short)
+								.setValue(bounty.attachmentURL ?? "")
+						),
+						new ActionRowBuilder().addComponents(
+							eventStartComponent
+						),
+						new ActionRowBuilder().addComponents(
+							eventEndComponent
+						)
+					)
+			);
+		})
+	}
+);


### PR DESCRIPTION
Summary
-------
- added `/bounty edit` flow
- made CommandWrapper's subcommands.optionsInput optional
- removed `isRankEligible` from query in `findOrCreate` for hunters
- fixed bountypostmodal not reporting non-integer error for only one timestamp
- fixed mangling of event ids due to storing them as numbers
- added support for `@silent` announcements

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested edit without event or image
- [x] tested edit that adds an event
- [x] tested edit that edits an event
- [x] tested edit that removes an event
- [x] tested edit that adds image
- [x] tested edit that removes image

Issue
-----
Closes #4