### PR TITLE
#9: Port `/event-info` as `/server-bonuses`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -15,6 +15,7 @@ exports.commandFiles = [
 	"raffle.js",
 	"rank.js",
 	"scoreboard.js",
+	"server-bonuses.js",
 	"stats.js",
 	"toast.js",
 	"version.js"

--- a/source/commands/server-bonuses.js
+++ b/source/commands/server-bonuses.js
@@ -1,0 +1,18 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { buildServerBonusesEmbed } = require('../embedHelpers');
+
+const customId = "server-bonuses";
+const options = [];
+const subcommands = [];
+module.exports = new CommandWrapper(customId, "Get info about the currently running server bonuses", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
+	/** Send the user info about currently running server bonuses */
+	(interaction) => {
+		database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(([guildProfile]) => {
+			return buildServerBonusesEmbed(interaction.channel, interaction.guild, guildProfile);
+		}).then(embed => {
+			interaction.reply({ embeds: [embed], ephemeral: true });
+		});
+	}
+);

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, Guild, Colors } = require("discord.js");
+const { EmbedBuilder, Guild, Colors, TextChannel } = require("discord.js");
 const fs = require("fs");
 const { database } = require("../database");
 const { Op } = require("sequelize");
@@ -52,6 +52,31 @@ exports.buildGuildStatsEmbed = async function (guild) {
 			.setFooter(exports.randomFooterTip())
 			.setTimestamp()
 	});
+}
+
+/** Build an embed mentioning if an event is running, the next raffle date and the raffle rewards
+ * @param {TextChannel} channel
+ * @param {Guild} guild
+ * @param {HunterGuild} guildProfile
+ */
+exports.buildServerBonusesEmbed = async function (channel, guild, guildProfile) {
+	const { displayColor, displayName } = await guild.members.fetch(guild.client.user.id);
+	const embed = new EmbedBuilder().setColor(displayColor)
+		.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
+		.setTitle(`${displayName} Server Bonuses`)
+		.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734097732897079336/calendar.png')
+		.setDescription(`There is ${guildProfile.eventMultiplier != 1 ? '' : 'not '}an XP multiplier event currently active${guildProfile.eventMultiplier == 1 ? '' : ` for ${guildProfile.eventMultiplierString()}`}.`)
+		.setFooter(exports.randomFooterTip())
+		.setTimestamp();
+	if (guildProfile.nextRaffleString) {
+		embed.addFields([{ name: "Next Raffle", value: Utils.cleanContent(`The next raffle will be on ${guildProfile.nextRaffleString}!`, channel) }]);
+	}
+	//TODO custom raffle rewards
+	// if (this.rewards.length > 0) {
+	// 	embed.addField("Raffle Rewards", Utils.cleanContent(this.rewardStringBuilder(), channel));
+	// }
+
+	return embed;
 }
 
 /** Listing XP acquired allows bounty hunters to compare ranking within a server

--- a/source/models/guilds/Guild.js
+++ b/source/models/guilds/Guild.js
@@ -27,29 +27,6 @@ exports.Guild = class extends Model {
 		return messageOptions;
 	}
 
-	// eventInfoBuilder(channel, guild, useManagerTips = false) {
-	// 	// Build an embed mentioning if an event is running, the next raffle date and the raffle rewards
-	// 	const { displayColor, displayName } = guild.me;
-	// 	const { prefix, text, url } = tipBuilder(this.maxSimBounties, guild.channels.resolve(this.pinChannelId), useManagerTips);
-	// 	let embed = new MessageEmbed().setColor(displayColor)
-	// 		.setAuthor({ name: prefix + text, iconURL: guild.client.user.displayAvatarURL(), url })
-	// 		.setTitle(`${displayName} Event Info`)
-	// 		.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734097732897079336/calendar.png')
-	// 		.setDescription(`There is ${this.eventMultiplier != 1 ? '' : 'not '}an XP multiplier event currently active${this.eventMultiplier == 1 ? '' : ` for ${this.eventMultiplierString()}`}.`)
-	// 		.setFooter({ text: guild.name, iconURL: guild.iconURL() })
-	// 		.setTimestamp();
-	// 	if (this.raffleDates) {
-	// 		embed.addField(`Next Raffle`, Util.cleanContent(`The next raffle will be on ${this.raffleDates}!`, channel));
-	// 	} else {
-	// 		embed.addField(`Next Raffle`, `The next raffle has not been scheduled yet.`);
-	// 	}
-	// 	if (this.rewards.length > 0) {
-	// 		embed.addField(`Raffle Rewards`, Util.cleanContent(this.rewardStringBuilder(), channel));
-	// 	}
-
-	// 	return embed;
-	// }
-
 	// /** Build the list of rewards
 	// * @param {string} guildId
 	// * @param {number} characterLimit


### PR DESCRIPTION
Summary
-------
- add `/server-bonuses` (name change to disambiguate from Discord scheduled events)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/server-bonuses` returns message with current running bonuses

Issue
-----
Closes #9