### PR TITLE
#42: Add AutoMod support for toasts, bounties, and evergreen bounties

### DIFF
--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -1,7 +1,7 @@
 const { PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { SAFE_DELIMITER, DAY_IN_MS } = require('../constants');
-const { getNumberEmoji, getRankUpdates, extractUserIdsFromMentions } = require('../helpers');
+const { getNumberEmoji, getRankUpdates, extractUserIdsFromMentions, checkTextsInAutoMod } = require('../helpers');
 const { database } = require('../../database');
 const { Op } = require('sequelize');
 const { updateScoreboard } = require('../embedHelpers');
@@ -71,9 +71,15 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 			return;
 		}
 
-		// Build rest of embed
 		const toastText = interaction.options.getString(options[1].name);
-		embed.setColor("e5b271") //TODO #42
+		const isBlockedByAutoMod = await checkTextsInAutoMod(interaction.channel, interaction.member, [toastText], "toast");
+		if (isBlockedByAutoMod) {
+			interaction.reply({ content: "Your toast was blocked by AutoMod.", ephemeral: true });
+			return;
+		}
+
+		// Build rest of embed
+		embed.setColor("e5b271")
 			.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
 			.setTitle(toastText)
 			.setDescription(`A toast to <@${nonBotToasteeIds.join(">, <@")}>!`)

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,5 +1,5 @@
 const { database } = require("../database");
-const { Guild } = require("discord.js");
+const { Guild, AutoModerationActionType, GuildMember, TextChannel } = require("discord.js");
 const { GuildRank } = require("./models/guilds/GuildRank");
 
 const CONGRATULATORY_PHRASES = [
@@ -243,4 +243,56 @@ exports.generateBountyBoardThread = function (threadManager, embeds, hunterGuild
 		thread.pin();
 		return thread;
 	})
+}
+
+/** Simulate auto mod actions for texts input to BountyBot
+ * @param {TextChannel} channel
+ * @param {GuildMember} member
+ * @param {string[]} texts
+ * @param {string} context
+ * @returns whether or not any of the texts included something the auto mod blocks as a message
+ */
+exports.checkTextsInAutoMod = async function (channel, member, texts, context) {
+	const autoModRules = await channel.guild.autoModerationRules.fetch();
+	let shouldBlockMessage = false;
+	for (const rule of autoModRules.values()) {
+		if (rule.exemptChannels.has(channel.id)) {
+			continue;
+		}
+		if (rule.exemptRoles.hasAny(member.roles.cache.keys())) {
+			continue;
+		}
+
+		//TODO use rule.triggerMetaData.allowList
+		const hasRegexTrigger = texts.some(text => rule.triggerMetadata.regexPatterns.some(regex => new RegExp(regex).test(text)));
+		const hasKeywordFilter = texts.some(text => rule.triggerMetadata.keywordFilter.some(regex => new RegExp(regex).test(text)));
+		//TODO fetch Discord presets from enum
+		const exceedsMentionLimit = texts.some(text => {
+			text.match(/<@[\d&]+>/)?.length > rule.triggerMetadata.mentionTotalLimit
+		});
+		for (const action of rule.actions) {
+			if (hasRegexTrigger || hasKeywordFilter || exceedsMentionLimit) {
+				switch (action.type) {
+					case AutoModerationActionType.SendAlertMessage:
+						if (action.metadata.channelId) {
+							const alertChannel = await channel.guild.channels.fetch(action.metadata.channelId);
+							alertChannel.send(`${member} tripped AutoMod in a ${context} with text(s): ${texts.join(", ")}`);
+						}
+						break;
+					case AutoModerationActionType.Timeout:
+						member.timeout(action.metadata.durationSeconds * 1000, `AutoMod timeout in a ${context} with texts: ${texts.join(", ")}`).catch(error => {
+							if (error.code != 50013) { // 50013 is Missing Permissions
+								console.error(error);
+							}
+						});
+						break;
+					case AutoModerationActionType.BlockMessage:
+						member.send(action.metadata.customMessage || `Your ${context} could not be completed because it tripped AutoMod.`);
+						shouldBlockMessage = true;
+						break;
+				}
+			}
+		}
+	}
+	return shouldBlockMessage;
 }


### PR DESCRIPTION
Summary
-------
- Add AutoMod support for toasts, bounties, and evergreen bounties

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] toast that trips automod is blocked
- [x] toast that does not trip automod is not blocked

Issue
-----
Closes #42