### PR TITLE
#8: Port `/remove` as `/bounty take-down`

### DIFF
--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -68,6 +68,10 @@ const subcommands = [
 				required: false
 			}
 		]
+	},
+	{
+		name: "take-down",
+		description: "Take down one of your bounties without awarding XP (forfeit posting XP)"
 	}
 ];
 module.exports = new CommandWrapper(customId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
@@ -321,6 +325,31 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 							})
 						});
 					})
+				})
+				break;
+			case subcommands[5].name: // take-down
+				database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.user.id, state: "open" } }).then(openBounties => {
+					const bountyOptions = openBounties.map(bounty => {
+						return {
+							emoji: getNumberEmoji(bounty.slotNumber),
+							label: bounty.title,
+							description: bounty.description,
+							value: bounty.slotNumber.toString()
+						};
+					});
+
+					interaction.reply({
+						content: "If you'd like to change the title, description, image, or time of your bounty, you can use `/bounty edit` instead.",
+						components: [
+							new ActionRowBuilder().addComponents(
+								new StringSelectMenuBuilder().setCustomId("bountytakedown")
+									.setPlaceholder("Select a bounty to take down...")
+									.setMaxValues(1)
+									.setOptions(bountyOptions)
+							)
+						],
+						ephemeral: true
+					});
 				})
 				break;
 		}

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -129,10 +129,6 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.DATE,
 			defaultValue: null
 		},
-		deletedAt: { //TODO #8 convert to paranoid
-			type: DataTypes.INTEGER,
-			defaultValue: null
-		},
 		editCount: {
 			type: DataTypes.INTEGER,
 			defaultValue: 0
@@ -140,6 +136,7 @@ exports.initModel = function (sequelize) {
 	}, {
 		sequelize,
 		modelName: 'Bounty',
-		freezeTableName: true
+		freezeTableName: true,
+		paranoid: true
 	});
 }

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -5,7 +5,8 @@ const selectDictionary = {};
 
 for (const file of [
 	"bountyeditselect.js",
-	"bountypostselect.js"
+	"bountypostselect.js",
+	"bountytakedown.js"
 ]) {
 	const select = require(`./${file}`);
 	selectDictionary[select.customId] = select;

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -13,9 +13,11 @@ module.exports = new InteractionWrapper(customId, 3000,
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
 		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
 		guildProfile.decrement("seasonXP");
-		const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
-		const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
-		postingThread.delete("Bounty taken down by poster");
+		if (guildProfile.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+			const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
+			postingThread.delete("Bounty taken down by poster");
+		}
 		bounty.destroy();
 
 		database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(hunter => {

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -1,0 +1,28 @@
+const { InteractionWrapper } = require('../classes');
+const { database } = require('../../database');
+const { getRankUpdates } = require('../helpers');
+
+const customId = "bountytakedown";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Take down the given bounty and completions */
+	async (interaction, args) => {
+		const slotNumber = interaction.values[0];
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		bounty.state = "deleted";
+		bounty.save();
+		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
+		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
+		guildProfile.decrement("seasonXP");
+		const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+		const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
+		postingThread.delete("Bounty taken down by poster");
+		bounty.destroy();
+
+		database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(hunter => {
+			hunter.decrement(["xp", "seasonXP"], { by: 1 });
+			getRankUpdates(interaction.guild);
+		})
+
+		interaction.reply({ content: "Your bounty has been taken down.", ephemeral: true });
+	}
+);


### PR DESCRIPTION
Summary
-------
- added `/remove` as `/bounty take-down`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty take-down` removes bounty posting, posting XP, Completions and Bounty entities

Issue
-----
Closes #8