### PR TITLE
#26: Added `/evergreen`

### DIFF
--- a/database.js
+++ b/database.js
@@ -47,13 +47,6 @@ exports.database.authenticate().then(() => {
 		foreignKey: "guildId"
 	});
 
-	Bounty.User = Bounty.belongsTo(User, {
-		foreignKey: "userId"
-	});
-	User.Bounty = User.hasMany(Bounty, {
-		foreignKey: "userId"
-	});
-
 	Bounty.Guild = Bounty.belongsTo(Guild, {
 		foreignKey: "guildId"
 	});

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -7,6 +7,7 @@ exports.commandFiles = [
 	"commands.js",
 	"create-bounty-board.js",
 	"event.js",
+	"evergreen.js",
 	"feedback.js",
 	"moderation.js",
 	"premium.js",

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -278,11 +278,9 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 
 					guildProfile.increment("seasonBounties");
 
-					if (!bounty.isEvergreen) {
-						bounty.state = "completed";
-						bounty.completedAt = new Date();
-						bounty.save();
-					}
+					bounty.state = "completed";
+					bounty.completedAt = new Date();
+					bounty.save();
 
 					const rawCompletions = [];
 					for (const userId of completerIdsWithoutReciept) {

--- a/source/commands/create-bounty-board.js
+++ b/source/commands/create-bounty-board.js
@@ -4,7 +4,7 @@ const { database } = require('../../database');
 const { generateScorelines } = require('../embedHelpers');
 const { generateBountyBoardThread } = require('../helpers');
 
-const customId = "create-bounty-board"; //TODO convert to supercommand, add "create scoreboard-reference"
+const customId = "create-bounty-board"; //TODO #56 convert to supercommand, add "create scoreboard-reference"
 const options = [];
 const subcommands = [];
 module.exports = new CommandWrapper(customId, "Create a new bounty board forum channel sibling to this channel", PermissionFlagsBits.ManageChannels, false, false, 30000, options, subcommands,

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -54,13 +54,14 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						new ModalBuilder().setCustomId(`evergreenpost${SAFE_DELIMITER}${slotNumber}`)
 							.setTitle("New Evergreen Bounty")
 							.addComponents(
-								new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
+								new ActionRowBuilder().addComponents(
 									new TextInputBuilder().setCustomId("title")
 										.setLabel("Title")
 										.setStyle(TextInputStyle.Short)
 										.setPlaceholder("Discord markdown allowed...")
+										.setMaxLength(256)
 								),
-								new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
+								new ActionRowBuilder().addComponents(
 									new TextInputBuilder().setCustomId("description")
 										.setLabel("Description")
 										.setStyle(TextInputStyle.Paragraph)

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -34,8 +34,11 @@ const subcommands = [
 			}
 		]
 	},
+	{
+		name: "take-down",
+		description: "Take down one of your bounties without awarding XP (forfeit posting XP)"
+	}
 ];
-//TODONOW remove
 //TODO swap
 //TODO showcase
 module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed after completion; ideal for server-wide objectives", PermissionFlagsBits.ManageChannels, true, false, 3000, options, subcommands,
@@ -193,6 +196,31 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 							})
 						});
 					})
+				})
+				break;
+			case subcommands[3].name: // take-down
+				database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" } }).then(openBounties => {
+					const bountyOptions = openBounties.map(bounty => {
+						return {
+							emoji: getNumberEmoji(bounty.slotNumber),
+							label: bounty.title,
+							description: bounty.description,
+							value: bounty.slotNumber.toString()
+						};
+					});
+
+					interaction.reply({
+						content: "If you'd like to change the title, description, or image of an evergreen bounty, you can use `/evergreen edit` instead.",
+						components: [
+							new ActionRowBuilder().addComponents(
+								new StringSelectMenuBuilder().setCustomId("evergreentakedown")
+									.setPlaceholder("Select a bounty to take down...")
+									.setMaxValues(1)
+									.setOptions(bountyOptions)
+							)
+						],
+						ephemeral: true
+					});
 				})
 				break;
 		}

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -5,40 +5,52 @@ const { SAFE_DELIMITER } = require('../constants');
 
 const customId = "evergreen";
 const options = [];
