### PR TITLE
#103: Port `/reset`

### DIFF
--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -16,6 +16,7 @@ exports.commandFiles = [
 	"premium.js",
 	"raffle.js",
 	"rank.js",
+	"reset.js",
 	"scoreboard.js",
 	"season-end.js",
 	"server-bonuses.js",

--- a/source/commands/reset.js
+++ b/source/commands/reset.js
@@ -1,0 +1,46 @@
+const { PermissionFlagsBits } = require('discord.js');
+const { CommandWrapper } = require('../classes');
+const { database } = require('../../database');
+const { updateScoreboard } = require('../embedHelpers');
+
+const mainId = "reset";
+const options = [];
+const subcommands = [
+	{
+		name: "all-hunter-stats",
+		description: "IRREVERSIBLY reset all bounty hunter stats on this server",
+	},
+	{
+		name: "server-settings",
+		description: "IRREVERSIBLY return all server configs to default",
+	}
+];
+module.exports = new CommandWrapper(mainId, "Reset all bounty hunter stats, bounties, or server configs", PermissionFlagsBits.ManageGuild, false, false, 3000, options, subcommands,
+	(interaction) => {
+		switch (interaction.options.getSubcommand()) {
+			case subcommands[0].name: // all-hunter-stats
+				database.models.Hunter.destroy({ where: { companyId: interaction.guildId } });
+				interaction.reply({ content: "Resetting bounty hunter stats has begun.", ephemeral: true });
+				database.models.Company.findByPk(interaction.guildId).then(async company => {
+					await database.models.SeasonParticipation.destroy({ where: { seasonId: company.seasonId } });
+					updateScoreboard(company, interaction.guild);
+					interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
+				});
+				break;
+			case subcommands[1].name: // server-settings
+				database.models.Company.update(
+					{
+						announcementPrefix: "@here",
+						disableBoostXP: true,
+						maxSimBounties: 5,
+						backupTimer: 3600000,
+						eventMultiplier: 1,
+						xpCoefficient: 3
+					},
+					{ where: { id: interaction.guildId } }
+				);
+				interaction.reply({ content: "Server settings have been reset.", ephemeral: true });
+				break;
+		}
+	}
+);

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -26,32 +26,6 @@ exports.Company = class extends Model {
 		}
 		return messageOptions;
 	}
-
-	// /** Build the list of rewards
-	// * @param {string} guildId
-	// * @param {number} characterLimit
-	// * @returns {string}
-	// */
-	// rewardStringBuilder(characterLimit = 1024) {
-	// 	let overflowText = "...and more";
-	// 	characterLimit -= overflowText.length;
-	// 	let rewardString = "";
-	// 	if (rewards.length == 0) {
-	// 		rewardString += "There are no rewards posted (yet).";
-	// 	} else {
-	// 		for (let i = 0; i < this.rewards.length; i += 1) {
-	// 			let singleReward = `__${i + 1}__: ${this.rewards[i]}\n`;
-	// 			if (characterLimit - singleReward.length > 0) {
-	// 				rewardString += singleReward;
-	// 				characterLimit -= singleReward.length;
-	// 			} else {
-	// 				rewardString += overflowText;
-	// 				break;
-	// 			}
-	// 		}
-	// 	}
-	// 	return rewardString;
-	// }
 }
 
 exports.initModel = function (sequelize) {
@@ -86,6 +60,14 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BIGINT,
 			defaultValue: 3600000
 		},
+		eventMultiplier: {
+			type: DataTypes.INTEGER,
+			defaultValue: 1
+		},
+		xpCoefficient: {
+			type: DataTypes.INTEGER,
+			defaultValue: 3
+		},
 		bountyBoardId: {
 			type: DataTypes.STRING
 		},
@@ -103,14 +85,6 @@ exports.initModel = function (sequelize) {
 		},
 		nextRaffleString: {
 			type: DataTypes.STRING
-		},
-		eventMultiplier: {
-			type: DataTypes.INTEGER,
-			defaultValue: 1
-		},
-		xpCoefficient: {
-			type: DataTypes.INTEGER,
-			defaultValue: 3
 		},
 		seasonId: {
 			type: DataTypes.UUID


### PR DESCRIPTION
Summary
-------
- port `/reset`
- decided `/reset all-bounties` was not part of MVP
- removed rewards code draft

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/reset server-settings` resets the Company's settings
- [x] `/reset all-hunter-stats` resets Hunters and SeasonParticpations

Issue
-----
Closes #103