### PR TITLE
#30: Port `/raffle`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -12,6 +12,7 @@ exports.commandFiles = [
 	"feedback.js",
 	"moderation.js",
 	"premium.js",
+	"raffle.js",
 	"rank.js",
 	"scoreboard.js",
 	"stats.js",

--- a/source/commands/raffle.js
+++ b/source/commands/raffle.js
@@ -1,0 +1,101 @@
+const { PermissionFlagsBits, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { Op } = require('sequelize');
+
+const customId = "raffle";
+const options = [];
+const subcommands = [
+	{
+		name: "by-ranks",
+		description: "Select a user at or above a particular rank"
+	},
+	{
+		name: "by-level",
+		description: "Select a user at or above a particular level",
+		optionsInput: [
+			{
+				type: "Integer",
+				name: "level",
+				description: "The level a hunter needs to be eligible for this raffle",
+				required: true
+			}
+		]
+	},
+	{
+		name: "announce-upcoming",
+		description: "Announce an upcoming raffle",
+		optionsInput: [
+			{
+				type: "String",
+				name: "announcement",
+				description: "A timestamp and/or eligibilty requirements can encourage interaction",
+				required: true
+			}
+		]
+	}
+];
+module.exports = new CommandWrapper(customId, "description", PermissionFlagsBits.ManageGuild, false, true, 3000, options, subcommands,
+	/** Randomly select a hunter from the pool determined by the subcommand configurations */
+	(interaction) => {
+		switch (interaction.options.getSubcommand()) {
+			case subcommands[0].name: // by-rank
+				database.models.GuildRank.findAll({ where: { guildId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] }).then(async ranks => {
+					if (ranks.length < 1) {
+						interaction.reply({ content: "This server doesn't have any ranks configured.", ephemeral: true });
+						return;
+					}
+					const guildRanks = await interaction.guild.roles.fetch();
+					interaction.reply({
+						content: "Select a rank to be the eligibility threshold for this raffle:",
+						components: [
+							new ActionRowBuilder().addComponents(
+								new StringSelectMenuBuilder().setCustomId("rafflerank")
+									.setPlaceholder("Select a rank...")
+									.addOptions(ranks.map((rank, index) => {
+										const option = {
+											label: rank.roleId ? guildRanks.get(rank.roleId).name : `Rank ${index + 1}`,
+											description: `Variance Threshold: ${rank.varianceThreshold}`,
+											value: index.toString()
+										};
+										if (rank.rankmoji) {
+											option.emoji = rank.rankmoji;
+										}
+										return option;
+									}))
+							)
+						],
+						ephemeral: true
+					}).catch(error => {
+						if (Object.values(error.rawError.errors.data.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
+							interaction.reply({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji.", ephemeral: true });
+						} else {
+							console.error(error);
+						}
+					});
+				});
+				break;
+			case subcommands[1].name: // by-level
+				const levelThreshold = interaction.options.getInteger("level");
+				database.models.Hunter.findAll({ where: { guildId: interaction.guildId, level: { [Op.gte]: levelThreshold } } }).then(eligibleHunters => {
+					if (eligibleHunters.length < 1) {
+						interaction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above level ${levelThreshold}).`, ephemeral: true });
+						return;
+					}
+					const winner = eligibleHunters[Math.floor(Math.random() * eligibleHunters.length)];
+					interaction.reply(`The winner of this raffle is: <@${winner.userId}>`);
+					database.models.Guild.findByPk(interaction.guildId).then(guildProfile => {
+						guildProfile.update("nextRaffleString", null);
+					});
+				});
+				break;
+			case subcommands[2].name: // announce-upcoming
+				database.models.Guild.findByPk(interaction.guildId).then(guildProfile => {
+					const announcement = interaction.options.getString("announcement")
+					guildProfile.update("nextRaffleString", announcement);
+					interaction.reply(guildProfile.sendAnnouncement({ content: announcement }));
+				})
+				break;
+		}
+	}
+);

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -124,8 +124,8 @@ exports.initModel = function (sequelize) {
 		scoreboardIsSeasonal: {
 			type: DataTypes.BOOLEAN
 		},
-		raffleDate: {
-			type: DataTypes.DATE
+		nextRaffleString: {
+			type: DataTypes.STRING
 		},
 		eventMultiplier: {
 			type: DataTypes.INTEGER,

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -13,7 +13,8 @@ for (const file of [
 	"evergreenswapbounty.js",
 	"evergreenswapslot.js",
 	"evergreentakedown.js",
-	"modtakedown.js"
+	"modtakedown.js",
+	"rafflerank.js"
 ]) {
 	const select = require(`./${file}`);
 	selectDictionary[select.customId] = select;

--- a/source/selects/rafflerank.js
+++ b/source/selects/rafflerank.js
@@ -1,0 +1,26 @@
+const { Op } = require('sequelize');
+const { database } = require('../../database');
+const { InteractionWrapper } = require('../classes');
+
+const customId = "rafflerank";
+
+module.exports = new InteractionWrapper(customId, 3000,
+	/** Given selected rank for raffle, randomly select eligible hunter */
+	(interaction, args) => {
+		const rankIndex = Number(interaction.values[0]);
+		database.models.Hunter.findAll({ where: { guildId: interaction.guildId, isRankEligible: true, isRankDisqualified: false, rank: { [Op.gte]: rankIndex } } }).then(eligibleHunters => {
+			if (eligibleHunters.length < 1) {
+				database.models.GuildRank.findAll({ where: { guildId: interaction.guildId }, order: [["varianceThreshold", "ASC"]] }).then(ranks => {
+					const rank = ranks[rankIndex];
+					interaction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above the rank ${rank.roleId ? `<@&${rank.rankId}>` : `Rank ${rankIndex + 1}`}).`, ephemeral: true });
+				});
+				return;
+			}
+			const winner = eligibleHunters[Math.floor(Math.random() * eligibleHunters.length)];
+			interaction.reply(`The winner of this raffle is: <@${winner.userId}>`);
+			database.models.Guild.findByPk(interaction.guildId).then(guildProfile => {
+				guildProfile.update("nextRaffleString", null);
+			});
+		})
+	}
+);


### PR DESCRIPTION
Summary
-------
- add `/raffle by-level`
- add `/raffle by-rank`
- add `/raffle announce-upcoming`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/raffle by-level` selects a random eligible user
- [x] `/raffle by-rank` sends an error reply to the user if bad select payload due to non-emoji on ranks
- [x] `/raffle by-rank` sends an error reply to the user if no eligible winners
- [x] `/raffle announce-upcoming` sets the upcoming raffle string

Issue
-----
Closes #30