-const subcommands = []; //TODONOW make into supercommand, add edit, complete, and remove
+const subcommands = [
+	{
+		name: "post",
+		description: "Post an evergreen bounty, limit 10"
+	}
+];
+//TODONOW add edit
+//TODONOW complete
+//TODONOW remove
 module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed after completion; ideal for server-wide objectives", PermissionFlagsBits.ManageChannels, true, false, 3000, options, subcommands,
 	(interaction) => {
-		database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(existingBounties => {
-			if (existingBounties.length > 9) {
-				interaction.reply({ content: "Each server can only have 10 Evergreen Bounties.", ephemeral: true });
-				return;
-			}
+		switch (interaction.options.getSubcommand()) {
+			case subcommands[0].name: // post
+				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(existingBounties => {
+					if (existingBounties.length > 9) {
+						interaction.reply({ content: "Each server can only have 10 Evergreen Bounties.", ephemeral: true });
+						return;
+					}
 
-			const slotNumber = existingBounties.length + 1;
-			interaction.showModal(
-				new ModalBuilder().setCustomId(`evergreenpost${SAFE_DELIMITER}${slotNumber}`)
-					.setTitle("New Evergreen Bounty")
-					.addComponents(
-						new ActionRowBuilder().addComponents(
-							new TextInputBuilder().setCustomId("title")
-								.setLabel("Title")
-								.setStyle(TextInputStyle.Short)
-								.setPlaceholder("Discord markdown allowed...")
-						),
-						new ActionRowBuilder().addComponents(
-							new TextInputBuilder().setCustomId("description")
-								.setLabel("Description")
-								.setStyle(TextInputStyle.Paragraph)
-								.setPlaceholder("Bounties with clear instructions are easier to complete...")
-						),
-						new ActionRowBuilder().addComponents(
-							new TextInputBuilder().setCustomId("imageURL")
-								.setLabel("Image URL")
-								.setRequired(false)
-								.setStyle(TextInputStyle.Short)
-						)
-					)
-			);
-		});
+					const slotNumber = existingBounties.length + 1;
+					interaction.showModal(
+						new ModalBuilder().setCustomId(`evergreenpost${SAFE_DELIMITER}${slotNumber}`)
+							.setTitle("New Evergreen Bounty")
+							.addComponents(
+								new ActionRowBuilder().addComponents(
+									new TextInputBuilder().setCustomId("title")
+										.setLabel("Title")
+										.setStyle(TextInputStyle.Short)
+										.setPlaceholder("Discord markdown allowed...")
+								),
+								new ActionRowBuilder().addComponents(
+									new TextInputBuilder().setCustomId("description")
+										.setLabel("Description")
+										.setStyle(TextInputStyle.Paragraph)
+										.setPlaceholder("Bounties with clear instructions are easier to complete...")
+								),
+								new ActionRowBuilder().addComponents(
+									new TextInputBuilder().setCustomId("imageURL")
+										.setLabel("Image URL")
+										.setRequired(false)
+										.setStyle(TextInputStyle.Short)
+								)
+							)
+					);
+				});
+				break;
+		}
 	}
 );

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -2,7 +2,8 @@ const { PermissionFlagsBits, ActionRowBuilder, ModalBuilder, TextInputBuilder, T
 const { CommandWrapper } = require('../classes');
 const { database } = require('../../database');
 const { SAFE_DELIMITER } = require('../constants');
-const { getNumberEmoji } = require('../helpers');
+const { getNumberEmoji, extractUserIdsFromMentions, getRankUpdates } = require('../helpers');
+const { Bounty } = require('../models/bounties/Bounty');
 
 const customId = "evergreen";
 const options = [];
@@ -14,14 +15,32 @@ const subcommands = [
 	{
 		name: "edit",
 		description: "Change the name, description, or image of an evergreen bounty"
-	}
+	},
+	{
+		name: "complete",
+		description: "Awarding XP to a hunter for completing an evergreen bounty",
+		optionsInput: [
+			{
+				type: "Integer",
+				name: "bounty-slot",
+				description: "The slot number of the bounty to complete",
+				required: true
+			},
+			{
+				type: "String",
+				name: "hunters",
+				description: "The bounty hunter(s) to credit with completion",
+				required: true
+			}
+		]
+	},
 ];
