### PR TITLE
#99: Port `/config-server`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -5,6 +5,7 @@ exports.commandFiles = [
 	"about.js",
 	"bounty.js",
 	"commands.js",
+	"config-server.js",
 	"create-default.js",
 	"data-policy.js",
 	"event.js",

--- a/source/commands/config-server.js
+++ b/source/commands/config-server.js
@@ -1,0 +1,50 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+
+const mainId = "config-server";
+const options = [
+	{
+		type: "String",
+		name: "notification",
+		description: "Configure who to send notifications to",
+		required: false,
+		choices: [
+			{ name: "Notify online members (@here)", value: "@here" },
+			{ name: "Notify all members (@everyone)", value: "@everyone" },
+			{ name: "No prefix", value: "(nothing)" },
+			{ name: "Suppress notifications (@silent)", value: "@silent" }
+		]
+	},
+	{
+		type: "Boolean",
+		name: "server-boost-xp",
+		description: "Configure whether boosting the server awards XP",
+		required: false
+	}
+];
+const subcommands = [];
+module.exports = new CommandWrapper(mainId, "Configure BountyBot settings for this server", PermissionFlagsBits.ManageGuild, false, false, 3000, options, subcommands,
+	(interaction) => {
+		const company = database.models.Company.findByPk(interaction.guildId).then(company => {
+
+			const updatePayload = {};
+			let content = "The following server settings have been configured:";
+
+			const prefix = interaction.options.getString(options[0].name);
+			if (prefix !== null) {
+				updatePayload.announcementPrefix = prefix === "(nothing)" ? "" : prefix;
+				content += `\n- The announcment prefix was set to ${prefix}`;
+			}
+
+			const shouldBoostXP = interaction.options.getBoolean(options[1].name);
+			if (shouldBoostXP !== null) {
+				updatePayload.disableBoostXP = !shouldBoostXP;
+				content += `\n- XP for Server Boosts has been ${shouldBoostXP ? "en" : "dis"}abled`;
+			}
+
+			company.update(updatePayload);
+			interaction.reply({ content, ephemeral: true });
+		});
+	}
+);


### PR DESCRIPTION
Summary
-------
- Port `/config-server`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] announcement prefix changes as expected
- [x] disable boost xp is changed in database as expected

Issue
-----
Closes #99