### PR TITLE
#51: fix crash on bounty complete if no bounty board

### DIFF
--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -21,8 +21,11 @@ module.exports = new InteractionWrapper(customId, 3000,
 			return;
 		}
 
-		const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId }, defaults: { isRankEligible: interaction.member.manageable } });
+		const [seconder] = await database.models.Hunter.findOrCreate({
+			where: { userId: interaction.user.id, guildId: interaction.guildId },
+			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },
+			include: database.models.Hunter.User
+		});
 		seconder.toastSeconded++;
 
 		const recipientIds = (await originalToast.recipients).map(reciept => reciept.recipientId);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -47,7 +47,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		}
 
 		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
-		const staleToastees = lastFiveToasts.reduce(async (list, toast) => {
+		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {
 			return (await list).concat((await toast.rewardedRecipients).map(recipient => recipient.userId));
 		}, []);
 

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -49,7 +49,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
 		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {
 			return (await list).concat((await toast.rewardedRecipients).map(recipient => recipient.userId));
-		}, []);
+		}, new Promise((resolve) => resolve([])));
 
 		const wasCrit = false;
 		if (critSecondsAvailable > 0) {

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -199,8 +199,11 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 					for (const member of completerMembers) {
 						if (!member.user.bot) {
 							const memberId = member.id;
-							const [user] = await database.models.User.findOrCreate({ where: { id: memberId } });
-							const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, guildId: interaction.guildId }, defaults: { isRankEligible: member.manageable } });
+							const [hunter] = await database.models.Hunter.findOrCreate({
+								where: { userId: memberId, guildId: interaction.guildId },
+								defaults: { isRankEligible: member.manageable, User: { id: memberId } },
+								include: database.models.Hunter.User
+							});
 							if (!hunter.isBanned) {
 								validatedCompleterIds.push(memberId);
 							}

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -238,7 +238,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						hunter.save();
 					}
 
-					bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()).then(embed => { //TODO #51 `/bounty complete` crashes on uncaught error if used without bounty board forum channel
+					bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()).then(embed => {
 						return interaction.reply({ embeds: [embed], fetchReply: true });
 					}).then(replyMessage => {
 						getRankUpdates(interaction.guild).then(rankUpdates => {

--- a/source/commands/moderation.js
+++ b/source/commands/moderation.js
@@ -99,7 +99,7 @@ module.exports = new CommandWrapper(customId, "BountyBot moderation tools", Perm
 				break;
 			case subcommands[1].name: // disqualify
 				member = interaction.options.getMember("bounty-hunter");
-				database.models.Hunter.findOrCreate({ where: { userId: member.id, guildId: interaction.guildId }, defaults: { isRankEligible: member.manageable } }).then(([hunter]) => {
+				database.models.Hunter.findOrCreate({ where: { userId: member.id, guildId: interaction.guildId }, defaults: { isRankEligible: member.manageable, User: { id: member.id }, Guild: { id: interaction.guildId } }, include: [database.models.Hunter.User, database.models.Hunter.Guild] }).then(([hunter]) => {
 					hunter.isRankDisqualified = !hunter.isRankDisqualified;
 					if (hunter.isRankDisqualified) {
 						hunter.increment("seasonDQCount");

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -119,12 +119,16 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		//TODO combine fetch and seasonToasts increment with upsert?
 		const [guildProfile] = await database.models.Guild.findOrCreate({ where: { id: interaction.guildId } });
 		guildProfile.increment("seasonToasts");
-		const [user] = await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-		const [sender] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, guildId: interaction.guildId }, defaults: { isRankEligible: interaction.member.manageable } });
+		guildProfile.save();
+		const [sender] = await database.models.Hunter.findOrCreate({
+			where: { userId: interaction.user.id, guildId: interaction.guildId },
+			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },
+			include: database.models.Hunter.User
+		});
 		sender.toastsRaised++;
 		const toast = await database.models.Toast.create({ guildId: interaction.guildId, senderId: interaction.user.id, text: toastText, imageURL });
 		for (const id of nonBotToasteeIds) {
-			//TODO move to bulkCreate when create by association is working
+			//TODO move to bulkCreate after finding solution to create by association only if user doesn't already exist
 			const [user] = await database.models.User.findOrCreate({ where: { id } });
 			const rawToast = { toastId: toast.id, recipientId: id, isRewarded: !hunterIdsToastedInLastDay.has(id) && rewardsAvailable > 0, wasCrit: false };
 			if (rawToast.isRewarded) {

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -13,6 +13,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
 		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
 		guildProfile.decrement("seasonXP");
+		guildProfile.save();
 		if (guildProfile.bountyBoardId) {
 			const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
 			const postingThread = await bountyBoard.threads.fetch(bounty.postingId);


### PR DESCRIPTION
Summary
-------
- fix crash on bounty complete if no bounty board
- allow findOrCreate to create associated entities

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty complete` no longer crashes without a bounty board
- [x] consolidated findOrCreate refactored code still works

Issue
-----
Closes #51 