-//TODONOW complete
 //TODONOW remove
 //TODO swap
 //TODO showcase
 module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed after completion; ideal for server-wide objectives", PermissionFlagsBits.ManageChannels, true, false, 3000, options, subcommands,
 	(interaction) => {
+		let slotNumber;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // post
 				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(existingBounties => {
@@ -35,13 +54,13 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						new ModalBuilder().setCustomId(`evergreenpost${SAFE_DELIMITER}${slotNumber}`)
 							.setTitle("New Evergreen Bounty")
 							.addComponents(
-								new ActionRowBuilder().addComponents(
+								new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
 									new TextInputBuilder().setCustomId("title")
 										.setLabel("Title")
 										.setStyle(TextInputStyle.Short)
 										.setPlaceholder("Discord markdown allowed...")
 								),
-								new ActionRowBuilder().addComponents(
+								new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
 									new TextInputBuilder().setCustomId("description")
 										.setLabel("Description")
 										.setStyle(TextInputStyle.Paragraph)
@@ -85,6 +104,94 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						],
 						ephemeral: true
 					});
+				})
+				break;
+			case subcommands[2].name: //complete
+				slotNumber = interaction.options.getInteger("bounty-slot");
+				database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+					if (!bounty) {
+						interaction.reply({ content: "There isn't an evergreen bounty in the `bounty-slot` provided.", ephemeral: true });
+						return;
+					}
+
+					const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+
+					const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
+
+					if (mentionedIds.length < 1) {
+						interaction.reply({ content: "Could not find any bounty hunter ids in `hunters`.", ephemeral: true })
+						return;
+					}
+
+					const dedupedCompleterIds = [];
+					for (const id of mentionedIds) {
+						if (!dedupedCompleterIds.includes(id)) {
+							dedupedCompleterIds.push(id);
+						}
+					}
+
+					const validatedCompleterIds = [];
+					const completerMembers = dedupedCompleterIds.length > 0 ? (await interaction.guild.members.fetch({ user: dedupedCompleterIds })).values() : [];
+					const levelTexts = [];
+					for (const member of completerMembers) {
+						if (!member.user.bot) {
+							const memberId = member.id;
+							const [user] = await database.models.User.findOrCreate({ where: { id: memberId } });
+							const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, guildId: interaction.guildId }, defaults: { isRankEligible: member.manageable } });
+							if (!hunter.isBanned) {
+								validatedCompleterIds.push(memberId);
+							}
+						}
+					}
+
+					if (validatedCompleterIds.length < 1) {
+						interaction.reply({ content: "There aren't any eligible bounty hunters to credit with completing this evergreen bounty.", ephemeral: true })
+						return;
+					}
+
+					guildProfile.increment("seasonBounties");
+
+					const rawCompletions = [];
+					for (const userId of dedupedCompleterIds) {
+						rawCompletions.push({
+							bountyId: bounty.id,
+							userId,
+							guildId: interaction.guildId
+						});
+					}
+					await database.models.Completion.bulkCreate(rawCompletions);
+
+					const bountyValue = Bounty.slotWorth(guildProfile.level, slotNumber) * guildProfile.eventMultiplier;
+					database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
+
+					for (const userId of validatedCompleterIds) {
+						const hunter = await database.models.Hunter.findOne({ where: { guildId: interaction.guildId, userId } });
+						levelTexts.concat(await hunter.addXP(interaction.guild, bountyValue, true));
+						hunter.othersFinished++;
+						hunter.save();
+					}
+
+					bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()).then(embed => { //TODO #51 `/bounty complete` crashes on uncaught error if used without bounty board forum channel
+						return interaction.reply({ embeds: [embed], fetchReply: true });
+					}).then(replyMessage => {
+						getRankUpdates(interaction.guild).then(rankUpdates => {
+							replyMessage.startThread({ name: "Rewards" }).then(thread => {
+								const multiplierString = guildProfile.eventMultiplierString();
+								let text = "";
+								if (rankUpdates.length > 0) {
+									text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}\n`;
+								}
+								text += `__**XP Gained**__\n${validatedCompleterIds.map(id => `<@${id}> + ${bountyValue} XP${multiplierString}`).join("\n")}\n`;
+								if (levelTexts.length > 0) {
+									text += `\n__**Rewards**__\n${levelTexts.filter(text => Boolean(text)).join("\n")}`;
+								}
+								if (text.length > 2000) {
+									text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+								}
+								thread.send(text);
+							})
+						});
+					})
 				})
 				break;
 		}

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -1,0 +1,44 @@
+const { PermissionFlagsBits, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { SAFE_DELIMITER } = require('../constants');
+
+const customId = "evergreen";
+const options = [];
+const subcommands = []; //TODONOW make into supercommand, add edit, complete, and remove
+module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed after completion; ideal for server-wide objectives", PermissionFlagsBits.ManageChannels, true, false, 3000, options, subcommands,
+	(interaction) => {
+		database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(existingBounties => {
+			if (existingBounties.length > 9) {
+				interaction.reply({ content: "Each server can only have 10 Evergreen Bounties.", ephemeral: true });
+				return;
+			}
+
+			const slotNumber = existingBounties.length + 1;
+			interaction.showModal(
+				new ModalBuilder().setCustomId(`evergreenpost${SAFE_DELIMITER}${slotNumber}`)
+					.setTitle("New Evergreen Bounty")
+					.addComponents(
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("title")
+								.setLabel("Title")
+								.setStyle(TextInputStyle.Short)
+								.setPlaceholder("Discord markdown allowed...")
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("description")
+								.setLabel("Description")
+								.setStyle(TextInputStyle.Paragraph)
+								.setPlaceholder("Bounties with clear instructions are easier to complete...")
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("imageURL")
+								.setLabel("Image URL")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Short)
+						)
+					)
+			);
+		});
+	}
+);

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -92,7 +92,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 								You have ${bountySlots} bounty slot${bountySlots == 1 ? '' : 's'}!`
 							)
 							.addFields(
-								//TODO previous season placements
+								//TODO #55 previous season placements
 								{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
 								{ name: `Level ${hunter.level + 1} Reward`, value: hunter.levelUpReward(hunter.level + 1, maxSimBounties, true), inline: true },
 								{ name: `Level ${hunter.level + 2} Reward`, value: hunter.levelUpReward(hunter.level + 2, maxSimBounties, true), inline: true },

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -181,3 +181,15 @@ exports.getRankUpdates = async function (guild, force = false) {
 		return outMessages;
 	});
 }
+
+exports.generateBountyBoardThread = function (threadManager, embeds, hunterGuild) {
+	return threadManager.create({
+		name: "Evergreen Bounties",
+		message: { embeds }
+	}).then(thread => {
+		hunterGuild.evergreenThreadId = thread.id;
+		hunterGuild.save();
+		thread.pin();
+		return thread;
+	})
+}

--- a/source/modals/_modalDictionary.js
+++ b/source/modals/_modalDictionary.js
@@ -7,6 +7,7 @@ for (const file of [
 	"bountyeditmodal.js",
 	"bountypostmodal.js",
 	"evergreenpost.js",
+	"evergreeneditmodal.js",
 	"feedback-bugreport.js",
 	"feedback-featurerequest.js"
 ]) {

--- a/source/modals/_modalDictionary.js
+++ b/source/modals/_modalDictionary.js
@@ -6,6 +6,7 @@ const modalDictionary = {};
 for (const file of [
 	"bountyeditmodal.js",
 	"bountypostmodal.js",
+	"evergreenpost.js",
 	"feedback-bugreport.js",
 	"feedback-featurerequest.js"
 ]) {

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -102,7 +102,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		// update bounty board
 		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
 		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster, hunterGuild);
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, hunterGuild.eventMultiplierString());
 		//TODO #42 figure out how to trip auto-mod or re-add taboos
 		bounty.updatePosting(interaction.guild, hunterGuild);
 

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -7,7 +7,7 @@ const { getRankUpdates } = require('../helpers');
 const customId = "bountypostmodal";
 module.exports = new InteractionWrapper(customId, 3000,
 	/** Serialize data into a bounty, then announce with showcase embed */
-	async (interaction, [slotNumber, isEvergreen]) => {
+	async (interaction, [slotNumber]) => {
 		const title = interaction.fields.getTextInputValue("title");
 		const description = interaction.fields.getTextInputValue("description");
 		const imageURL = interaction.fields.getTextInputValue("imageURL");
@@ -19,7 +19,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			userId: interaction.user.id,
 			guildId: interaction.guildId,
 			slotNumber: parseInt(slotNumber),
-			isEvergreen: isEvergreen === "true",
+			isEvergreen: false,
 			title,
 			description
 		};
@@ -95,7 +95,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 
 		// post in bounty board forum
 		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster, hunterGuild);
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, hunterGuild.eventMultiplierString());
 		interaction.reply(hunterGuild.sendAnnouncement({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] })).then(() => {
 			if (hunterGuild.bountyBoardId) {
 				//TODO #42 figure out how to trip auto-mod or re-add taboos

--- a/source/modals/evergreeneditmodal.js
+++ b/source/modals/evergreeneditmodal.js
@@ -1,0 +1,53 @@
+const { database } = require('../../database');
+const { InteractionWrapper } = require('../classes');
+
+const customId = "evergreeneditmodal";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Serialize data into a bounty, then announce with showcase embed */
+	async (interaction, [slotNumber]) => {
+		const title = interaction.fields.getTextInputValue("title");
+		const description = interaction.fields.getTextInputValue("description");
+		const imageURL = interaction.fields.getTextInputValue("imageURL");
+
+		if (imageURL) {
+			try {
+				new URL(imageURL);
+			} catch (error) {
+				interaction.reply({ content: `The following errors were encountered while editing your bounty **${title}**:\n• ${error.message}`, ephemeral: true });
+			}
+		}
+
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		if (title) {
+			bounty.title = title;
+		}
+		if (description) {
+			bounty.description = description;
+		}
+		if (imageURL) {
+			bounty.attachmentURL = imageURL;
+		} else if (bounty.attachmentURL) {
+			bounty.attachmentURL = null;
+		}
+
+		bounty.editCount++;
+		bounty.save();
+
+		// update bounty board
+		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString());
+		//TODO #42 figure out how to trip auto-mod or re-add taboos
+		const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+		const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString())));
+		if (hunterGuild.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(hunterGuild.bountyBoardId);
+			bountyBoard.threads.fetch(hunterGuild.evergreenThreadId).then(async thread => {
+				const message = await thread.fetchStarterMessage();
+				message.edit({ embeds });
+			});
+		}
+
+		interaction.update({ content: "Bounty edited!", components: [] });
+		interaction.channel.send(hunterGuild.sendAnnouncement({ content: `${interaction.member} has edited an evergreen bounty:`, embeds: [bountyEmbed] }));
+	}
+);

--- a/source/modals/evergreenpost.js
+++ b/source/modals/evergreenpost.js
@@ -1,5 +1,6 @@
 const { database } = require('../../database');
 const { InteractionWrapper } = require('../classes');
+const { generateBountyBoardThread } = require('../helpers');
 
 const customId = "evergreenpost";
 module.exports = new InteractionWrapper(customId, 3000,
@@ -47,15 +48,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 							return thread;
 						});
 					} else {
-						return bountyBoard.threads.create({ //TODONOW make into function
-							name: "Evergreen Bounties",
-							message: { embeds }
-						}).then(thread => {
-							hunterGuild.evergreenThreadId = thread.id;
-							hunterGuild.save();
-							thread.pin();
-							return thread;
-						});
+						return generateBountyBoardThread(bountyBoard.threads, embeds, hunterGuild);
 					}
 				}).then(thread => {
 					bounty.postingId = thread.id;

--- a/source/modals/evergreenpost.js
+++ b/source/modals/evergreenpost.js
@@ -1,0 +1,73 @@
+const { database } = require('../../database');
+const { InteractionWrapper } = require('../classes');
+
+const customId = "evergreenpost";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Serialize data into a bounty, then announce with showcase embed */
+	async (interaction, [slotNumber]) => {
+		const title = interaction.fields.getTextInputValue("title");
+		const description = interaction.fields.getTextInputValue("description");
+		const imageURL = interaction.fields.getTextInputValue("imageURL");
+
+		const rawBounty = {
+			userId: interaction.client.user.id,
+			guildId: interaction.guildId,
+			slotNumber: parseInt(slotNumber),
+			isEvergreen: true,
+			title,
+			description
+		};
+
+		if (imageURL) {
+			try {
+				new URL(imageURL);
+				rawBounty.attachmentURL = imageURL;
+			} catch (error) {
+				interaction.message.edit({ components: [] });
+				interaction.reply({ content: `The following errors were encountered while posting your bounty **${title}**:\n• ${error.message}`, ephemeral: true });
+				return;
+			}
+		}
+
+		const [hunterGuild] = await database.models.Guild.findOrCreate({ where: { id: interaction.guildId } });
+		const bounty = await database.models.Bounty.create(rawBounty);
+
+		// post in bounty board forum
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString());
+		interaction.reply(hunterGuild.sendAnnouncement({ content: `A new evergreen bounty has been posted:`, embeds: [bountyEmbed] })).then(() => {
+			if (hunterGuild.bountyBoardId) {
+				//TODO #42 figure out how to trip auto-mod or re-add taboos
+				interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(async bountyBoard => {
+					const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+					const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString())));
+					if (hunterGuild.evergreenThreadId) {
+						return bountyBoard.threads.fetch(hunterGuild.evergreenThreadId).then(async thread => {
+							const message = await thread.fetchStarterMessage();
+							message.edit({ embeds });
+							return thread;
+						});
+					} else {
+						return bountyBoard.threads.create({ //TODONOW make into function
+							name: "Evergreen Bounties",
+							message: { embeds }
+						}).then(thread => {
+							hunterGuild.evergreenThreadId = thread.id;
+							hunterGuild.save();
+							thread.pin();
+							return thread;
+						});
+					}
+				}).then(thread => {
+					bounty.postingId = thread.id;
+					bounty.save()
+				}).catch(error => {
+					if (error.code == 10003) {
+						interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-bounty-board`?", ephemeral: true });
+					} else {
+						throw error;
+					}
+				})
+			}
+		});
+	}
+);

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -32,10 +32,6 @@ exports.Bounty = class extends Model {
 				const event = await guild.scheduledEvents.fetch(this.scheduledEventId);
 				embed.addFields({ name: "Time", value: `<t:${event.scheduledStartTimestamp / 1000}> - <t:${event.scheduledEndTimestamp / 1000}>` });
 			}
-			const completions = await database.models.Completion.findAll({ where: { bountyId: this.id } });
-			if (completions.length > 0) {
-				embed.addFields({ name: "Completers", value: `<@${completions.map(reciept => reciept.userId).join(">, <@")}>` });
-			}
 			embed.addFields(
 				{ name: "Reward", value: `${exports.Bounty.slotWorth(posterLevel, this.slotNumber)} XP${eventMultiplierString}`, inline: true }
 			)
@@ -43,6 +39,10 @@ exports.Bounty = class extends Model {
 			if (this.isEvergreen) {
 				embed.setFooter({ text: `Evergreen Bounty #${this.slotNumber}`, iconURL: author.user.displayAvatarURL() });
 			} else {
+				const completions = await database.models.Completion.findAll({ where: { bountyId: this.id } });
+				if (completions.length > 0) {
+					embed.addFields({ name: "Completers", value: `<@${completions.map(reciept => reciept.userId).join(">, <@")}>` });
+				}
 				embed.setFooter({ text: `${author.displayName}'s #${this.slotNumber} Bounty`, iconURL: author.user.displayAvatarURL() });
 			}
 

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -5,16 +5,18 @@ exports.Completion = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.Completion.init({
-		bountyId: {
+		id: {
 			primaryKey: true,
+			type: DataTypes.BIGINT,
+			autoIncrement: true
+		},
+		bountyId: {
 			type: DataTypes.BIGINT
 		},
 		userId: {
-			primaryKey: true,
 			type: DataTypes.STRING
 		},
 		guildId: {
-			primaryKey: true,
 			type: DataTypes.STRING
 		},
 		xpAwarded: {

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -110,16 +110,16 @@ exports.initModel = function (sequelize) {
 			defaultValue: 3600000
 		},
 		bountyBoardId: {
+			type: DataTypes.STRING
+		},
+		evergreenThreadId: {
 			type: DataTypes.STRING,
-			defaultValue: ''
 		},
 		scoreId: {
-			type: DataTypes.STRING,
-			defaultValue: ''
+			type: DataTypes.STRING
 		},
 		raffleDate: {
-			type: DataTypes.STRING,
-			defaultValue: ''
+			type: DataTypes.DATE
 		},
 		eventMultiplier: {
 			type: DataTypes.INTEGER,
@@ -142,8 +142,7 @@ exports.initModel = function (sequelize) {
 			defaultValue: 0
 		},
 		resetSchedulerId: {
-			type: DataTypes.STRING,
-			defaultValue: ""
+			type: DataTypes.STRING
 		},
 		lastSeasonXP: {
 			type: DataTypes.BIGINT,

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -23,10 +23,6 @@ exports.Hunter = class extends Model {
 		return Math.min(slots, maxSimBounties);
 	}
 
-	slotWorth(slotNum) {
-		return Math.floor(6 + 0.5 * this.level - 3 * slotNum + 0.5 * slotNum % 2);
-	}
-
 	/**
 	 * @param {Guild} guild
 	 * @param {number} points

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -8,6 +8,7 @@ for (const file of [
 	"bountypostselect.js",
 	"bountytakedown.js",
 	"evergreeneditselect.js",
+	"evergreentakedown.js",
 	"modtakedown.js"
 ]) {
 	const select = require(`./${file}`);

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -7,6 +7,7 @@ for (const file of [
 	"bountyeditselect.js",
 	"bountypostselect.js",
 	"bountytakedown.js",
+	"evergreeneditselect.js",
 	"modtakedown.js"
 ]) {
 	const select = require(`./${file}`);

--- a/source/selects/bountypostselect.js
+++ b/source/selects/bountypostselect.js
@@ -8,7 +8,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 	(interaction, args) => {
 		const slotNumber = interaction.values[0];
 		interaction.showModal(
-			new ModalBuilder().setCustomId(`bountypostmodal${SAFE_DELIMITER}${slotNumber}${SAFE_DELIMITER}false`)
+			new ModalBuilder().setCustomId(`bountypostmodal${SAFE_DELIMITER}${slotNumber}`)
 				.setTitle(`New Bounty (Slot ${slotNumber})`)
 				.addComponents(
 					new ActionRowBuilder().addComponents(

--- a/source/selects/bountypostselect.js
+++ b/source/selects/bountypostselect.js
@@ -11,13 +11,14 @@ module.exports = new InteractionWrapper(customId, 3000,
 			new ModalBuilder().setCustomId(`bountypostmodal${SAFE_DELIMITER}${slotNumber}`)
 				.setTitle(`New Bounty (Slot ${slotNumber})`)
 				.addComponents(
-					new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
+					new ActionRowBuilder().addComponents(
 						new TextInputBuilder().setCustomId("title")
 							.setLabel("Title")
 							.setStyle(TextInputStyle.Short)
 							.setPlaceholder("Discord markdown allowed...")
+							.setMaxLength(256)
 					),
-					new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
+					new ActionRowBuilder().addComponents(
 						new TextInputBuilder().setCustomId("description")
 							.setLabel("Description")
 							.setStyle(TextInputStyle.Paragraph)

--- a/source/selects/bountypostselect.js
+++ b/source/selects/bountypostselect.js
@@ -11,13 +11,13 @@ module.exports = new InteractionWrapper(customId, 3000,
 			new ModalBuilder().setCustomId(`bountypostmodal${SAFE_DELIMITER}${slotNumber}`)
 				.setTitle(`New Bounty (Slot ${slotNumber})`)
 				.addComponents(
-					new ActionRowBuilder().addComponents(
+					new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
 						new TextInputBuilder().setCustomId("title")
 							.setLabel("Title")
 							.setStyle(TextInputStyle.Short)
 							.setPlaceholder("Discord markdown allowed...")
 					),
-					new ActionRowBuilder().addComponents(
+					new ActionRowBuilder().addComponents( //TODONOW match character limit to embed limit
 						new TextInputBuilder().setCustomId("description")
 							.setLabel("Description")
 							.setStyle(TextInputStyle.Paragraph)

--- a/source/selects/evergreeneditselect.js
+++ b/source/selects/evergreeneditselect.js
@@ -1,0 +1,43 @@
+const { ModalBuilder, TextInputBuilder, ActionRowBuilder, TextInputStyle } = require('discord.js');
+const { InteractionWrapper } = require('../classes');
+const { SAFE_DELIMITER } = require('../constants');
+const { database } = require('../../database');
+
+const customId = "evergreeneditselect";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Recieve bounty reconfigurations from the user */
+	(interaction, args) => {
+		const slotNumber = interaction.values[0];
+		database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+			interaction.showModal(
+				new ModalBuilder().setCustomId(`evergreeneditmodal${SAFE_DELIMITER}${slotNumber}`)
+					.setTitle(`Editing Bounty (${bounty.title})`)
+					.addComponents(
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("title")
+								.setLabel("Title")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Short)
+								.setPlaceholder("Discord markdown allowed...")
+								.setValue(bounty.title)
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("description")
+								.setLabel("Description")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Paragraph)
+								.setPlaceholder("Bounties with clear instructions are easier to complete...")
+								.setValue(bounty.description)
+						),
+						new ActionRowBuilder().addComponents(
+							new TextInputBuilder().setCustomId("imageURL")
+								.setLabel("Image URL")
+								.setRequired(false)
+								.setStyle(TextInputStyle.Short)
+								.setValue(bounty.attachmentURL ?? "")
+						)
+					)
+			);
+		})
+	}
+);

--- a/source/selects/evergreentakedown.js
+++ b/source/selects/evergreentakedown.js
@@ -1,0 +1,35 @@
+const { InteractionWrapper } = require('../classes');
+const { database } = require('../../database');
+
+const customId = "evergreentakedown";
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Take down the given bounty and completions */
+	async (interaction, args) => {
+		const slotNumber = interaction.values[0];
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		bounty.state = "deleted";
+		bounty.save();
+		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
+		const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+		if (evergreenBounties.length > 1) {
+			const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString())));
+			if (guildProfile.bountyBoardId) {
+				const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+				bountyBoard.threads.fetch(guildProfile.evergreenThreadId).then(async thread => {
+					const message = await thread.fetchStarterMessage();
+					message.edit({ embeds });
+				});
+			}
+		} else if (guildProfile.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+			bountyBoard.threads.fetch(guildProfile.evergreenThreadId).then(thread => {
+				thread.delete(`Evergreen bounty taken down by ${interaction.member}`);
+				guildProfile.evergreenThreadId = null;
+				guildProfile.save();
+			});
+		}
+		bounty.destroy();
+
+		interaction.reply({ content: "The evergreen bounty has been taken down.", ephemeral: true });
+	}
+);


### PR DESCRIPTION
Summary
-------
- added /evergreen supercommand (included `post`, `edit`, `complete`, and `take-down`)
- the bounty board now pins the evergreen bounties instead of the scoreboard
- added length validations to bounty title

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested each command critical path, considered edge case of no bounty board for each

Issue
-----
Closes #26