### PR TITLE
#12: Port `/data-policy`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -6,6 +6,7 @@ exports.commandFiles = [
 	"bounty.js",
 	"commands.js",
 	"create.js",
+	"data-policy.js",
 	"event.js",
 	"evergreen.js",
 	"feedback.js",

--- a/source/commands/data-policy.js
+++ b/source/commands/data-policy.js
@@ -1,0 +1,12 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+
+const customId = "data-policy";
+const options = [];
+const subcommands = [];
+module.exports = new CommandWrapper(customId, "Get a link to BountyBot's data policy page", PermissionFlagsBits.ViewChannel, false, true, 3000, options, subcommands,
+	/** Link the user to the repo Data Policy wiki page (automatically updated) */
+	(interaction) => {
+		interaction.reply({ content: "Here's a link to the BountyBot Data Policy page (automatically updated): https://github.com/Imaginary-Horizons-Productions/BountyBot/wiki/Data-Policy", ephemeral: true });
+	}
+);

--- a/wiki/Data-Policy.md
+++ b/wiki/Data-Policy.md
@@ -1,0 +1,3 @@
+If you leave a server with BountyBot, your data will be deleted. If you kick BountyBot from a server, all user data will be deleted. BountyBot will show your account name details and account creation times to bot managers to verify spam bots.
+## Anonymous User Data
+BountyBot collects anonymous usage data including number of season participants, bounty completions, and toasts raised. Imaginary Horizons Productions uses this data to inform new features and improve existing features.


### PR DESCRIPTION
Summary
-------
- Ported `/data-policy` command

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/data-policy` provides link, and link works

Issue
-----
Closes #12