### PR TITLE
#82: Port `/next-season`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -15,6 +15,7 @@ exports.commandFiles = [
 	"raffle.js",
 	"rank.js",
 	"scoreboard.js",
+	"season-end.js",
 	"server-bonuses.js",
 	"stats.js",
 	"toast.js",

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -1,0 +1,29 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { getRankUpdates } = require('../helpers');
+const { buildCompanyStatsEmbed } = require('../embedHelpers');
+
+const customId = "season-end";
+const options = [];
+const subcommands = [];
+module.exports = new CommandWrapper(customId, "Start a new season for this server, resetting ranks and placements", PermissionFlagsBits.ManageGuild, false, false, 3000, options, subcommands,
+	/** End the Company's current season and start a new one */
+	async (interaction) => {
+		const company = await database.models.Company.findByPk(interaction.guildId);
+		if (!company) {
+			interaction.reply({ content: "This server hasn't used BountyBot yet, so it doesn't have a season to end.", ephemeral: true });
+			return;
+		}
+
+		buildCompanyStatsEmbed(interaction.guild).then(async embed => {
+			const newSeason = await database.models.Season.create({ companyId: company.id });
+			company.lastSeasonId = company.seasonId;
+			company.seasonId = newSeason.id;
+			company.save();
+			await database.models.Hunter.update({ seasonParticpationId: null, rank: null, lastRank: null, nextRankXP: null }, { where: { companyId: company.id } });
+			getRankUpdates(interaction.guild);
+			interaction.reply(company.sendAnnouncement({ content: "A new season has started, ranks and placements have been reset!", embeds: [embed] }));
+		})
+	}
+);

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -21,7 +21,7 @@ module.exports = new CommandWrapper(customId, "Start a new season for this serve
 			company.lastSeasonId = company.seasonId;
 			company.seasonId = newSeason.id;
 			company.save();
-			await database.models.Hunter.update({ seasonParticpationId: null, rank: null, lastRank: null, nextRankXP: null }, { where: { companyId: company.id } });
+			await database.models.Hunter.update({ seasonParticipationId: null, rank: null, lastRank: null, nextRankXP: null }, { where: { companyId: company.id } });
 			getRankUpdates(interaction.guild);
 			interaction.reply(company.sendAnnouncement({ content: "A new season has started, ranks and placements have been reset!", embeds: [embed] }));
 		})


### PR DESCRIPTION
Summary
-------
- ported `/next-season` as `/season-end`
- decided not to implement delay functionality in favor of scheduling functionality in the future (#87)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/season-end` creates a new season entity, resets Hunter stats, and reports correct stats for end of season

Issue
-----
Closes #82