### PR TITLE
#55: add Season and SeasonParticipation tables

### DIFF
--- a/database.js
+++ b/database.js
@@ -16,7 +16,7 @@ exports.database.authenticate().then(() => {
 	const { ToastRecipient, initModel: initToastRecipient } = require("./source/models/toasts/ToastRecipient.js");
 	const { ToastSeconding, initModel: initToastSeconding } = require("./source/models/toasts/ToastSeconding.js");
 	const { Season, initModel: initSeason } = require("./source/models/seasons/Season.js");
-	const { HunterSeason, initModel: initHunterSeason } = require("./source/models/seasons/HunterSeason.js");
+	const { SeasonParticpation, initModel: initSeasonParticipation } = require("./source/models/seasons/SeasonParticipation.js");
 
 	initCompany(exports.database);
 	initCompanyRank(exports.database);
@@ -28,8 +28,9 @@ exports.database.authenticate().then(() => {
 	initToastRecipient(exports.database);
 	initToastSeconding(exports.database);
 	initSeason(exports.database);
-	initHunterSeason(exports.database);
+	initSeasonParticipation(exports.database);
 
+	//TODONOW prune associations (not all references need to be associations)
 	Company.CompanyRanks = Company.hasMany(CompanyRank, {
 		foreignKey: "companyId"
 	});
@@ -134,17 +135,11 @@ exports.database.authenticate().then(() => {
 		foreignKey: "lastSeasonId"
 	})
 
-	Hunter.SeasonStats = Hunter.belongsTo(HunterSeason, {
-		foreignKey: "seasonStatsId"
+	Hunter.SeasonParticipation = Hunter.belongsTo(SeasonParticpation, {
+		foreignKey: "seasonParticipationId"
 	})
-	HunterSeason.Hunter = HunterSeason.hasOne(Hunter, {
-		foreignKey: "seasonStatsId"
-	})
-	Hunter.SeasonStats = Hunter.belongsTo(HunterSeason, {
-		foreignKey: "lastSeasonStatsId"
-	})
-	HunterSeason.Hunter = HunterSeason.hasOne(Hunter, {
-		foreignKey: "lastSeasonStatsId"
+	SeasonParticpation.Hunter = SeasonParticpation.hasOne(Hunter, {
+		foreignKey: "seasonParticipationId"
 	})
 
 	exports.database.sync();

--- a/database.js
+++ b/database.js
@@ -6,18 +6,20 @@ exports.database = new Sequelize({
 });
 
 exports.database.authenticate().then(() => {
-	const { Guild, initModel: initGuild } = require("./source/models/guilds/Guild.js")
-	const { GuildRank, initModel: initGuildRank } = require("./source/models/guilds/GuildRank.js")
+	const { Company, initModel: initCompany } = require("./source/models/companies/Company.js");
+	const { CompanyRank, initModel: initCompanyRank } = require("./source/models/companies/CompanyRank.js");
 	const { User, initModel: initUser } = require("./source/models/users/User.js");
 	const { Hunter, initModel: initHunter } = require("./source/models/users/Hunter.js");
-	const { Bounty, initModel: initBounty } = require("./source/models/bounties/Bounty.js")
-	const { Completion, initModel: initCompletion } = require("./source/models/bounties/Completion.js")
-	const { Toast, initModel: initToast } = require("./source/models/toasts/Toast.js")
-	const { ToastRecipient, initModel: initToastRecipient } = require("./source/models/toasts/ToastRecipient.js")
-	const { ToastSeconding, initModel: initToastSeconding } = require("./source/models/toasts/ToastSeconding.js")
+	const { Bounty, initModel: initBounty } = require("./source/models/bounties/Bounty.js");
+	const { Completion, initModel: initCompletion } = require("./source/models/bounties/Completion.js");
+	const { Toast, initModel: initToast } = require("./source/models/toasts/Toast.js");
+	const { ToastRecipient, initModel: initToastRecipient } = require("./source/models/toasts/ToastRecipient.js");
+	const { ToastSeconding, initModel: initToastSeconding } = require("./source/models/toasts/ToastSeconding.js");
+	const { Season, initModel: initSeason } = require("./source/models/seasons/Season.js");
+	const { HunterSeason, initModel: initHunterSeason } = require("./source/models/seasons/HunterSeason.js");
 
-	initGuild(exports.database);
-	initGuildRank(exports.database);
+	initCompany(exports.database);
+	initCompanyRank(exports.database);
 	initUser(exports.database);
 	initHunter(exports.database);
 	initBounty(exports.database);
@@ -25,97 +27,125 @@ exports.database.authenticate().then(() => {
 	initToast(exports.database);
 	initToastRecipient(exports.database);
 	initToastSeconding(exports.database);
+	initSeason(exports.database);
+	initHunterSeason(exports.database);
 
-	Guild.GuildRank = Guild.hasMany(GuildRank, {
-		foreignKey: "guildId"
+	Company.CompanyRanks = Company.hasMany(CompanyRank, {
+		foreignKey: "companyId"
 	});
-	GuildRank.Guild = GuildRank.belongsTo(Guild, {
-		foreignKey: "guildId"
+	CompanyRank.Company = CompanyRank.belongsTo(Company, {
+		foreignKey: "companyId"
 	});
 
 	Hunter.User = Hunter.belongsTo(User, {
 		foreignKey: "userId"
 	});
-	User.Hunter = User.hasMany(Hunter, {
+	User.Hunters = User.hasMany(Hunter, {
 		foreignKey: "userId"
 	});
 
-	Hunter.Guild = Hunter.belongsTo(Guild, {
-		foreignKey: "guildId"
+	Hunter.Company = Hunter.belongsTo(Company, {
+		foreignKey: "companyId"
 	});
-	Guild.Hunter = Guild.hasMany(Hunter, {
-		foreignKey: "guildId"
+	Company.Hunters = Company.hasMany(Hunter, {
+		foreignKey: "companyId"
 	});
 
-	Bounty.Guild = Bounty.belongsTo(Guild, {
-		foreignKey: "guildId"
+	Bounty.Company = Bounty.belongsTo(Company, {
+		foreignKey: "companyId"
 	});
-	Guild.Bounty = Guild.hasMany(Bounty, {
-		foreignKey: "guildId"
+	Company.Bounties = Company.hasMany(Bounty, {
+		foreignKey: "companyId"
 	});
 
 	Completion.Bounty = Completion.belongsTo(Bounty, {
 		foreignKey: "bountyId"
 	});
-	Bounty.Completion = Bounty.hasMany(Completion, {
+	Bounty.Completions = Bounty.hasMany(Completion, {
 		foreignKey: "bountyId"
 	});
 
 	Completion.User = Completion.belongsTo(User, {
 		foreignKey: "userId"
 	});
-	User.Completion = User.hasMany(Completion, {
+	User.Completions = User.hasMany(Completion, {
 		foreignKey: "userId"
 	});
 
-	Completion.Guild = Completion.belongsTo(Guild, {
-		foreignKey: "guildId"
+	Completion.Company = Completion.belongsTo(Company, {
+		foreignKey: "companyId"
 	});
-	Guild.Completion = Guild.hasMany(Completion, {
-		foreignKey: "guildId"
+	Company.Completions = Company.hasMany(Completion, {
+		foreignKey: "companyId"
 	});
 
-	Toast.Guild = Toast.belongsTo(Guild, {
-		foreignKey: "guildId"
+	Toast.Company = Toast.belongsTo(Company, {
+		foreignKey: "companyId"
 	});
-	Guild.Toast = Guild.hasMany(Toast, {
-		foreignKey: "guildId"
+	Company.Toasts = Company.hasMany(Toast, {
+		foreignKey: "companyId"
 	});
 
 	Toast.User = Toast.belongsTo(User, {
 		foreignKey: "senderId"
 	});
-	User.Toast = User.hasMany(Toast, {
+	User.Toasts = User.hasMany(Toast, {
 		foreignKey: "senderId"
 	});
 
 	ToastRecipient.Toast = ToastRecipient.belongsTo(Toast, {
 		foreignKey: "toastId"
 	});
-	Toast.ToastRecipient = Toast.hasMany(ToastRecipient, {
+	Toast.ToastRecipients = Toast.hasMany(ToastRecipient, {
 		foreignKey: "toastId"
 	});
 
 	ToastRecipient.User = ToastRecipient.belongsTo(User, {
 		foreignKey: "recipientId"
 	});
-	User.ToastRecipient = User.hasMany(ToastRecipient, {
+	User.ToastRecipients = User.hasMany(ToastRecipient, {
 		foreignKey: "recipientId"
 	});
 
 	ToastSeconding.Toast = ToastSeconding.belongsTo(Toast, {
 		foreignKey: "toastId"
 	});
-	Toast.ToastSeconding = Toast.hasMany(ToastSeconding, {
+	Toast.ToastSecondings = Toast.hasMany(ToastSeconding, {
 		foreignKey: "toastId"
 	});
 
 	ToastSeconding.User = ToastSeconding.belongsTo(User, {
 		foreignKey: "seconderId"
 	});
-	User.ToastSeconding = User.hasMany(ToastSeconding, {
+	User.ToastSecondings = User.hasMany(ToastSeconding, {
 		foreignKey: "seconderId"
 	});
+
+	Company.Season = Company.belongsTo(Season, {
+		foreignKey: "seasonId"
+	})
+	Season.Company = Season.hasOne(Company, {
+		foreignKey: "seasonId"
+	})
+	Company.LastSeason = Company.belongsTo(Season, {
+		foreignKey: "lastSeasonId"
+	})
+	Season.Company = Season.hasOne(Company, {
+		foreignKey: "lastSeasonId"
+	})
+
+	Hunter.SeasonStats = Hunter.belongsTo(HunterSeason, {
+		foreignKey: "seasonStatsId"
+	})
+	HunterSeason.Hunter = HunterSeason.hasOne(Hunter, {
+		foreignKey: "seasonStatsId"
+	})
+	Hunter.SeasonStats = Hunter.belongsTo(HunterSeason, {
+		foreignKey: "lastSeasonStatsId"
+	})
+	HunterSeason.Hunter = HunterSeason.hasOne(Hunter, {
+		foreignKey: "lastSeasonStatsId"
+	})
 
 	exports.database.sync();
 })

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -22,7 +22,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		}
 
 		const [seconder] = await database.models.Hunter.findOrCreate({
-			where: { userId: interaction.user.id, guildId: interaction.guildId },
+			where: { userId: interaction.user.id, companyId: interaction.guildId },
 			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },
 			include: database.models.Hunter.User
 		});
@@ -31,7 +31,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		const recipientIds = (await originalToast.recipients).map(reciept => reciept.recipientId);
 		const levelTexts = [];
 		for (const userId of recipientIds) {
-			const hunter = await database.models.Hunter.findOne({ where: { userId, guildId: interaction.guildId } });
+			const hunter = await database.models.Hunter.findOne({ where: { userId, companyId: interaction.guildId } });
 			levelTexts.concat(await hunter.addXP(interaction.guild, 1, true));
 		}
 
@@ -46,7 +46,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		const lastFiveToasts = await database.models.Toast.findAll({ where: { guildId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
+		const lastFiveToasts = await database.models.Toast.findAll({ where: { companyId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
 		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {
 			return (await list).concat((await toast.rewardedRecipients).map(recipient => recipient.userId));
 		}, new Promise((resolve) => resolve([])));

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -308,7 +308,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 					}
 
 					// disallow completion within 5 minutes of creating bounty
-					if (bounty.createdAt < Date.now() + timeConversion(5, "m", "ms")) {
+					if (new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {
 						interaction.reply({ content: "Bounties cannot be completed within 5 minutes of their posting. You can `/bounty add-completers` so you won't forget instead.", ephemeral: true });
 						return;
 					}

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -89,7 +89,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 		let slotNumber;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // post
-				database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
+				database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season }).then(async ([{ maxSimBounties }]) => {
 					const userId = interaction.user.id;
 					const [hunter] = await database.models.Hunter.findOrCreate({
 						where: { userId, companyId: interaction.guildId },

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -316,6 +316,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 					// poster guaranteed to exist, creating a bounty gives 1 XP
 					const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 					const company = await database.models.Company.findByPk(interaction.guildId);
+					const season = await database.models.Season.findByPk(company.seasonId);
 					const bountyValue = Bounty.calculateReward(poster.level, slotNumber, bounty.showcaseCount) * company.eventMultiplier;
 
 					const allCompleterIds = (await database.models.Completion.findAll({ where: { bountyId: bounty.id } })).map(reciept => reciept.userId);
@@ -350,7 +351,7 @@ module.exports = new CommandWrapper(customId, "Bounties are user-created objecti
 						return;
 					}
 
-					company.increment("seasonBounties");
+					season.increment("bountiesCompleted");
 
 					bounty.state = "completed";
 					bounty.completedAt = new Date();

--- a/source/commands/create-default.js
+++ b/source/commands/create-default.js
@@ -48,27 +48,24 @@ module.exports = new CommandWrapper(customId, "Create a Discord resource for use
 							allow: [PermissionFlagsBits.SendMessagesInThreads]
 						}
 					],
-					//TODO use "availableTags" to allow tagging bounties ("completed", "event", "open" as default tags?)
+					//TODO #77 use "availableTags" to allow tagging bounties ("completed", "event", "open" as default tags?)
 					defaultSortOrder: SortOrderType.CreationDate,
 					defaultForumLayout: ForumLayoutType.ListView,
 					reason: `/create-default bounty-board-forum by ${interaction.user}`
 				}).then(async bountyBoard => {
-					let guildProfile = await database.models.Guild.findByPk(interaction.guildId);
-					if (!guildProfile) {
-						guildProfile = await database.models.Guild.create({ id: interaction.guildId });
-					}
+					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 
-					guildProfile.bountyBoardId = bountyBoard.id;
+					company.bountyBoardId = bountyBoard.id;
 
 					const evergreenBounties = [];
-					database.models.Bounty.findAll({ where: { guildId: interaction.guildId, state: "open" }, order: [["createdAt", "DESC"]] }).then(bounties => {
+					database.models.Bounty.findAll({ where: { companyId: interaction.guildId, state: "open" }, order: [["createdAt", "DESC"]] }).then(bounties => {
 						for (const bounty of bounties) {
 							if (bounty.isEvergreen) {
 								evergreenBounties.unshift(bounty);
 								continue;
 							}
-							database.models.Hunter.findOne({ guildId: bounty.guildId, userId: bounty.userId }).then(poster => {
-								return bounty.asEmbed(interaction.guild, bounty.userId == interaction.client.user.id ? guildProfile.level : poster.level, guildProfile.eventMultiplierString());
+							database.models.Hunter.findOne({ companyId: bounty.guildId, userId: bounty.userId }).then(poster => {
+								return bounty.asEmbed(interaction.guild, bounty.userId == interaction.client.user.id ? company.level : poster.level, company.eventMultiplierString());
 							}).then(bountyEmbed => {
 								return bountyBoard.threads.create({
 									name: bounty.title,
@@ -82,13 +79,13 @@ module.exports = new CommandWrapper(customId, "Create a Discord resource for use
 
 						// make Evergreen Bounty list
 						if (evergreenBounties.length > 0) {
-							Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()))).then(embeds => {
-								generateBountyBoardThread(bountyBoard.threads, embeds, guildProfile);
+							Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString()))).then(embeds => {
+								generateBountyBoardThread(bountyBoard.threads, embeds, company);
 							})
 						}
 					});
 
-					guildProfile.save();
+					company.save();
 					interaction.reply({ content: `A new bounty board has been created: ${bountyBoard}`, ephemeral: true });
 				});
 				break;
@@ -110,15 +107,15 @@ module.exports = new CommandWrapper(customId, "Create a Discord resource for use
 					],
 					reason: `/create-default scoreboard-reference by ${interaction.user}`
 				}).then(async scoreboard => {
-					const [guildProfile] = await database.models.Guild.findOrCreate({ where: { id: interaction.guildId } });
+					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 					const isSeasonal = interaction.options.getString("scoreboard-type") == "season";
 					scoreboard.send({
 						embeds: [await buildScoreboardEmbed(interaction.guild, isSeasonal)]
 					}).then(message => {
-						guildProfile.scoreboardChannelId = scoreboard.id;
-						guildProfile.scoreboardMessageId = message.id;
-						guildProfile.scoreboardIsSeasonal = isSeasonal;
-						guildProfile.save();
+						company.scoreboardChannelId = scoreboard.id;
+						company.scoreboardMessageId = message.id;
+						company.scoreboardIsSeasonal = isSeasonal;
+						company.save();
 					});
 					interaction.reply({ content: `A new scoreboard reference channel has been created: ${scoreboard}`, ephemeral: true });
 				})

--- a/source/commands/event.js
+++ b/source/commands/event.js
@@ -25,12 +25,12 @@ const subcommands = [
 module.exports = new CommandWrapper(customId, "Manage a server-wide event that multiplies XP of bounty completions, toast reciepts, and crit toasts", PermissionFlagsBits.ManageGuild, true, false, 3000, options, subcommands,
 	/** Allow users to manage XP multiplier events */
 	(interaction) => {
-		database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(([guildProfile]) => {
+		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
 			switch (interaction.options.getSubcommand()) {
 				case subcommands[0].name: // open-event
 					// Default null and 0 to 2
 					const multiplier = interaction.options.getInteger(subcommands[0].optionsInput[0].name) || 2;
-					guildProfile.update({ "eventMultiplier": multiplier });
+					company.update({ "eventMultiplier": multiplier });
 					interaction.guild.members.fetchMe().then(bountyBot => {
 						const multiplierTag = ` [XP x ${multiplier}]`;
 						const bountyBotName = bountyBot.nickname ?? bountyBot.displayName;
@@ -38,14 +38,14 @@ module.exports = new CommandWrapper(customId, "Manage a server-wide event that m
 							bountyBot.setNickname(`${bountyBotName}${multiplierTag}`);
 						}
 					})
-					interaction.reply(guildProfile.sendAnnouncement({ content: `An XP multiplier event has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
+					interaction.reply(company.sendAnnouncement({ content: `An XP multiplier event has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
 					break;
 				case subcommands[1].name: // close-event
-					guildProfile.update({ "eventMultiplier": 1 });
+					company.update({ "eventMultiplier": 1 });
 					interaction.guild.members.fetchMe().then(bountyBot => {
 						bountyBot.setNickname(null);
 					})
-					interaction.reply(guildProfile.sendAnnouncement({ content: "The XP multiplier event has ended. Hope you participate next time!" }));
+					interaction.reply(company.sendAnnouncement({ content: "The XP multiplier event has ended. Hope you participate next time!" }));
 					break;
 			}
 		});

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -53,7 +53,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 		let slotNumber;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // post
-				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, state: "open" } }).then(existingBounties => {
+				database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" } }).then(existingBounties => {
 					if (existingBounties.length > 9) {
 						interaction.reply({ content: "Each server can only have 10 Evergreen Bounties.", ephemeral: true });
 						return;

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -53,7 +53,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 		let slotNumber;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // post
-				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(existingBounties => {
+				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, state: "open" } }).then(existingBounties => {
 					if (existingBounties.length > 9) {
 						interaction.reply({ content: "Each server can only have 10 Evergreen Bounties.", ephemeral: true });
 						return;
@@ -88,7 +88,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 				});
 				break;
 			case subcommands[1].name: // edit
-				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, state: "open" } }).then(openBounties => {
+				database.models.Bounty.findAll({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, state: "open" } }).then(openBounties => {
 					const slotOptions = openBounties.map(bounty => {
 						return {
 							emoji: getNumberEmoji(bounty.slotNumber),
@@ -118,7 +118,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 				})
 				break;
 			case subcommands[2].name: // swap
-				database.models.Bounty.findAll({ where: { isEvergreen: true, guildId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] }).then(existingBounties => {
+				database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] }).then(existingBounties => {
 					if (existingBounties.length < 2) {
 						interaction.reply({ content: "There must be at least 2 evergreen bounties for this server to swap.", ephemeral: true });
 						return;
@@ -144,7 +144,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 				});
 				break;
 			case subcommands[3].name: // showcase
-				database.models.Bounty.findAll({ where: { isEvergreen: true, guildId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] }).then(existingBounties => {
+				database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] }).then(existingBounties => {
 					if (existingBounties.length < 1) {
 						interaction.reply({ content: "This server doesn't have any open evergreen bounties posted.", ephemeral: true });
 						return;
@@ -171,13 +171,13 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 				break;
 			case subcommands[4].name: // complete
 				slotNumber = interaction.options.getInteger("bounty-slot");
-				database.models.Bounty.findOne({ where: { isEvergreen: true, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+				database.models.Bounty.findOne({ where: { isEvergreen: true, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
 					if (!bounty) {
 						interaction.reply({ content: "There isn't an evergreen bounty in the `bounty-slot` provided.", ephemeral: true });
 						return;
 					}
 
-					const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+					const company = await database.models.Company.findByPk(interaction.guildId);
 
 					const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
 
@@ -200,7 +200,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						if (!member.user.bot) {
 							const memberId = member.id;
 							const [hunter] = await database.models.Hunter.findOrCreate({
-								where: { userId: memberId, guildId: interaction.guildId },
+								where: { userId: memberId, companyId: interaction.guildId },
 								defaults: { isRankEligible: member.manageable, User: { id: memberId } },
 								include: database.models.Hunter.User
 							});
@@ -215,35 +215,35 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						return;
 					}
 
-					guildProfile.increment("seasonBounties");
+					company.increment("seasonBounties");
 
 					const rawCompletions = [];
 					for (const userId of dedupedCompleterIds) {
 						rawCompletions.push({
 							bountyId: bounty.id,
 							userId,
-							guildId: interaction.guildId
+							companyId: interaction.guildId
 						});
 					}
 					await database.models.Completion.bulkCreate(rawCompletions);
 
 					// Evergreen bounties are not eligible for showcase bonuses
-					const bountyValue = Bounty.calculateReward(guildProfile.level, slotNumber, 0) * guildProfile.eventMultiplier;
+					const bountyValue = Bounty.calculateReward(company.level, slotNumber, 0) * company.eventMultiplier;
 					database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
 
 					for (const userId of validatedCompleterIds) {
-						const hunter = await database.models.Hunter.findOne({ where: { guildId: interaction.guildId, userId } });
+						const hunter = await database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId } });
 						levelTexts.concat(await hunter.addXP(interaction.guild, bountyValue, true));
 						hunter.othersFinished++;
 						hunter.save();
 					}
 
-					bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()).then(embed => {
+					bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString()).then(embed => {
 						return interaction.reply({ embeds: [embed], fetchReply: true });
 					}).then(replyMessage => {
 						getRankUpdates(interaction.guild).then(rankUpdates => {
 							replyMessage.startThread({ name: "Rewards" }).then(thread => {
-								const multiplierString = guildProfile.eventMultiplierString();
+								const multiplierString = company.eventMultiplierString();
 								let text = "";
 								if (rankUpdates.length > 0) {
 									text += `\n__**Rank Ups**__\n${rankUpdates.join("\n")}\n`;
@@ -257,13 +257,13 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 								}
 								thread.send(text);
 							})
-							updateScoreboard(guildProfile, interaction.guild);
+							updateScoreboard(company, interaction.guild);
 						});
 					})
 				})
 				break;
 			case subcommands[5].name: // take-down
-				database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" } }).then(openBounties => {
+				database.models.Bounty.findAll({ where: { companyId: interaction.guildId, userId: interaction.client.user.id, state: "open" } }).then(openBounties => {
 					const bountyOptions = openBounties.map(bounty => {
 						return {
 							emoji: getNumberEmoji(bounty.slotNumber),

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -178,6 +178,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 					}
 
 					const company = await database.models.Company.findByPk(interaction.guildId);
+					const season = await database.models.Season.findByPk(company.seasonId);
 
 					const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
 
@@ -215,7 +216,7 @@ module.exports = new CommandWrapper(customId, "Evergreen Bounties are not closed
 						return;
 					}
 
-					company.increment("seasonBounties");
+					season.increment("bountiesCompleted");
 
 					const rawCompletions = [];
 					for (const userId of dedupedCompleterIds) {

--- a/source/commands/moderation.js
+++ b/source/commands/moderation.js
@@ -100,7 +100,7 @@ module.exports = new CommandWrapper(customId, "BountyBot moderation tools", Perm
 			case subcommands[1].name: // disqualify
 				member = interaction.options.getMember("bounty-hunter");
 				database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season }).then(async ([company]) => {
-					const hunter = await database.models.Hunter.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId }, defaults: { isRankEligible: member.manageable, User: { id: member.id } }, include: database.models.Hunter.User });
+					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId }, defaults: { isRankEligible: member.manageable, User: { id: member.id } }, include: database.models.Hunter.User });
 					let isDisqualification;
 					if (hunter.seasonParticipationId) {
 						const seasonParticipation = await database.models.SeasonParticipation.findByPk(hunter.seasonParticipationId);
@@ -116,6 +116,7 @@ module.exports = new CommandWrapper(customId, "BountyBot moderation tools", Perm
 						});
 						hunter.seasonParticipationId = seasonParticpation.id;
 						hunter.save();
+						isDisqualification = true;
 					}
 					if (isDisqualification) {
 						hunter.increment("seasonDQCount");

--- a/source/commands/rank.js
+++ b/source/commands/rank.js
@@ -84,21 +84,21 @@ module.exports = new CommandWrapper(customId, "Seasonal Ranks distinguish bounty
 		let varianceThreshold;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // add
-				database.models.GuildRank.findAll({ where: { guildId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] }).then(guildRanks => {
+				database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] }).then(companyRanks => {
 					const newThreshold = interaction.options.getNumber(subcommands[0].optionsInput[0].name);
-					const existingThresholds = guildRanks.map(rank => rank.varianceThreshold);
+					const existingThresholds = companyRanks.map(rank => rank.varianceThreshold);
 					if (existingThresholds.includes(newThreshold)) {
 						interaction.reply({ content: `There is already a rank at the ${newThreshold} standard deviations threshold for this server. If you'd like to change the role or rankmoji for that rank, you can use \`/rank edit\`.`, ephemeral: true });
 						return;
 					}
 
-					if (guildRanks.length > 24) {
+					if (companyRanks.length > 24) {
 						interaction.reply({ content: "A server can only have 25 seasonal ranks at a time.", ephemeral: true });
 						return;
 					}
 
 					const rawRank = {
-						guildId: interaction.guildId,
+						companyId: interaction.guildId,
 						varianceThreshold: newThreshold
 					};
 
@@ -111,8 +111,8 @@ module.exports = new CommandWrapper(customId, "Seasonal Ranks distinguish bounty
 					if (newRankmoji) {
 						rawRank.rankmoji = newRankmoji;
 					}
-					database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(() => {
-						database.models.GuildRank.create(rawRank);
+					database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(() => {
+						database.models.CompanyRank.create(rawRank);
 					})
 					getRankUpdates(interaction.guild);
 					interaction.reply({ content: `A new seasonal rank ${newRankmoji ? `${newRankmoji} ` : ""}was created at ${newThreshold} standard deviations above mean season xp${newRole ? ` with the role ${newRole}` : ""}.`, ephemeral: true });
@@ -120,9 +120,9 @@ module.exports = new CommandWrapper(customId, "Seasonal Ranks distinguish bounty
 				break;
 			case subcommands[1].name: // info
 				varianceThreshold = interaction.options.getNumber(subcommands[1].optionsInput[0].name);
-				database.models.GuildRank.findAll({ where: { guildId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] }).then(guildRanks => {
+				database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] }).then(companyRanks => {
 					let index = 0;
-					const rank = guildRanks.find(rank => {
+					const rank = companyRanks.find(rank => {
 						index++;
 						return rank.varianceThreshold == varianceThreshold
 					});
@@ -138,7 +138,7 @@ module.exports = new CommandWrapper(customId, "Seasonal Ranks distinguish bounty
 				break;
 			case subcommands[2].name: // edit
 				varianceThreshold = interaction.options.getNumber(subcommands[2].optionsInput[0].name);
-				database.models.GuildRank.findOne({ where: { guildId: interaction.guildId, varianceThreshold } }).then(rank => {
+				database.models.CompanyRank.findOne({ where: { companyId: interaction.guildId, varianceThreshold } }).then(rank => {
 					if (!rank) {
 						interaction.reply({ content: `Could not find a seasonal rank with variance threshold of ${varianceThreshold}.`, ephemeral: true });
 						return;
@@ -162,7 +162,7 @@ module.exports = new CommandWrapper(customId, "Seasonal Ranks distinguish bounty
 				break;
 			case subcommands[3].name: // remove
 				varianceThreshold = interaction.options.getNumber(subcommands[3].optionsInput[0].name);
-				database.models.GuildRank.findOne({ where: { guildId: interaction.guildId, varianceThreshold } }).then(rank => {
+				database.models.CompanyRank.findOne({ where: { companyId: interaction.guildId, varianceThreshold } }).then(rank => {
 					if (!rank) {
 						interaction.reply({ content: `Could not find a seasonal rank with variance threshold of ${varianceThreshold}.`, ephemeral: true });
 						return;

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -1,5 +1,5 @@
 const { CommandWrapper } = require('../classes');
-const { buildScoreboardEmbed } = require('../embedHelpers');
+const { buildSeasonalScoreboardEmbed, buildOverallScoreboardEmbed } = require('../embedHelpers');
 
 const customId = "scoreboard";
 const options = [
@@ -18,11 +18,20 @@ const subcommands = [];
 module.exports = new CommandWrapper(customId, "View the XP scoreboard", null, false, false, 3000, options, subcommands,
 	/** View the XP scoreboard */
 	(interaction) => {
-		buildScoreboardEmbed(interaction.guild, interaction.options.getString(options[0].name) === "season").then(embed => {
-			interaction.reply({
-				embeds: [embed],
-				ephemeral: true
-			});
-		})
+		if (interaction.options.getString(options[0].name) === "season") {
+			buildSeasonalScoreboardEmbed(interaction.guild).then(embed => {
+				interaction.reply({
+					embeds: [embed],
+					ephemeral: true
+				});
+			})
+		} else {
+			buildOverallScoreboardEmbed(interaction.guild).then(embed => {
+				interaction.reply({
+					embeds: [embed],
+					ephemeral: true
+				});
+			})
+		}
 	}
 );

--- a/source/commands/server-bonuses.js
+++ b/source/commands/server-bonuses.js
@@ -9,8 +9,8 @@ const subcommands = [];
 module.exports = new CommandWrapper(customId, "Get info about the currently running server bonuses", PermissionFlagsBits.ViewChannel, false, false, 3000, options, subcommands,
 	/** Send the user info about currently running server bonuses */
 	(interaction) => {
-		database.models.Guild.findOrCreate({ where: { id: interaction.guildId } }).then(([guildProfile]) => {
-			return buildServerBonusesEmbed(interaction.channel, interaction.guild, guildProfile);
+		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
+			return buildServerBonusesEmbed(interaction.channel, interaction.guild, company);
 		}).then(embed => {
 			interaction.reply({ embeds: [embed], ephemeral: true });
 		});

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -50,7 +50,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season.`)
 								.addFields(
 									//TODO previous season placements
-									{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
+									{ name: "Season Placements", value: `Currently: ${hunter.SeasonParticipation?.placement ?? 0 == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}` },
 									{ name: "Bounties Hunted", value: `${hunter.othersFinished} bount${hunter.othersFinished == 1 ? 'y' : 'ies'}`, inline: true },
 									{ name: "Bounty Postings", value: `${hunter.mineFinished} bount${hunter.mineFinished == 1 ? 'y' : 'ies'}`, inline: true },
 									{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
@@ -93,7 +93,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 							)
 							.addFields(
 								//TODO #55 previous season placements
-								{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
+								{ name: "Season Placements", value: `Currently: ${hunter.SeasonParticipation?.placement ?? 0 == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}` },
 								{ name: `Level ${hunter.level + 1} Reward`, value: hunter.levelUpReward(hunter.level + 1, maxSimBounties, true), inline: true },
 								{ name: `Level ${hunter.level + 2} Reward`, value: hunter.levelUpReward(hunter.level + 2, maxSimBounties, true), inline: true },
 								{ name: `Level ${hunter.level + 3} Reward`, value: hunter.levelUpReward(hunter.level + 3, maxSimBounties, true), inline: true },

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { buildGuildStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../embedHelpers');
+const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../embedHelpers');
 const { database } = require('../../database');
 const { generateTextBar } = require('../helpers');
 const { Hunter } = require('../models/users/Hunter');
@@ -22,7 +22,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 		if (target && target.id !== interaction.user.id) {
 			if (target.id == interaction.client.user.id) {
 				// BountyBot
-				buildGuildStatsEmbed(interaction.guild).then(embed => {
+				buildCompanyStatsEmbed(interaction.guild).then(embed => {
 					interaction.reply({
 						embeds: [embed],
 						ephemeral: true
@@ -30,13 +30,13 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 				})
 			} else {
 				// Other Hunter
-				database.models.Hunter.findOne({ where: { userId: target.id, guildId: interaction.guildId } }).then(async hunter => {
+				database.models.Hunter.findOne({ where: { userId: target.id, companyId: interaction.guildId } }).then(async hunter => {
 					if (!hunter) {
 						interaction.reply({ content: "The specified user doesn't seem to have a profile with this server's BountyBot yet. It'll be created when they gain XP.", ephemeral: true });
 						return;
 					}
 
-					const { xpCoefficient } = await database.models.Guild.findByPk(interaction.guildId);
+					const { xpCoefficient } = await database.models.Company.findByPk(interaction.guildId);
 					const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 					const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 
@@ -68,13 +68,13 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 			}
 		} else {
 			// Self
-			database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(async hunter => {
+			database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
 				if (!hunter) {
 					interaction.reply("You don't seem to have a profile with this server's BountyBot yet. It'll be created when you gain XP.");
 					return;
 				}
 
-				const { xpCoefficient, maxSimBounties } = await database.models.Guild.findByPk(interaction.guildId);
+				const { xpCoefficient, maxSimBounties } = await database.models.Company.findByPk(interaction.guildId);
 				const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 				const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 				const bountySlots = hunter.maxSlots(maxSimBounties);

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -30,7 +30,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 				})
 			} else {
 				// Other Hunter
-				database.models.Hunter.findOne({ where: { userId: target.id, companyId: interaction.guildId } }).then(async hunter => {
+				database.models.Hunter.findOne({ where: { userId: target.id, companyId: interaction.guildId }, include: database.models.Hunter.SeasonParticipation }).then(async hunter => {
 					if (!hunter) {
 						interaction.reply({ content: "The specified user doesn't seem to have a profile with this server's BountyBot yet. It'll be created when they gain XP.", ephemeral: true });
 						return;
@@ -47,7 +47,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 								.setAuthor(ihpAuthorPayload)
 								.setThumbnail(target.user.avatarURL())
 								.setTitle(`${target.displayName} is __Level ${hunter.level}__`)
-								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.seasonXP} XP* this season.`)
+								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season.`)
 								.addFields(
 									//TODO previous season placements
 									{ name: "Season Placements", value: `Currently: ${hunter.seasonPlacement == 0 ? "Unranked" : "#" + hunter.seasonPlacement}` },
@@ -68,7 +68,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 			}
 		} else {
 			// Self
-			database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
+			database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId }, include: database.models.Hunter.SeasonParticipation }).then(async hunter => {
 				if (!hunter) {
 					interaction.reply("You don't seem to have a profile with this server's BountyBot yet. It'll be created when you gain XP.");
 					return;
@@ -88,7 +88,7 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 							.setTitle(`You are __Level ${hunter.level}__ in ${interaction.guild.name}`)
 							.setDescription(
 								`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)} *Next Level:* ${nextLevelThreshold - hunter.xp} XP\n\
-								You have earned *${hunter.seasonXP} XP* this season${false /* TODO rankString */ ? ` which qualifies for the rank @${"" /* TODO rankString */}` : ""}.\n\n\
+								You have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season${false /* TODONOW rankString */ ? ` which qualifies for the rank @${"" /* TODONOW rankString */}` : ""}.\n\n\
 								You have ${bountySlots} bounty slot${bountySlots == 1 ? '' : 's'}!`
 							)
 							.addFields(

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -4,6 +4,7 @@ const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('.
 const { database } = require('../../database');
 const { generateTextBar } = require('../helpers');
 const { Hunter } = require('../models/users/Hunter');
+const { Op } = require('sequelize');
 
 const customId = "stats";
 const options = [
@@ -39,18 +40,20 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 					const { xpCoefficient } = await database.models.Company.findByPk(interaction.guildId);
 					const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 					const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
+					const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { id: { [Op.not]: hunter.seasonParticipationId }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
+					const ranks = await database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] });
+					const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 
-					//TODO add "most seconded toast"
+					//TODO #80 add "most seconded toast"
 					interaction.reply({
 						embeds: [
 							new EmbedBuilder().setColor(target.displayColor)
 								.setAuthor(ihpAuthorPayload)
 								.setThumbnail(target.user.avatarURL())
 								.setTitle(`${target.displayName} is __Level ${hunter.level}__`)
-								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season.`)
+								.setDescription(`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}\nThey have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season${hunter.rank != null ? ` which qualifies for ${rankName}` : ""}.`)
 								.addFields(
-									//TODO previous season placements
-									{ name: "Season Placements", value: `Currently: ${hunter.SeasonParticipation?.placement ?? 0 == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}` },
+									{ name: "Season Placements", value: `Currently: ${(hunter.SeasonParticipation?.placement ?? 0) == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}\n${previousSeasonParticipations.length > 0 ? `Previous Placements: ${previousSeasonParticipations.map(participation => `#${participation.placement}`).join(", ")}` : ""}` },
 									{ name: "Bounties Hunted", value: `${hunter.othersFinished} bount${hunter.othersFinished == 1 ? 'y' : 'ies'}`, inline: true },
 									{ name: "Bounty Postings", value: `${hunter.mineFinished} bount${hunter.mineFinished == 1 ? 'y' : 'ies'}`, inline: true },
 									{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
@@ -78,8 +81,11 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 				const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 				const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 				const bountySlots = hunter.maxSlots(maxSimBounties);
+				const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { id: { [Op.not]: hunter.seasonParticipationId }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
+				const ranks = await database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] });
+				const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 
-				//TODO add "most seconded toast"
+				//TODO #80 add "most seconded toast"
 				interaction.reply({
 					embeds: [
 						new EmbedBuilder().setColor(interaction.member.displayColor)
@@ -88,12 +94,11 @@ module.exports = new CommandWrapper(customId, "Get the BountyBot stats for yours
 							.setTitle(`You are __Level ${hunter.level}__ in ${interaction.guild.name}`)
 							.setDescription(
 								`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)} *Next Level:* ${nextLevelThreshold - hunter.xp} XP\n\
-								You have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season${false /* TODONOW rankString */ ? ` which qualifies for the rank @${"" /* TODONOW rankString */}` : ""}.\n\n\
+								You have earned *${hunter.SeasonParticipation?.xp ?? 0} XP* this season${hunter.rank != null ? ` which qualifies for ${rankName}` : ""}.${hunter.nextRankXP > 0 ? `You need ${hunter.nextRankXP} XP to reach the next rank.` : ""}\n\n\
 								You have ${bountySlots} bounty slot${bountySlots == 1 ? '' : 's'}!`
 							)
 							.addFields(
-								//TODO #55 previous season placements
-								{ name: "Season Placements", value: `Currently: ${hunter.SeasonParticipation?.placement ?? 0 == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}` },
+								{ name: "Season Placements", value: `Currently: ${(hunter.SeasonParticipation?.placement ?? 0) == 0 ? "Unranked" : "#" + hunter.SeasonParticipation.placement}\n${previousSeasonParticipations.length > 0 ? `Previous Placements: ${previousSeasonParticipations.map(participation => `#${participation.placement}`).join(", ")}` : ""}` },
 								{ name: `Level ${hunter.level + 1} Reward`, value: hunter.levelUpReward(hunter.level + 1, maxSimBounties, true), inline: true },
 								{ name: `Level ${hunter.level + 2} Reward`, value: hunter.levelUpReward(hunter.level + 2, maxSimBounties, true), inline: true },
 								{ name: `Level ${hunter.level + 3} Reward`, value: hunter.levelUpReward(hunter.level + 3, maxSimBounties, true), inline: true },

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -116,10 +116,10 @@ module.exports = new CommandWrapper(customId, "Raise a toast to other bounty hun
 		const rawRecipients = [];
 		let rewardedRecipients = [];
 		let critValue = 0;
-		//TODO combine fetch and seasonToasts increment with upsert?
-		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
-		company.increment("seasonToasts");
-		company.save();
+		//TODO combine fetch and toastsRaised increment with upsert?
+		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
+		const season = await database.models.Season.findByPk(company.seasonId);
+		season.increment("toastsRaised");
 		const [sender] = await database.models.Hunter.findOrCreate({
 			where: { userId: interaction.user.id, companyId: interaction.guildId },
 			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },

--- a/source/constants.js
+++ b/source/constants.js
@@ -14,4 +14,4 @@ exports.lastPostedVersion = lastPostedVersion;
 
 exports.MAX_EMBED_TITLE_LENGTH = 256;
 
-exports.GUILD_XP_COEFFICIENT = 3;
+exports.COMPANY_XP_COEFFICIENT = 3;

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -63,7 +63,7 @@ exports.buildCompanyStatsEmbed = async function (guild) {
 /** A seasonal scoreboard orders a company's hunters by their seasonal xp
  * @param {Guild} guild
  */
-exports.buildSeasonalScoreboardEmbed = async function (guild) { //TODONOW test with participants
+exports.buildSeasonalScoreboardEmbed = async function (guild) {
 	const [company] = await database.models.Company.findOrCreate({ where: { id: guild.id }, defaults: { Season: { companyId: guild.id } }, include: database.models.Company.Season });
 	const participations = await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId }, include: database.models.SeasonParticipation.Hunter, order: [["xp", "DESC"]] });
 
@@ -85,8 +85,7 @@ exports.buildSeasonalScoreboardEmbed = async function (guild) { //TODONOW test w
 /** An overall scoreboard orders a company's hunters by total xp
  * @param {Guild} guild
  */
-exports.buildOverallScoreboardEmbed = async function (guild) { //TODONOW test with participants
-	//TODONOW consider dropping support?
+exports.buildOverallScoreboardEmbed = async function (guild) {
 	const hunters = await database.models.Hunter.findAll({ where: { companyId: guild.id }, order: [["xp", "DESC"]] });
 
 	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -33,90 +33,81 @@ exports.randomFooterTip = function () {
 }
 
 exports.buildCompanyStatsEmbed = async function (guild) {
-	return database.models.Hunter.findAll({ where: { companyId: guild.id, seasonXP: { [Op.gt]: 0 } }, order: [["seasonXP", "DESC"]] }).then(async seasonParticipants => {
-		const { xp: companyXPPromise, level: companyLevel, seasonXP, lastSeasonXP, seasonBounties, bountiesLastSeason, seasonToasts, toastsLastSeason } = await database.models.Company.findByPk(guild.id);
-		const companyXP = await companyXPPromise;
+	const [company] = await database.models.Company.findOrCreate({ where: { id: guild.id }, defaults: { Season: { companyId: guild.id } }, include: database.models.Company.Season });
+	const seasonParticipants = (await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId }, include: database.models.SeasonParticipation.Hunter, order: [["xp", "DESC"]] })).map(participation => participation.Hunter);
+	const [currentSeason, lastSeason] = await database.models.Season.findAll({ where: { id: { [Op.in]: [company.seasonId, company.lastSeasonId] } }, order: [["createdAt", "DESC"]] });
+	const companyXP = await company.xp;
+	const currentSeasonXP = await currentSeason.totalXP;
+	const lastSeasonXP = await lastSeason?.totalXP ?? 0;
 
-		const currentLevelThreshold = Hunter.xpThreshold(companyLevel, COMPANY_XP_COEFFICIENT);
-		const nextLevelThreshold = Hunter.xpThreshold(companyLevel + 1, COMPANY_XP_COEFFICIENT);
-		const particpantPercentage = seasonParticipants.length / guild.memberCount * 100;
-		const seasonXPDifference = seasonXP - lastSeasonXP;
-		const seasonBountyDifference = seasonBounties - bountiesLastSeason;
-		const seasonToastDifference = seasonToasts - toastsLastSeason;
-		return new EmbedBuilder().setColor(Colors.Blurple)
-			.setAuthor(exports.ihpAuthorPayload)
-			.setTitle(`${guild.name} is __Level ${companyLevel}__`)
-			.setThumbnail(guild.iconURL())
-			.setDescription(`${generateTextBar(companyXP - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - companyXP} Bounty Hunter Levels`)
-			.addFields(
-				{ name: "Total Bounty Hunter Level", value: `${companyXP} level${companyXP == 1 ? "" : "s"}`, inline: true },
-				{ name: "Participation", value: `${seasonParticipants.length} server members have interacted with BountyBot this season (${particpantPercentage.toPrecision(3)}% of server members)` },
-				{ name: `${seasonXP} XP Earned Total (${seasonXPDifference === 0 ? "same as last season" : `${seasonXPDifference > 0 ? `+${seasonXPDifference} more XP` : `${seasonXPDifference * -1} fewer XP`} than last season`})`, value: `${seasonBounties} bounties (${seasonBountyDifference === 0 ? "same as last season" : `${seasonBountyDifference > 0 ? `**+${seasonBountyDifference} more bounties**` : `**${seasonBountyDifference * -1} fewer bounties**`} than last season`})\n${seasonToasts} toasts (${seasonToastDifference === 0 ? "same as last season" : `${seasonToastDifference > 0 ? `**+${seasonToastDifference} more toasts**` : `**${seasonToastDifference * -1} fewer toasts**`} than last season`})` }
-			)
-			.setFooter(exports.randomFooterTip())
-			.setTimestamp()
-	});
-}
-
-/** Build an embed mentioning if an event is running, the next raffle date and the raffle rewards
- * @param {TextChannel} channel
- * @param {Guild} guild
- * @param {Company} company
- */
-exports.buildServerBonusesEmbed = async function (channel, guild, company) {
-	const { displayColor, displayName } = await guild.members.fetch(guild.client.user.id);
-	const embed = new EmbedBuilder().setColor(displayColor)
-		.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
-		.setTitle(`${displayName} Server Bonuses`)
-		.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734097732897079336/calendar.png')
-		.setDescription(`There is ${company.eventMultiplier != 1 ? '' : 'not '}an XP multiplier event currently active${company.eventMultiplier == 1 ? '' : ` for ${company.eventMultiplierString()}`}.`)
+	const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
+	const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
+	const particpantPercentage = seasonParticipants.length / guild.memberCount * 100;
+	const seasonXPDifference = currentSeasonXP - lastSeasonXP;
+	const seasonBountyDifference = currentSeason.bountiesCompleted - (lastSeason?.bountiesCompleted ?? 0);
+	const seasonToastDifference = currentSeason.toastsRaised - (lastSeason?.toastsRaised ?? 0);
+	return new EmbedBuilder().setColor(Colors.Blurple)
+		.setAuthor(exports.ihpAuthorPayload)
+		.setTitle(`${guild.name} is __Level ${company.level}__`)
+		.setThumbnail(guild.iconURL())
+		.setDescription(`${generateTextBar(companyXP - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - companyXP} Bounty Hunter Levels`)
+		.addFields(
+			{ name: "Total Bounty Hunter Level", value: `${companyXP} level${companyXP == 1 ? "" : "s"}`, inline: true },
+			{ name: "Participation", value: `${seasonParticipants.length} server members have interacted with BountyBot this season (${particpantPercentage.toPrecision(3)}% of server members)` },
+			{ name: `${currentSeasonXP} XP Earned Total (${seasonXPDifference === 0 ? "same as last season" : `${seasonXPDifference > 0 ? `+${seasonXPDifference} more XP` : `${seasonXPDifference * -1} fewer XP`} than last season`})`, value: `${currentSeason.bountiesCompleted} bounties (${seasonBountyDifference === 0 ? "same as last season" : `${seasonBountyDifference > 0 ? `**+${seasonBountyDifference} more bounties**` : `**${seasonBountyDifference * -1} fewer bounties**`} than last season`})\n${currentSeason.toastsRaised} toasts (${seasonToastDifference === 0 ? "same as last season" : `${seasonToastDifference > 0 ? `**+${seasonToastDifference} more toasts**` : `**${seasonToastDifference * -1} fewer toasts**`} than last season`})` }
+		)
 		.setFooter(exports.randomFooterTip())
-		.setTimestamp();
-	if (company.nextRaffleString) {
-		embed.addFields([{ name: "Next Raffle", value: Utils.cleanContent(`The next raffle will be on ${company.nextRaffleString}!`, channel) }]);
-	}
-	//TODO custom raffle rewards
-	// if (this.rewards.length > 0) {
-	// 	embed.addField("Raffle Rewards", Utils.cleanContent(this.rewardStringBuilder(), channel));
-	// }
-
-	return embed;
+		.setTimestamp()
 }
 
-/** Listing XP acquired allows bounty hunters to compare ranking within a server
+/** A seasonal scoreboard orders a company's hunters by their seasonal xp
  * @param {Guild} guild
- * @param {boolean} isSeasonScoreboard
  */
-exports.buildScoreboardEmbed = async function (guild, isSeasonScoreboard) {
-	const queryParams = { where: { companyId: guild.id } };
-	if (isSeasonScoreboard) {
-		queryParams.where.seasonXP = { [Op.gt]: 0 };
-		queryParams.order = [["seasonXP", "DESC"]];
-	} else {
-		queryParams.order = [["xp", "DESC"]];
-	}
+exports.buildSeasonalScoreboardEmbed = async function (guild) { //TODONOW test with participants
+	const [company] = await database.models.Company.findOrCreate({ where: { id: guild.id }, defaults: { Season: { companyId: guild.id } }, include: database.models.Company.Season });
+	const participations = await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId }, include: database.models.SeasonParticipation.Hunter, order: [["xp", "DESC"]] });
 
-	const hunters = await database.models.Hunter.findAll(queryParams);
-	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
+	const hunterMembers = await guild.members.fetch({ user: participations.map(participation => participation.userId) });
 	const rankmojiArray = (await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] })).map(rank => rank.rankmoji);
 
-	const scorelines = hunters.map(hunter => `${hunter.rank ? `${rankmojiArray[hunter.rank]} ` : ""}#${hunter.seasonPlacement} **${hunterMembers.get(hunter.userId).displayName}** __Level ${hunter.level}__ *${isSeasonScoreboard ? `${hunter.seasonXP} season XP` : `${hunter.xp} XP`}*`).join("\n");
 	//TODO handle character overflow
+	const scorelines = participations.map(participation => `${participation.Hunter.rank ? `${rankmojiArray[participation.Hunter.rank]} ` : ""}#${participation.placement} **${hunterMembers.get(participation.userId).displayName}** __Level ${participation.Hunter.level}__ *${participation.xp} season XP*`).join("\n");
 
 	return new EmbedBuilder().setColor(Colors.Blurple)
 		.setAuthor(exports.ihpAuthorPayload)
 		.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/734094693217992804/scoreboard.png")
-		.setTitle(`The ${isSeasonScoreboard ? "Season " : ""}Scoreboard`)
+		.setTitle("The Season Scoreboard")
+		.setDescription(scorelines || "No Bounty Hunters yet...")
+		.setFooter(exports.randomFooterTip())
+		.setTimestamp();
+}
+
+/** An overall scoreboard orders a company's hunters by total xp
+ * @param {Guild} guild
+ */
+exports.buildOverallScoreboardEmbed = async function (guild) { //TODONOW test with participants
+	//TODONOW consider dropping support?
+	const hunters = await database.models.Hunter.findAll({ where: { companyId: guild.id }, order: [["xp", "DESC"]] });
+
+	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
+	const rankmojiArray = (await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] })).map(rank => rank.rankmoji);
+
+	//TODO handle character overflow
+	const scorelines = hunters.map(hunter => `${hunter.rank ? `${rankmojiArray[hunter.rank]} ` : ""} **${hunterMembers.get(hunter.userId).displayName}** __Level ${hunter.level}__ *${hunter.xp} XP*`).join("\n");
+
+	return new EmbedBuilder().setColor(Colors.Blurple)
+		.setAuthor(exports.ihpAuthorPayload)
+		.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/734094693217992804/scoreboard.png")
+		.setTitle("The Scoreboard")
 		.setDescription(scorelines || "No Bounty Hunters yet...")
 		.setFooter(exports.randomFooterTip())
 		.setTimestamp();
 }
 
 /** The version embed lists the following: changes in the most recent update, known issues in the most recent update, and links to support the project
- * @param {string} avatarURL
  * @returns {MessageEmbed}
  */
-exports.buildVersionEmbed = async function (avatarURL) {
+exports.buildVersionEmbed = async function () {
 	const data = await fs.promises.readFile('./ChangeLog.md', { encoding: 'utf8' });
 	const dividerRegEx = /## .+ Version/g;
 	const changesStartRegEx = /\.\d+:/g;
@@ -158,7 +149,7 @@ exports.updateScoreboard = function (company, guild) {
 		guild.channels.fetch(company.scoreboardChannelId).then(scoreboard => {
 			return scoreboard.messages.fetch(company.scoreboardMessageId);
 		}).then(async scoreboardMessage => {
-			scoreboardMessage.edit({ embeds: [await exports.buildScoreboardEmbed(guild, company.scoreboardIsSeasonal)] });
+			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await exports.buildSeasonalScoreboardEmbed(guild) : await exports.buildOverallScoreboardEmbed(guild)] });
 		});
 	}
 }

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -210,7 +210,7 @@ exports.getRankUpdates = async function (guild) {
 	const ranks = await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] });
 	const allHunters = await database.models.Hunter.findAll({ where: { companyId: guild.id } });
 
-	return calculateRanks(company.seasonId, allHunters, existingParticipationMap, ranks).then(async (firstPlaceMessage) => {
+	return calculateRanks(company.seasonId, allHunters, ranks).then(async (firstPlaceMessage) => {
 		const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);
 		const outMessages = [];
 		if (firstPlaceMessage) {
@@ -223,7 +223,7 @@ exports.getRankUpdates = async function (guild) {
 			}
 		}
 		const updatedMembers = await guild.members.fetch({ user: userIdsWithChangedRanks });
-		const updatedParticipationsMap = await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId, userId: { [Op.in]: userIdsWithChangedRanks } }, include: database.models.SeasonParticipation.Hunter })
+		const updatedParticipationsMap = (await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId, userId: { [Op.in]: userIdsWithChangedRanks } }, include: database.models.SeasonParticipation.Hunter }))
 			.reduce((map, participation) => {
 				map[participation.userId] = participation;
 				return map;

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,6 +1,6 @@
 const { database } = require("../database");
 const { Guild, AutoModerationActionType, GuildMember, TextChannel } = require("discord.js");
-const { GuildRank } = require("./models/guilds/GuildRank");
+const { CompanyRank } = require("./models/companies/CompanyRank");
 
 const CONGRATULATORY_PHRASES = [
 	"Congratulations",
@@ -130,7 +130,7 @@ exports.extractUserIdsFromMentions = function (mentionsText, exlcuedIds) {
 
 /** Recalculates the ranks (standard deviations from mean) and placements (ordinal) for the given participants
  * @param {database.models.Hunter[]} participants
- * @param {GuildRank[]} ranks
+ * @param {CompanyRank[]} ranks
  * @returns Promise of the message congratulating the hunter reaching first place (or `null` if no change)
  */
 exports.setRanks = async (participants, ranks) => {
@@ -202,8 +202,8 @@ exports.setRanks = async (participants, ranks) => {
  * @returns an array of rank and placement update strings
  */
 exports.getRankUpdates = async function (guild, force = false) {
-	const allHunters = await database.models.Hunter.findAll({ where: { guildId: guild.id }, order: [["seasonXP", "DESC"]] });
-	const ranks = await database.models.GuildRank.findAll({ where: { guildId: guild.id }, order: [["varianceThreshold", "DESC"]] });
+	const allHunters = await database.models.Hunter.findAll({ where: { companyId: guild.id }, order: [["seasonXP", "DESC"]] });
+	const ranks = await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] });
 	return exports.setRanks(allHunters, ranks).then(async (firstPlaceMessage) => {
 		const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);
 		const outMessages = [];
@@ -233,13 +233,13 @@ exports.getRankUpdates = async function (guild, force = false) {
 	});
 }
 
-exports.generateBountyBoardThread = function (threadManager, embeds, hunterGuild) {
+exports.generateBountyBoardThread = function (threadManager, embeds, company) {
 	return threadManager.create({
 		name: "Evergreen Bounties",
 		message: { embeds }
 	}).then(thread => {
-		hunterGuild.evergreenThreadId = thread.id;
-		hunterGuild.save();
+		company.evergreenThreadId = thread.id;
+		company.save();
 		thread.pin();
 		return thread;
 	})

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -151,6 +151,8 @@ async function calculateRanks(seasonId, allHunters, ranks) {
 			}
 			hunter.lastRank = hunter.rank;
 			rankableHunters.push(hunter);
+		} else {
+			hunter.nextRankXP = 0;
 		}
 	}
 
@@ -177,6 +179,7 @@ async function calculateRanks(seasonId, allHunters, ranks) {
 				}
 			}
 			hunter.rank = index;
+			hunter.nextRankXP = Math.ceil(stdDev * ranks[hunter.rank].varianceThreshold + mean - hunter.seasonXP);
 		}
 	}
 	let recentPlacement = allHunters.length - 1; // subtract 1 to adjust for array indexes starting from 0

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -157,7 +157,6 @@ async function calculateRanks(seasonId, allHunters, ranks) {
 	if (rankableHunters.length < 2) {
 		for (const hunter of allHunters) {
 			hunter.rank = null;
-			hunter.seasonPlacement = 0;
 			hunter.save();
 		}
 		return null;

--- a/source/modals/bountyeditmodal.js
+++ b/source/modals/bountyeditmodal.js
@@ -66,7 +66,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			return;
 		}
 
-		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" } });
 		if (title) {
 			bounty.title = title;
 		}
@@ -107,13 +107,13 @@ module.exports = new InteractionWrapper(customId, 3000,
 		bounty.save();
 
 		// update bounty board
-		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
-		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, hunterGuild.eventMultiplierString());
+		const company = await database.models.Company.findByPk(interaction.guildId);
+		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, company.eventMultiplierString());
 
-		bounty.updatePosting(interaction.guild, hunterGuild);
+		bounty.updatePosting(interaction.guild, company);
 
 		interaction.update({ content: "Bounty edited!", components: [] });
-		interaction.channel.send(hunterGuild.sendAnnouncement({ content: `${interaction.member} has edited one of their bounties:`, embeds: [bountyEmbed] }));
+		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has edited one of their bounties:`, embeds: [bountyEmbed] }));
 	}
 );

--- a/source/modals/bountypostmodal.js
+++ b/source/modals/bountypostmodal.js
@@ -19,7 +19,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 
 		const rawBounty = {
 			userId: interaction.user.id,
-			guildId: interaction.guildId,
+			companyId: interaction.guildId,
 			slotNumber: parseInt(slotNumber),
 			isEvergreen: false,
 			title,
@@ -75,7 +75,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			return;
 		}
 
-		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+		const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 		poster.addXP(interaction.guild, 1, true).then(() => {
 			getRankUpdates(interaction.guild);
 		});
@@ -100,11 +100,11 @@ module.exports = new InteractionWrapper(customId, 3000,
 		const bounty = await database.models.Bounty.create(rawBounty);
 
 		// post in bounty board forum
-		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, hunterGuild.eventMultiplierString());
-		interaction.reply(hunterGuild.sendAnnouncement({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] })).then(() => {
-			if (hunterGuild.bountyBoardId) {
-				interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(bountyBoard => {
+		const company = await database.models.Company.findByPk(interaction.guildId);
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, poster.level, company.eventMultiplierString());
+		interaction.reply(company.sendAnnouncement({ content: `${interaction.member} has posted a new bounty:`, embeds: [bountyEmbed] })).then(() => {
+			if (company.bountyBoardId) {
+				interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 					return bountyBoard.threads.create({
 						name: bounty.title,
 						message: { embeds: [bountyEmbed] }

--- a/source/modals/evergreeneditmodal.js
+++ b/source/modals/evergreeneditmodal.js
@@ -24,7 +24,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, slotNumber, state: "open" } });
 		if (title) {
 			bounty.title = title;
 		}
@@ -41,19 +41,19 @@ module.exports = new InteractionWrapper(customId, 3000,
 		bounty.save();
 
 		// update bounty board
-		const hunterGuild = await database.models.Guild.findByPk(interaction.guildId);
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString());
-		const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
-		const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString())));
-		if (hunterGuild.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(hunterGuild.bountyBoardId);
-			bountyBoard.threads.fetch(hunterGuild.evergreenThreadId).then(async thread => {
+		const company = await database.models.Company.findByPk(interaction.guildId);
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString());
+		const evergreenBounties = await database.models.Bounty.findAll({ where: { companyId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+		const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString())));
+		if (company.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
+			bountyBoard.threads.fetch(company.evergreenThreadId).then(async thread => {
 				const message = await thread.fetchStarterMessage();
 				message.edit({ embeds });
 			});
 		}
 
 		interaction.update({ content: "Bounty edited!", components: [] });
-		interaction.channel.send(hunterGuild.sendAnnouncement({ content: `${interaction.member} has edited an evergreen bounty:`, embeds: [bountyEmbed] }));
+		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has edited an evergreen bounty:`, embeds: [bountyEmbed] }));
 	}
 );

--- a/source/modals/evergreenpost.js
+++ b/source/modals/evergreenpost.js
@@ -36,7 +36,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
 		const bounty = await database.models.Bounty.create(rawBounty);
 
 		// post in bounty board forum

--- a/source/modals/evergreenpost.js
+++ b/source/modals/evergreenpost.js
@@ -17,7 +17,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 
 		const rawBounty = {
 			userId: interaction.client.user.id,
-			guildId: interaction.guildId,
+			companyId: interaction.guildId,
 			slotNumber: parseInt(slotNumber),
 			isEvergreen: true,
 			title,
@@ -36,24 +36,24 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 		}
 
-		const [hunterGuild] = await database.models.Guild.findOrCreate({ where: { id: interaction.guildId } });
+		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 		const bounty = await database.models.Bounty.create(rawBounty);
 
 		// post in bounty board forum
-		const bountyEmbed = await bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString());
-		interaction.reply(hunterGuild.sendAnnouncement({ content: `A new evergreen bounty has been posted:`, embeds: [bountyEmbed] })).then(() => {
-			if (hunterGuild.bountyBoardId) {
-				interaction.guild.channels.fetch(hunterGuild.bountyBoardId).then(async bountyBoard => {
-					const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
-					const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, hunterGuild.level, hunterGuild.eventMultiplierString())));
-					if (hunterGuild.evergreenThreadId) {
-						return bountyBoard.threads.fetch(hunterGuild.evergreenThreadId).then(async thread => {
+		const bountyEmbed = await bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString());
+		interaction.reply(company.sendAnnouncement({ content: `A new evergreen bounty has been posted:`, embeds: [bountyEmbed] })).then(() => {
+			if (company.bountyBoardId) {
+				interaction.guild.channels.fetch(company.bountyBoardId).then(async bountyBoard => {
+					const evergreenBounties = await database.models.Bounty.findAll({ where: { companyId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+					const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString())));
+					if (company.evergreenThreadId) {
+						return bountyBoard.threads.fetch(company.evergreenThreadId).then(async thread => {
 							const message = await thread.fetchStarterMessage();
 							message.edit({ embeds });
 							return thread;
 						});
 					} else {
-						return generateBountyBoardThread(bountyBoard.threads, embeds, hunterGuild);
+						return generateBountyBoardThread(bountyBoard.threads, embeds, company);
 					}
 				}).then(thread => {
 					bounty.postingId = thread.id;

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -1,7 +1,7 @@
 ﻿const { EmbedBuilder, Guild } = require('discord.js');
 const { DataTypes, Model } = require('sequelize');
 const { ihpAuthorPayload } = require('../../embedHelpers');
-const { Guild: HunterGuild } = require('../guilds/Guild');
+const { Company } = require('../companies/Company');
 const { database } = require('../../../database');
 
 /** Bounties are user created objectives for other server members to complete */
@@ -52,18 +52,18 @@ exports.Bounty = class extends Model {
 
 	/** Update the bounty's embed in the bounty board
 	 * @param {Guild} guild
-	 * @param {HunterGuild} guildProfile
+	 * @param {Company} company
 	 */
-	async updatePosting(guild, guildProfile) {
-		if (guildProfile.bountyBoardId) {
-			const poster = await database.models.Hunter.findOne({ where: { userId: this.userId, guildId: this.guildId } });
-			guild.channels.fetch(guildProfile.bountyBoardId).then(bountyBoard => {
+	async updatePosting(guild, company) {
+		if (company.bountyBoardId) {
+			const poster = await database.models.Hunter.findOne({ where: { userId: this.userId, companyId: this.companyId } });
+			guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 				return bountyBoard.threads.fetch(this.postingId);
 			}).then(thread => {
 				thread.edit({ name: this.title });
 				return thread.fetchStarterMessage();
 			}).then(posting => {
-				this.asEmbed(guild, poster.level, guildProfile.eventMultiplierString()).then(embed => {
+				this.asEmbed(guild, poster.level, company.eventMultiplierString()).then(embed => {
 					posting.edit({ embeds: [embed] })
 				})
 			})
@@ -87,7 +87,7 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.STRING,
 			allowNull: false
 		},
-		guildId: {
+		companyId: {
 			type: DataTypes.STRING,
 			allowNull: false
 		},

--- a/source/models/bounties/Completion.js
+++ b/source/models/bounties/Completion.js
@@ -16,7 +16,7 @@ exports.initModel = function (sequelize) {
 		userId: {
 			type: DataTypes.STRING
 		},
-		guildId: {
+		companyId: {
 			type: DataTypes.STRING
 		},
 		xpAwarded: {

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -63,7 +63,7 @@ exports.initModel = function (sequelize) {
 		xp: {
 			type: DataTypes.VIRTUAL,
 			async get() {
-				return await sequelize.models.Hunter.sum("level", { where: { companyId: this.id } });
+				return await sequelize.models.Hunter.sum("level", { where: { companyId: this.id } }) ?? 0;
 			}
 		},
 		level: {
@@ -112,32 +112,11 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.INTEGER,
 			defaultValue: 3
 		},
-		seasonXP: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
+		seasonId: {
+			type: DataTypes.UUID
 		},
-		seasonBounties: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
-		},
-		seasonToasts: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
-		},
-		resetSchedulerId: {
-			type: DataTypes.STRING
-		},
-		lastSeasonXP: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
-		},
-		bountiesLastSeason: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
-		},
-		toastsLastSeason: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
+		lastSeasonId: {
+			type: DataTypes.UUID
 		}
 	}, {
 		sequelize,

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -1,8 +1,8 @@
 const { MessageFlags } = require('discord.js');
 const { DataTypes, Model } = require('sequelize');
 
-/** Guild information and bot settings */
-exports.Guild = class extends Model {
+/** A Company of bounty hunters contains a Discord Guild's information and settings */
+exports.Company = class extends Model {
 	eventMultiplierString() {
 		if (this.eventMultiplier != 1) {
 			return ` ***x${this.eventMultiplier}***`;
@@ -11,7 +11,7 @@ exports.Guild = class extends Model {
 		}
 	}
 
-	/** Apply the guild's announcement prefix to the message (bots suppress notifications through flags instead of starting with "@silent")
+	/** Apply the company's announcement prefix to the message (bots suppress notifications through flags instead of starting with "@silent")
 	 * @param {import('discord.js').MessageCreateOptions} messageOptions
 	 */
 	sendAnnouncement(messageOptions) {
@@ -55,7 +55,7 @@ exports.Guild = class extends Model {
 }
 
 exports.initModel = function (sequelize) {
-	exports.Guild.init({
+	exports.Company.init({
 		id: {
 			primaryKey: true,
 			type: DataTypes.STRING
@@ -63,7 +63,7 @@ exports.initModel = function (sequelize) {
 		xp: {
 			type: DataTypes.VIRTUAL,
 			async get() {
-				return await sequelize.models.Hunter.sum("level", { where: { guildId: this.id } });
+				return await sequelize.models.Hunter.sum("level", { where: { companyId: this.id } });
 			}
 		},
 		level: {
@@ -141,7 +141,7 @@ exports.initModel = function (sequelize) {
 		}
 	}, {
 		sequelize,
-		modelName: 'Guild',
+		modelName: "Company",
 		freezeTableName: true
 	});
 }

--- a/source/models/companies/CompanyRank.js
+++ b/source/models/companies/CompanyRank.js
@@ -1,11 +1,11 @@
 ﻿const { DataTypes, Model } = require('sequelize');
 
-/** Ranks, individual per guild, include a variance threshold (difficulty to achieve) and optionally a role to give hunters and emoji for the scoreboard */
-exports.GuildRank = class extends Model { }
+/** A company's Ranks include a variance threshold (difficulty to achieve) and optionally a role to give hunters and emoji for the scoreboard */
+exports.CompanyRank = class extends Model { }
 
 exports.initModel = function (sequelize) {
-	exports.GuildRank.init({
-		guildId: {
+	exports.CompanyRank.init({
+		companyId: {
 			primaryKey: true,
 			type: DataTypes.STRING
 		},
@@ -21,7 +21,7 @@ exports.initModel = function (sequelize) {
 		}
 	}, {
 		sequelize,
-		modelName: 'GuildRank',
+		modelName: "CompanyRank",
 		freezeTableName: true
 	});
 }

--- a/source/models/seasons/Season.js
+++ b/source/models/seasons/Season.js
@@ -1,0 +1,35 @@
+const { Model, DataTypes } = require("sequelize");
+
+exports.Season = class extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.Season.init({
+		id: {
+			primaryKey: true,
+			type: DataTypes.UUID,
+			defaultValue: DataTypes.UUIDV4
+		},
+		companyId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		totalXP: {
+			type: DataTypes.VIRTUAL,
+			async get() {
+				return await sequelize.models.SeasonParticipation.sum("xp", { where: { seasonId: this.id } }) ?? 0;
+			}
+		},
+		bountiesCompleted: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		toastsRaised: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		}
+	}, {
+		sequelize,
+		modelName: "Season",
+		freezeTableName: true
+	})
+}

--- a/source/models/seasons/SeasonParticipation.js
+++ b/source/models/seasons/SeasonParticipation.js
@@ -1,0 +1,41 @@
+const { Model, DataTypes } = require("sequelize");
+
+exports.SeasonParticpation = class extends Model { }
+
+exports.initModel = function (sequelize) {
+	exports.SeasonParticpation.init({
+		id: {
+			primaryKey: true,
+			type: DataTypes.UUID,
+			defaultValue: DataTypes.UUIDV4
+		},
+		userId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		companyId: {
+			type: DataTypes.STRING,
+			allowNull: false
+		},
+		seasonId: {
+			type: DataTypes.UUID,
+			allowNull: false
+		},
+		isRankDisqualified: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false
+		},
+		xp: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
+		},
+		placement: {
+			type: DataTypes.INTEGER,
+			defaultValue: 0
+		}
+	}, {
+		sequelize,
+		modelName: "SeasonParticipation",
+		freezeTableName: true
+	})
+}

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -10,7 +10,7 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.UUID,
 			defaultValue: DataTypes.UUIDV4
 		},
-		guildId: {
+		companyId: {
 			type: DataTypes.STRING,
 			allowNull: false
 		},

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -143,6 +143,9 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.INTEGER,
 			defaultValue: null
 		},
+		nextRankXP: {
+			type: DataTypes.BIGINT,
+		},
 		lastShowcaseTimestamp: {
 			type: DataTypes.DATE
 		},

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -37,8 +37,8 @@ exports.Hunter = class extends Model {
 		const previousCompanyLevel = company.level;
 
 		this.xp += totalPoints;
-		this.seasonXP += totalPoints;
-		company.seasonXP += totalPoints;
+		const seasonParticipation = await database.models.seasonParticipation.findByPk(this.seasonParticipationId);
+		seasonParticipation.increment({ xp: totalPoints });
 
 		this.level = Math.floor(Math.sqrt(this.xp / company.xpCoefficient) + 1);
 		this.save();
@@ -122,9 +122,8 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
-		seasonXP: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
+		seasonParticipationId: {
+			type: DataTypes.UUID
 		},
 		isRankEligible: {
 			type: DataTypes.BOOLEAN,
@@ -137,10 +136,6 @@ exports.initModel = function (sequelize) {
 		lastRank: {
 			type: DataTypes.INTEGER,
 			defaultValue: null
-		},
-		seasonPlacement: {
-			type: DataTypes.INTEGER,
-			defaultValue: 0
 		},
 		lastShowcaseTimestamp: {
 			type: DataTypes.DATE
@@ -174,10 +169,6 @@ exports.initModel = function (sequelize) {
 			defaultValue: false
 		},
 		hasBeenBanned: {
-			type: DataTypes.BOOLEAN,
-			defaultValue: false
-		},
-		isRankDisqualified: { // Expires at end of season
 			type: DataTypes.BOOLEAN,
 			defaultValue: false
 		},

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -37,7 +37,13 @@ exports.Hunter = class extends Model {
 		const previousCompanyLevel = company.level;
 
 		this.xp += totalPoints;
-		const seasonParticipation = await database.models.seasonParticipation.findByPk(this.seasonParticipationId);
+		let seasonParticipation;
+		if (this.seasonParticipationId) {
+			seasonParticipation = await database.models.SeasonParticipation.findByPk(this.seasonParticipationId);
+		} else {
+			seasonParticipation = await database.models.SeasonParticipation.create({ seasonId: company.seasonId, companyId: company.id, userId: this.userId });
+			this.seasonParticipationId = seasonParticipation.id;
+		}
 		seasonParticipation.increment({ xp: totalPoints });
 
 		this.level = Math.floor(Math.sqrt(this.xp / company.xpCoefficient) + 1);

--- a/source/selects/bountyeditselect.js
+++ b/source/selects/bountyeditselect.js
@@ -8,7 +8,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Recieve bounty reconfigurations from the user */
 	(interaction, args) => {
 		const [slotNumber] = interaction.values;
-		database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+		database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
 			const eventStartComponent = new TextInputBuilder().setCustomId("startTimestamp")
 				.setLabel("Event Start (Unix Timestamp)")
 				.setRequired(false)

--- a/source/selects/bountyshowcase.js
+++ b/source/selects/bountyshowcase.js
@@ -6,15 +6,15 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Show the selected bounty's embed and record it's been showcased */
 	(interaction, args) => {
 		const [slotNumber] = interaction.values;
-		database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+		database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
 			bounty.increment("showcaseCount");
 			await bounty.save().then(bounty => bounty.reload());
-			const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
-			bounty.updatePosting(interaction.guild, guildProfile);
-			const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+			const company = await database.models.Company.findByPk(interaction.guildId);
+			bounty.updatePosting(interaction.guild, company);
+			const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 			hunter.lastShowcaseTimestamp = new Date();
 			hunter.save();
-			return bounty.asEmbed(interaction.guild, hunter.level, guildProfile.eventMultiplierString())
+			return bounty.asEmbed(interaction.guild, hunter.level, company.eventMultiplierString())
 		}).then(embed => {
 			interaction.reply({ content: `${interaction.member} increased the reward on their bounty!`, embeds: [embed] });
 		})

--- a/source/selects/bountyswapbounty.js
+++ b/source/selects/bountyswapbounty.js
@@ -9,17 +9,17 @@ const customId = "bountyswapbounty";
 module.exports = new InteractionWrapper(customId, 3000,
 	/** Recieve the bounty to swap and solicit the slot to swap to */
 	(interaction, args) => {
-		database.models.Hunter.findOne({ where: { guildId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
 			if (hunter.maxSlots() < 2) {
 				interaction.reply({ content: "You currently only have 1 bounty slot in this server.", ephemeral: true });
 				return;
 			}
 
-			const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, state: "open" } });
+			const existingBounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, companyId: interaction.guildId, state: "open" } });
 			const previousBountySlot = parseInt(interaction.values[0]);
-			const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+			const company = await database.models.Company.findByPk(interaction.guildId);
 			const slotOptions = [];
-			for (let i = 1; i <= hunter.maxSlots(guildProfile.maxSimBounties); i++) {
+			for (let i = 1; i <= hunter.maxSlots(company.maxSimBounties); i++) {
 				if (i != previousBountySlot) {
 					const existingBounty = existingBounties.find(bounty => bounty.slotNumber == i);
 					slotOptions.push(

--- a/source/selects/bountyswapslot.js
+++ b/source/selects/bountyswapslot.js
@@ -9,24 +9,24 @@ module.exports = new InteractionWrapper(customId, 3000,
 	async (interaction, [unparsedSourceSlot]) => {
 		const sourceSlot = parseInt(unparsedSourceSlot);
 		const destinationSlot = parseInt(interaction.values[0]);
-		const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+		const company = await database.models.Company.findByPk(interaction.guildId);
 
-		const bounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber: { [Op.in]: [sourceSlot, destinationSlot] }, state: "open" } });
+		const bounties = await database.models.Bounty.findAll({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber: { [Op.in]: [sourceSlot, destinationSlot] }, state: "open" } });
 		const sourceBounty = bounties.find(bounty => bounty.slotNumber == sourceSlot);
 		const destinationBounty = bounties.find(bounty => bounty.slotNumber == destinationSlot);
 		sourceBounty.slotNumber = destinationSlot;
 		await sourceBounty.save();
 		await sourceBounty.reload();
-		sourceBounty.updatePosting(interaction.guild, guildProfile);
+		sourceBounty.updatePosting(interaction.guild, company);
 
 		if (destinationBounty) {
 			destinationBounty.slotNumber = sourceSlot;
 			await destinationBounty.save();
 			await destinationBounty.reload();
-			destinationBounty.updatePosting(interaction.guild, guildProfile);
+			destinationBounty.updatePosting(interaction.guild, company);
 		}
 
-		const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } });
+		const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 		interaction.update({ components: [] });
 		interaction.channel.send(`${interaction.member}'s bounty, **${sourceBounty.title}** is now worth ${Bounty.calculateReward(hunter.level, destinationSlot, sourceBounty.showcaseCount)} XP.`);
 	}

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -12,7 +12,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 		bounty.save();
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
 		if (bounty.Company.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
+			const bountyBoard = await interaction.guild.channels.fetch(bounty.Company.bountyBoardId);
 			const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 			postingThread.delete("Bounty taken down by poster");
 		}

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -7,11 +7,11 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Take down the given bounty and completions */
 	async (interaction, args) => {
 		const [slotNumber] = interaction.values;
-		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" } });
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" }, include: database.models.Bounty.Company });
 		bounty.state = "deleted";
 		bounty.save();
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
-		if (company.bountyBoardId) {
+		if (bounty.Company.bountyBoardId) {
 			const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
 			const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 			postingThread.delete("Bounty taken down by poster");

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -7,21 +7,21 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Take down the given bounty and completions */
 	async (interaction, args) => {
 		const [slotNumber] = interaction.values;
-		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId, slotNumber, state: "open" } });
 		bounty.state = "deleted";
 		bounty.save();
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
-		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
-		guildProfile.decrement("seasonXP");
-		guildProfile.save();
-		if (guildProfile.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+		const company = await database.models.Company.findOne({ where: { id: interaction.guildId } });
+		company.decrement("seasonXP");
+		company.save();
+		if (company.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
 			const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 			postingThread.delete("Bounty taken down by poster");
 		}
 		bounty.destroy();
 
-		database.models.Hunter.findOne({ where: { userId: interaction.user.id, guildId: interaction.guildId } }).then(hunter => {
+		database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(hunter => {
 			hunter.decrement(["xp", "seasonXP"], { by: 1 });
 			getRankUpdates(interaction.guild);
 		})

--- a/source/selects/evergreeneditselect.js
+++ b/source/selects/evergreeneditselect.js
@@ -8,7 +8,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Recieve bounty reconfigurations from the user */
 	(interaction, args) => {
 		const [slotNumber] = interaction.values;
-		database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+		database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
 			interaction.showModal(
 				new ModalBuilder().setCustomId(`evergreeneditmodal${SAFE_DELIMITER}${slotNumber}`)
 					.setTitle(`Editing Bounty (${bounty.title})`)

--- a/source/selects/evergreenshowcase.js
+++ b/source/selects/evergreenshowcase.js
@@ -6,9 +6,9 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Show the evergreen bounty's embed again */
 	(interaction, args) => {
 		const [slotNumber] = interaction.values;
-		database.models.Bounty.findOne({ where: { isEvergreen: true, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
-			const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
-			return bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString());
+		database.models.Bounty.findOne({ where: { isEvergreen: true, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+			const company = await database.models.Company.findByPk(interaction.guildId);
+			return bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString());
 		}).then(embed => {
 			interaction.reply({ embeds: [embed] });
 		});

--- a/source/selects/evergreenswapbounty.js
+++ b/source/selects/evergreenswapbounty.js
@@ -9,8 +9,8 @@ const customId = "evergreenswapbounty";
 module.exports = new InteractionWrapper(customId, 3000,
 	/** Recieve the bounty to swap and solicit the slot to swap to */
 	(interaction, args) => {
-		database.models.Hunter.findOne({ where: { guildId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
-			const existingBounties = await database.models.Bounty.findAll({ where: { isEvergreen: true, guildId: interaction.guildId, state: "open" } });
+		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+			const existingBounties = await database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" } });
 			const previousBountySlot = parseInt(interaction.values[0]);
 			const slotOptions = [];
 			for (const bounty of existingBounties) {

--- a/source/selects/evergreenswapslot.js
+++ b/source/selects/evergreenswapslot.js
@@ -8,9 +8,9 @@ module.exports = new InteractionWrapper(customId, 3000,
 	async (interaction, [unparsedSourceSlot]) => {
 		const sourceSlot = parseInt(unparsedSourceSlot);
 		const destinationSlot = parseInt(interaction.values[0]);
-		const guildProfile = await database.models.Guild.findByPk(interaction.guildId);
+		const company = await database.models.Company.findByPk(interaction.guildId);
 
-		const evergreenBounties = await database.models.Bounty.findAll({ where: { isEvergreen: true, guildId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] });
+		const evergreenBounties = await database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] });
 		const sourceBounty = evergreenBounties.find(bounty => bounty.slotNumber == sourceSlot);
 		const destinationBounty = evergreenBounties.find(bounty => bounty.slotNumber == destinationSlot);
 		sourceBounty.slotNumber = destinationSlot;
@@ -19,19 +19,19 @@ module.exports = new InteractionWrapper(customId, 3000,
 		destinationBounty.slotNumber = sourceSlot;
 		await destinationBounty.save();
 
-		if (guildProfile.bountyBoardId) {
-			interaction.guild.channels.fetch(guildProfile.bountyBoardId).then(bountyBoard => {
-				bountyBoard.threads.fetch(guildProfile.evergreenThreadId).then(thread => {
+		if (company.bountyBoardId) {
+			interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
+				bountyBoard.threads.fetch(company.evergreenThreadId).then(thread => {
 					return thread.fetchStarterMessage();
 				}).then(async message => {
 					evergreenBounties.sort((bountyA, bountyB) => bountyA.slotNumber - bountyB.slotNumber);
-					message.edit({ embeds: await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString()))) });
+					message.edit({ embeds: await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString()))) });
 				});
 			})
 		}
 
 		interaction.update({ components: [] });
 		// Evergreen bounties are not eligible for showcase bonuses
-		interaction.channel.send(`Some evergreen bounties have been swapped, **${sourceBounty.title}** is now worth ${Bounty.calculateReward(guildProfile.level, destinationSlot, 0)} XP and **${destinationBounty.title}** is now worth ${Bounty.calculateReward(guildProfile.level, sourceSlot, 0)} XP.`);
+		interaction.channel.send(`Some evergreen bounties have been swapped, **${sourceBounty.title}** is now worth ${Bounty.calculateReward(company.level, destinationSlot, 0)} XP and **${destinationBounty.title}** is now worth ${Bounty.calculateReward(company.level, sourceSlot, 0)} XP.`);
 	}
 );

--- a/source/selects/evergreentakedown.js
+++ b/source/selects/evergreentakedown.js
@@ -6,27 +6,27 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Take down the given bounty and completions */
 	async (interaction, args) => {
 		const [slotNumber] = interaction.values;
-		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, guildId: interaction.guildId, slotNumber, state: "open" } });
+		const bounty = await database.models.Bounty.findOne({ where: { userId: interaction.client.user.id, companyId: interaction.guildId, slotNumber, state: "open" } });
 		bounty.state = "deleted";
 		bounty.save();
 		database.models.Completion.destroy({ where: { bountyId: bounty.id } });
-		const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
-		const evergreenBounties = await database.models.Bounty.findAll({ where: { guildId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
+		const company = await database.models.Company.findOne({ where: { id: interaction.guildId } });
+		const evergreenBounties = await database.models.Bounty.findAll({ where: { companyId: interaction.guildId, userId: interaction.client.user.id, state: "open" }, order: [["slotNumber", "ASC"]] });
 		if (evergreenBounties.length > 1) {
-			const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, guildProfile.level, guildProfile.eventMultiplierString())));
-			if (guildProfile.bountyBoardId) {
-				const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
-				bountyBoard.threads.fetch(guildProfile.evergreenThreadId).then(async thread => {
+			const embeds = await Promise.all(evergreenBounties.map(bounty => bounty.asEmbed(interaction.guild, company.level, company.eventMultiplierString())));
+			if (company.bountyBoardId) {
+				const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
+				bountyBoard.threads.fetch(company.evergreenThreadId).then(async thread => {
 					const message = await thread.fetchStarterMessage();
 					message.edit({ embeds });
 				});
 			}
-		} else if (guildProfile.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
-			bountyBoard.threads.fetch(guildProfile.evergreenThreadId).then(thread => {
+		} else if (company.bountyBoardId) {
+			const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
+			bountyBoard.threads.fetch(company.evergreenThreadId).then(thread => {
 				thread.delete(`Evergreen bounty taken down by ${interaction.member}`);
-				guildProfile.evergreenThreadId = null;
-				guildProfile.save();
+				company.evergreenThreadId = null;
+				company.save();
 			});
 		}
 		bounty.destroy();

--- a/source/selects/modtakedown.js
+++ b/source/selects/modtakedown.js
@@ -7,20 +7,20 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Take down specified bounty */
 	(interaction, [posterId]) => {
 		const slotNumber = interaction.values[0];
-		database.models.Bounty.findOne({ where: { userId: posterId, guildId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+		database.models.Bounty.findOne({ where: { userId: posterId, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
 			await database.models.Completion.destroy({ where: { bountyId: bounty.id } });
 			bounty.state = "deleted";
 			bounty.save();
-			const guildProfile = await database.models.Guild.findOne({ where: { id: interaction.guildId } });
-			guildProfile.decrement("seasonXP");
-			if (guildProfile.bountyBoardId) {
-				const bountyBoard = await interaction.guild.channels.fetch(guildProfile.bountyBoardId);
+			const company = await database.models.Company.findOne({ where: { id: interaction.guildId } });
+			company.decrement("seasonXP");
+			if (company.bountyBoardId) {
+				const bountyBoard = await interaction.guild.channels.fetch(company.bountyBoardId);
 				const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 				postingThread.delete("Bounty taken down by moderator");
 			}
 			bounty.destroy();
 
-			database.models.Hunter.findOne({ where: { userId: posterId, guildId: interaction.guildId } }).then(poster => {
+			database.models.Hunter.findOne({ where: { userId: posterId, companyId: interaction.guildId } }).then(poster => {
 				poster.decrement(["xp", "seasonXP"], { by: 1 })
 				getRankUpdates(interaction.guild);
 			})

--- a/source/selects/rafflerank.js
+++ b/source/selects/rafflerank.js
@@ -8,7 +8,8 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Given selected rank for raffle, randomly select eligible hunter */
 	(interaction, args) => {
 		const rankIndex = Number(interaction.values[0]);
-		database.models.Hunter.findAll({ where: { companyId: interaction.guildId, isRankEligible: true, isRankDisqualified: false, rank: { [Op.gte]: rankIndex } } }).then(eligibleHunters => {
+		database.models.Hunter.findAll({ where: { companyId: interaction.guildId, isRankEligible: true, rank: { [Op.gte]: rankIndex } }, include: database.models.Hunter.SeasonParticipation }).then(unvalidatedHunters => {
+			const eligibleHunters = unvalidatedHunters.filter(hunter => !hunter.isRankDisqualified);
 			if (eligibleHunters.length < 1) {
 				database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "ASC"]] }).then(ranks => {
 					const rank = ranks[rankIndex];

--- a/source/selects/rafflerank.js
+++ b/source/selects/rafflerank.js
@@ -8,7 +8,7 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Given selected rank for raffle, randomly select eligible hunter */
 	(interaction, args) => {
 		const rankIndex = Number(interaction.values[0]);
-		database.models.Hunter.findAll({ where: { companyId: interaction.guildId, isRankEligible: true, rank: { [Op.gte]: rankIndex } }, include: database.models.Hunter.SeasonParticipation }).then(unvalidatedHunters => {
+		database.models.Hunter.findAll({ where: { companyId: interaction.guildId, isRankEligible: true, rank: { [Op.gte]: rankIndex } } }).then(unvalidatedHunters => {
 			const eligibleHunters = unvalidatedHunters.filter(hunter => !hunter.isRankDisqualified);
 			if (eligibleHunters.length < 1) {
 				database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "ASC"]] }).then(ranks => {

--- a/source/selects/rafflerank.js
+++ b/source/selects/rafflerank.js
@@ -8,9 +8,9 @@ module.exports = new InteractionWrapper(customId, 3000,
 	/** Given selected rank for raffle, randomly select eligible hunter */
 	(interaction, args) => {
 		const rankIndex = Number(interaction.values[0]);
-		database.models.Hunter.findAll({ where: { guildId: interaction.guildId, isRankEligible: true, isRankDisqualified: false, rank: { [Op.gte]: rankIndex } } }).then(eligibleHunters => {
+		database.models.Hunter.findAll({ where: { companyId: interaction.guildId, isRankEligible: true, isRankDisqualified: false, rank: { [Op.gte]: rankIndex } } }).then(eligibleHunters => {
 			if (eligibleHunters.length < 1) {
-				database.models.GuildRank.findAll({ where: { guildId: interaction.guildId }, order: [["varianceThreshold", "ASC"]] }).then(ranks => {
+				database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "ASC"]] }).then(ranks => {
 					const rank = ranks[rankIndex];
 					interaction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above the rank ${rank.roleId ? `<@&${rank.rankId}>` : `Rank ${rankIndex + 1}`}).`, ephemeral: true });
 				});
@@ -18,8 +18,8 @@ module.exports = new InteractionWrapper(customId, 3000,
 			}
 			const winner = eligibleHunters[Math.floor(Math.random() * eligibleHunters.length)];
 			interaction.reply(`The winner of this raffle is: <@${winner.userId}>`);
-			database.models.Guild.findByPk(interaction.guildId).then(guildProfile => {
-				guildProfile.update("nextRaffleString", null);
+			database.models.Company.findByPk(interaction.guildId).then(company => {
+				company.update("nextRaffleString", null);
 			});
 		})
 	}


### PR DESCRIPTION
Summary
-------
- add Season and SeasonParticipation tables
- added nextRankXP, rank name, and previous season placements to /stats (self)
- rename Guild table to Company

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /toast
- [x] /scoreboard scoreboard-type: seasonal
- [x] /scoreboard scoreboard-type: overall
- [x] /stats (server)
- [x] /stats (self)
- [x] /stats (other)
- [x] /bounty take-down
- [x] /bounty complete
- [x] /evergreen complete
- [x] /moderation season-disqualify

Issue
-----
Closes #55