### PR TITLE
#91: improve model definitions

### DIFF
--- a/database.js
+++ b/database.js
@@ -30,7 +30,6 @@ exports.database.authenticate().then(() => {
 	initSeason(exports.database);
 	initSeasonParticipation(exports.database);
 
-	//TODO #91 prune associations (not all references need to be associations)
 	Company.CompanyRanks = Company.hasMany(CompanyRank, {
 		foreignKey: "companyId"
 	});
@@ -129,11 +128,25 @@ exports.database.authenticate().then(() => {
 		foreignKey: "companyId"
 	})
 
-	Hunter.SeasonParticipation = Hunter.belongsTo(SeasonParticpation, {
-		foreignKey: "seasonParticipationId"
+	User.SeasonParticipations = User.hasMany(SeasonParticpation, {
+		foreignKey: "userId"
 	})
-	SeasonParticpation.Hunter = SeasonParticpation.hasOne(Hunter, {
-		foreignKey: "seasonParticipationId"
+	SeasonParticpation.User = SeasonParticpation.belongsTo(User, {
+		foreignKey: "userId"
+	})
+
+	Company.SeasonParticipations = Company.hasMany(SeasonParticpation, {
+		foreignKey: "companyId"
+	})
+	SeasonParticpation.Company = SeasonParticpation.belongsTo(Company, {
+		foreignKey: "companyId"
+	})
+
+	Season.SeasonParticipations = Season.hasMany(SeasonParticpation, {
+		foreignKey: "seasonId"
+	})
+	SeasonParticpation.Season = SeasonParticpation.belongsTo(Season, {
+		foreignKey: "seasonId"
 	})
 
 	exports.database.sync();

--- a/database.js
+++ b/database.js
@@ -122,17 +122,11 @@ exports.database.authenticate().then(() => {
 		foreignKey: "seconderId"
 	});
 
-	Company.Season = Company.belongsTo(Season, {
-		foreignKey: "seasonId"
+	Season.Company = Season.belongsTo(Company, {
+		foreignKey: "companyId"
 	})
-	Season.Company = Season.hasOne(Company, {
-		foreignKey: "seasonId"
-	})
-	Company.LastSeason = Company.belongsTo(Season, {
-		foreignKey: "lastSeasonId"
-	})
-	Season.Company = Season.hasOne(Company, {
-		foreignKey: "lastSeasonId"
+	Company.Seasons = Company.hasMany(Season, {
+		foreignKey: "companyId"
 	})
 
 	Hunter.SeasonParticipation = Hunter.belongsTo(SeasonParticpation, {

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -29,7 +29,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		seconder.toastSeconded++;
 
 		const recipientIds = originalToast.ToastRecipients.map(reciept => reciept.recipientId);
-		recipientIds.push(originalToast.userId);
+		recipientIds.push(originalToast.senderId);
 		const levelTexts = [];
 		for (const userId of recipientIds) {
 			if (userId != interaction.user.id) {
@@ -49,7 +49,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}
 		}
 
-		const lastFiveToasts = await database.models.Toast.findAll({ where: { companyId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
+		const lastFiveToasts = await database.models.Toast.findAll({ where: { companyId: interaction.guildId, senderId: interaction.user.id }, include: database.models.Toast.ToastRecipients, order: [["createdAt", "DESC"]], limit: 5 });
 		const staleToastees = lastFiveToasts.reduce((list, toast) => {
 			return list.concat(toast.ToastRecipients.filter(reciept => reciept.isRewarded).map(recipient => recipient.userId));
 		}, []);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -9,7 +9,7 @@ const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Provide each recipient of a toast an extra XP, roll crit toast for author, and update embed */
 	async (interaction, [toastId]) => {
-		const originalToast = await database.models.Toast.findByPk(toastId);
+		const originalToast = await database.models.Toast.findByPk(toastId, { include: database.models.Toast.ToastRecipients });
 		if (originalToast.userId == interaction.user.id) {
 			interaction.reply({ content: "You cannot second your own toast.", ephemeral: true });
 			return;
@@ -28,7 +28,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		});
 		seconder.toastSeconded++;
 
-		const recipientIds = (await originalToast.recipients).map(reciept => reciept.recipientId);
+		const recipientIds = originalToast.ToastRecipients.map(reciept => reciept.recipientId);
 		recipientIds.push(originalToast.userId);
 		const levelTexts = [];
 		for (const userId of recipientIds) {
@@ -50,9 +50,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		const lastFiveToasts = await database.models.Toast.findAll({ where: { companyId: interaction.guildId, senderId: interaction.user.id }, order: [["createdAt", "DESC"]], limit: 5 });
-		const staleToastees = await lastFiveToasts.reduce(async (list, toast) => {
-			return (await list).concat((await toast.rewardedRecipients).map(recipient => recipient.userId));
-		}, new Promise((resolve) => resolve([])));
+		const staleToastees = lastFiveToasts.reduce((list, toast) => {
+			return list.concat(toast.ToastRecipients.filter(reciept => reciept.isRewarded).map(recipient => recipient.userId));
+		}, []);
 
 		const wasCrit = false;
 		if (critSecondsAvailable > 0) {

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -101,7 +101,7 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 		let slotNumber;
 		switch (interaction.options.getSubcommand()) {
 			case subcommands[0].name: // post
-				database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season }).then(async ([{ maxSimBounties }]) => {
+				database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
 					const userId = interaction.user.id;
 					const [hunter] = await database.models.Hunter.findOrCreate({
 						where: { userId, companyId: interaction.guildId },
@@ -328,7 +328,7 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 					// poster guaranteed to exist, creating a bounty gives 1 XP
 					const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 					const company = await database.models.Company.findByPk(interaction.guildId);
-					const season = await database.models.Season.findByPk(company.seasonId);
+					const season = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 					const bountyValue = Bounty.calculateReward(poster.level, slotNumber, bounty.showcaseCount) * company.eventMultiplier;
 
 					const allCompleterIds = (await database.models.Completion.findAll({ where: { bountyId: bounty.id } })).map(reciept => reciept.userId);

--- a/source/commands/config-server.js
+++ b/source/commands/config-server.js
@@ -26,7 +26,7 @@ const options = [
 const subcommands = [];
 module.exports = new CommandWrapper(mainId, "Configure BountyBot settings for this server", PermissionFlagsBits.ManageGuild, false, false, 3000, options, subcommands,
 	(interaction) => {
-		database.models.Company.findByPk(interaction.guildId).then(company => {
+		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
 			const updatePayload = {};
 			let content = "The following server settings have been configured:";
 

--- a/source/commands/create-default.js
+++ b/source/commands/create-default.js
@@ -57,7 +57,7 @@ module.exports = new CommandWrapper(mainId, "Create a Discord resource for use b
 					defaultForumLayout: ForumLayoutType.ListView,
 					reason: `/create-default bounty-board-forum by ${interaction.user}`
 				}).then(async bountyBoard => {
-					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
+					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 
 					company.bountyBoardId = bountyBoard.id;
 
@@ -111,7 +111,7 @@ module.exports = new CommandWrapper(mainId, "Create a Discord resource for use b
 					],
 					reason: `/create-default scoreboard-reference by ${interaction.user}`
 				}).then(async scoreboard => {
-					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
+					const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 					const isSeasonal = interaction.options.getString("scoreboard-type") == "season";
 					scoreboard.send({
 						embeds: [await buildScoreboardEmbed(interaction.guild, isSeasonal)]
@@ -164,7 +164,7 @@ module.exports = new CommandWrapper(mainId, "Create a Discord resource for use b
 					const varianceThresholds = [2.5, 1, 0, -3];
 					const rankmojis = ["🏆", "🥇", "🥈", "🥉"];
 
-					database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season }).then(() => {
+					database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(() => {
 						database.models.CompanyRank.bulkCreate(roles.map((role, index) => ({
 							companyId: interaction.guildId,
 							varianceThreshold: varianceThresholds[index],

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -116,7 +116,7 @@ module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed a
 							}
 						}
 
-						const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
+						const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 						const bounty = await database.models.Bounty.create(rawBounty);
 
 						// post in bounty board forum

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -241,7 +241,7 @@ module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed a
 					}
 
 					const company = await database.models.Company.findByPk(interaction.guildId);
-					const season = await database.models.Season.findByPk(company.seasonId);
+					const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 
 					const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
 

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -138,13 +138,9 @@ module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed a
 								}).then(thread => {
 									bounty.postingId = thread.id;
 									bounty.save()
-								}).catch(error => {
-									if (error.code == 10003) {
-										interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
-									} else {
-										throw error;
-									}
-								})
+								});
+							} else {
+								interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
 							}
 						});
 					}).catch(console.error)

--- a/source/commands/moderation.js
+++ b/source/commands/moderation.js
@@ -99,7 +99,9 @@ module.exports = new CommandWrapper(mainId, "BountyBot moderation tools", Permis
 				break;
 			case subcommands[1].name: // disqualify
 				member = interaction.options.getMember("bounty-hunter");
-				database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } }).then(async ([season]) => {
+				database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(async () => {
+					const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+					await database.models.User.findOrCreate({ where: { id: member.id } });
 					const [seasonParticipation, participationCreated] = await database.models.SeasonParticipation.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { isRankDisqualified: true } });
 					if (!participationCreated) {
 						seasonParticipation.isRankDisqualified = !seasonParticipation.isRankDisqualified;

--- a/source/commands/moderation.js
+++ b/source/commands/moderation.js
@@ -109,8 +109,8 @@ module.exports = new CommandWrapper(mainId, "BountyBot moderation tools", Permis
 						seasonParticipation.increment("dqCount");
 					}
 					getRankUpdates(interaction.guild);
-					interaction.reply({ content: `<@${member.id}> has been ${isDisqualification ? "dis" : "re"}qualified for achieving ranks this season.`, ephemeral: true });
-					member.send(`You have been ${isDisqualification ? "dis" : "re"}qualified for season ranks this season by ${interaction.member}. The reason provided was: ${interaction.options.getString("reason")}`);
+					interaction.reply({ content: `<@${member.id}> has been ${seasonParticipation.isRankDisqualified ? "dis" : "re"}qualified for achieving ranks this season.`, ephemeral: true });
+					member.send(`You have been ${seasonParticipation.isRankDisqualified ? "dis" : "re"}qualified for season ranks this season by ${interaction.member}. The reason provided was: ${interaction.options.getString("reason")}`);
 				});
 				break;
 			case subcommands[2].name: // penalty

--- a/source/commands/moderation.js
+++ b/source/commands/moderation.js
@@ -100,14 +100,13 @@ module.exports = new CommandWrapper(mainId, "BountyBot moderation tools", Permis
 			case subcommands[1].name: // disqualify
 				member = interaction.options.getMember("bounty-hunter");
 				database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } }).then(async ([season]) => {
-					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId }, defaults: { isRankEligible: member.manageable, User: { id: member.id } }, include: database.models.Hunter.User }); //TODO #110 crashes if user already exists, but hunter doesn't
 					const [seasonParticipation, participationCreated] = await database.models.SeasonParticipation.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { isRankDisqualified: true } });
 					if (!participationCreated) {
 						seasonParticipation.isRankDisqualified = !seasonParticipation.isRankDisqualified;
 						seasonParticipation.save();
 					}
 					if (participationCreated || seasonParticipation.isRankDisqualified) {
-						hunter.increment("seasonDQCount");
+						seasonParticipation.increment("dqCount");
 					}
 					getRankUpdates(interaction.guild);
 					interaction.reply({ content: `<@${member.id}> has been ${isDisqualification ? "dis" : "re"}qualified for achieving ranks this season.`, ephemeral: true });

--- a/source/commands/reset.js
+++ b/source/commands/reset.js
@@ -22,7 +22,10 @@ module.exports = new CommandWrapper(mainId, "Reset all bounty hunter stats, boun
 				database.models.Hunter.destroy({ where: { companyId: interaction.guildId } });
 				interaction.reply({ content: "Resetting bounty hunter stats has begun.", ephemeral: true });
 				database.models.Company.findByPk(interaction.guildId).then(async company => {
-					await database.models.SeasonParticipation.destroy({ where: { seasonId: company.seasonId } });
+					const season = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+					if (season) {
+						await database.models.SeasonParticipation.destroy({ where: { seasonId: season.id } });
+					}
 					updateScoreboard(company, interaction.guild);
 					interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
 				});

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -29,7 +29,7 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				endingSeason.save();
 			}
 			await database.models.Season.create({ companyId: interaction.guildId });
-			await database.models.Hunter.update({ seasonParticipationId: null, rank: null, lastRank: null, nextRankXP: null }, { where: { companyId: company.id } });
+			await database.models.Hunter.update({ rank: null, lastRank: null, nextRankXP: null }, { where: { companyId: company.id } });
 			getRankUpdates(interaction.guild);
 			interaction.reply(company.sendAnnouncement({ content: "A new season has started, ranks and placements have been reset!", embeds: [embed] }));
 		})

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -40,7 +40,8 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 					const { xpCoefficient } = await database.models.Company.findByPk(interaction.guildId);
 					const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 					const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
-					const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { id: { [Op.not]: hunter.seasonParticipationId }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
+					const currentSeason = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+					const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { seasonId: { [Op.not]: currentSeason.id }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
 					const ranks = await database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] });
 					const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 
@@ -81,7 +82,8 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 				const currentLevelThreshold = Hunter.xpThreshold(hunter.level, xpCoefficient);
 				const nextLevelThreshold = Hunter.xpThreshold(hunter.level + 1, xpCoefficient);
 				const bountySlots = hunter.maxSlots(maxSimBounties);
-				const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { id: { [Op.not]: hunter.seasonParticipationId }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
+				const currentSeason = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+				const previousSeasonParticipations = await database.models.SeasonParticipation.findAll({ where: { seasonId: { [Op.not]: currentSeason.id }, userId: hunter.userId, companyId: hunter.companyId }, order: [["createdAt", "DESC"]] });
 				const ranks = await database.models.CompanyRank.findAll({ where: { companyId: interaction.guildId }, order: [["varianceThreshold", "DESC"]] });
 				const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -117,8 +117,8 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		let rewardedRecipients = [];
 		let critValue = 0;
 		//TODO #96 combine fetch and toastsRaised increment with upsert?
-		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId }, defaults: { Season: { companyId: interaction.guildId } }, include: database.models.Company.Season });
-		const season = await database.models.Season.findByPk(company.seasonId);
+		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 		season.increment("toastsRaised");
 		const [sender] = await database.models.Hunter.findOrCreate({
 			where: { userId: interaction.user.id, companyId: interaction.guildId },

--- a/source/constants.js
+++ b/source/constants.js
@@ -1,5 +1,5 @@
-exports.authPath = "../config/auth.json";
-const { testGuildId, feedbackChannelId } = require(exports.authPath);
+const authPath = "../config/auth.json";
+const { testGuildId, feedbackChannelId } = require(authPath);
 const { announcementsChannelId, lastPostedVersion } = require("../config/versionData.json");
 
 module.exports = {
@@ -14,6 +14,7 @@ module.exports = {
 	MAX_EMBED_TITLE_LENGTH: 256,
 
 	// Config
+	authPath,
 	testGuildId,
 	feedbackChannelId,
 	announcementsChannelId,

--- a/source/embedHelpers.js
+++ b/source/embedHelpers.js
@@ -84,10 +84,10 @@ async function buildSeasonalScoreboardEmbed(guild) {
 	const hunterMembers = await guild.members.fetch({ user: participations.map(participation => participation.userId) });
 	const rankmojiArray = (await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] })).map(rank => rank.rankmoji);
 
-	const scorelines = participations.map(async participation => {
+	const scorelines = await Promise.all(participations.map(async participation => {
 		const hunter = await participation.hunter;
 		return `${hunter.rank ? `${rankmojiArray[hunter.rank]} ` : ""}#${participation.placement} **${hunterMembers.get(participation.userId).displayName}** __Level ${hunter.level}__ *${participation.xp} season XP*`;
-	});
+	}));
 	let description = "";
 	const andMore = "…and more";
 	const maxDescriptionLength = 2048 - andMore.length;

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -210,11 +210,11 @@ async function calculateRanks(seasonId, allHunters, ranks) {
  * @returns an array of rank and placement update strings
  */
 async function getRankUpdates(guild) {
-	const [company] = await database.models.Company.findOrCreate({ where: { id: guild.id }, defaults: { Season: { companyId: guild.id } }, include: database.models.Company.Season });
+	const season = await database.models.Season.findOrCreate({ where: { companyId: guild.id, isCurrentSeason: true } });
 	const ranks = await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] });
 	const allHunters = await database.models.Hunter.findAll({ where: { companyId: guild.id } });
 
-	return calculateRanks(company.seasonId, allHunters, ranks).then(async (firstPlaceMessage) => {
+	return calculateRanks(season.id, allHunters, ranks).then(async (firstPlaceMessage) => {
 		const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);
 		const outMessages = [];
 		if (firstPlaceMessage) {
@@ -227,7 +227,7 @@ async function getRankUpdates(guild) {
 			}
 		}
 		const updatedMembers = await guild.members.fetch({ user: userIdsWithChangedRanks });
-		const updatedParticipationsMap = (await database.models.SeasonParticipation.findAll({ where: { seasonId: company.seasonId, userId: { [Op.in]: userIdsWithChangedRanks } }, include: database.models.SeasonParticipation.Hunter }))
+		const updatedParticipationsMap = (await database.models.SeasonParticipation.findAll({ where: { seasonId: season.id, userId: { [Op.in]: userIdsWithChangedRanks } }, include: database.models.SeasonParticipation.Hunter }))
 			.reduce((map, participation) => {
 				map[participation.userId] = participation;
 				return map;

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -227,7 +227,7 @@ async function getRankUpdates(guild) {
 			}
 		}
 		const updatedMembers = await guild.members.fetch({ user: userIdsWithChangedRanks });
-		const updatedParticipationsMap = (await database.models.SeasonParticipation.findAll({ where: { seasonId: season.id, userId: { [Op.in]: userIdsWithChangedRanks } }, include: database.models.SeasonParticipation.Hunter }))
+		const updatedParticipationsMap = (await database.models.SeasonParticipation.findAll({ where: { seasonId: season.id, userId: { [Op.in]: userIdsWithChangedRanks } } }))
 			.reduce((map, participation) => {
 				map[participation.userId] = participation;
 				return map;
@@ -236,7 +236,7 @@ async function getRankUpdates(guild) {
 			if (member.manageable) {
 				await member.roles.remove(roleIds);
 				const participation = updatedParticipationsMap[member.id];
-				if (participation.Hunter.isRankEligible && !participation.isRankDisqualified) { // Feature: remove rank roles from DQ'd users but don't give them new ones
+				if ((await participation.hunter).isRankEligible && !participation.isRankDisqualified) { // Feature: remove rank roles from DQ'd users but don't give them new ones
 					let destinationRole;
 					const rankRoleId = ranks[hunter.rank]?.roleId;
 					if (rankRoleId) {

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -244,7 +244,7 @@ async function getRankUpdates(guild) {
 						destinationRole = await guild.roles.fetch(rankRoleId);
 					}
 					if (destinationRole && hunter.rank < hunter.lastRank) { // Note: higher ranks are lower value
-						outMessages.push(`${exports.congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole.name}!`);
+						outMessages.push(`${congratulationBuilder()}, ${member.toString()}! You've risen to ${destinationRole.name}!`);
 					}
 				}
 			}

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -210,7 +210,7 @@ async function calculateRanks(seasonId, allHunters, ranks) {
  * @returns an array of rank and placement update strings
  */
 async function getRankUpdates(guild) {
-	const season = await database.models.Season.findOrCreate({ where: { companyId: guild.id, isCurrentSeason: true } });
+	const [season] = await database.models.Season.findOrCreate({ where: { companyId: guild.id, isCurrentSeason: true } });
 	const ranks = await database.models.CompanyRank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] });
 	const allHunters = await database.models.Hunter.findAll({ where: { companyId: guild.id } });
 

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -85,12 +85,6 @@ exports.initModel = function (sequelize) {
 		},
 		nextRaffleString: {
 			type: DataTypes.STRING
-		},
-		seasonId: {
-			type: DataTypes.UUID
-		},
-		lastSeasonId: {
-			type: DataTypes.UUID
 		}
 	}, {
 		sequelize,

--- a/source/models/seasons/Season.js
+++ b/source/models/seasons/Season.js
@@ -13,6 +13,14 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.STRING,
 			allowNull: false
 		},
+		isCurrentSeason: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: true,
+		},
+		isPreviousSeason: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false,
+		},
 		totalXP: {
 			type: DataTypes.VIRTUAL,
 			async get() {

--- a/source/models/seasons/SeasonParticipation.js
+++ b/source/models/seasons/SeasonParticipation.js
@@ -19,6 +19,12 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.UUID,
 			allowNull: false
 		},
+		hunter: {
+			type: DataTypes.VIRTUAL,
+			async get() {
+				return await sequelize.models.Hunter.findOne({ where: { userId: this.userId, companyId: this.companyId } });
+			}
+		},
 		isRankDisqualified: {
 			type: DataTypes.BOOLEAN,
 			defaultValue: false

--- a/source/models/seasons/SeasonParticipation.js
+++ b/source/models/seasons/SeasonParticipation.js
@@ -36,6 +36,10 @@ exports.initModel = function (sequelize) {
 		placement: {
 			type: DataTypes.INTEGER,
 			defaultValue: 0
+		},
+		dqCount: {
+			type: DataTypes.INTEGER,
+			defaultValue: 0
 		}
 	}, {
 		sequelize,

--- a/source/models/seasons/SeasonParticipation.js
+++ b/source/models/seasons/SeasonParticipation.js
@@ -4,20 +4,18 @@ exports.SeasonParticpation = class extends Model { }
 
 exports.initModel = function (sequelize) {
 	exports.SeasonParticpation.init({
-		id: {
-			primaryKey: true,
-			type: DataTypes.UUID,
-			defaultValue: DataTypes.UUIDV4
-		},
 		userId: {
+			primaryKey: true,
 			type: DataTypes.STRING,
 			allowNull: false
 		},
 		companyId: {
+			primaryKey: true,
 			type: DataTypes.STRING,
 			allowNull: false
 		},
 		seasonId: {
+			primaryKey: true,
 			type: DataTypes.UUID,
 			allowNull: false
 		},

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -18,18 +18,6 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.STRING,
 			allowNull: false
 		},
-		recipients: {
-			type: DataTypes.VIRTUAL,
-			async get() {
-				return await sequelize.models.ToastRecipient.findAll({ where: { toastId: this.id } });
-			}
-		},
-		rewardedRecipients: {
-			type: DataTypes.VIRTUAL,
-			async get() {
-				return await sequelize.models.ToastRecipient.findAll({ where: { toastId: this.id, isRewarded: true } });
-			}
-		},
 		text: {
 			type: DataTypes.STRING,
 			allowNull: false

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -41,7 +41,8 @@ exports.Hunter = class extends Model {
 		if (this.seasonParticipationId) {
 			seasonParticipation = await database.models.SeasonParticipation.findByPk(this.seasonParticipationId);
 		} else {
-			seasonParticipation = await database.models.SeasonParticipation.create({ seasonId: company.seasonId, companyId: company.id, userId: this.userId });
+			const [season] = await database.models.Season.findOrCreate({ where: { companyId: guild.id, isCurrentSeason: true } });
+			seasonParticipation = await database.models.SeasonParticipation.create({ seasonId: season.id, companyId: guild.id, userId: this.userId });
 			this.seasonParticipationId = seasonParticipation.id;
 		}
 		seasonParticipation.increment({ xp: totalPoints });

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -175,10 +175,6 @@ exports.initModel = function (sequelize) {
 			type: DataTypes.BOOLEAN,
 			defaultValue: false
 		},
-		seasonDQCount: {
-			type: DataTypes.BIGINT,
-			defaultValue: 0
-		},
 		penaltyCount: {
 			type: DataTypes.BIGINT,
 			defaultValue: 0

--- a/source/selects/bountypost.js
+++ b/source/selects/bountypost.js
@@ -154,13 +154,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 					}).then(posting => {
 						bounty.postingId = posting.id;
 						bounty.save()
-					}).catch(error => {
-						if (error.code == 10003) {
-							modalSubmission.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
-						} else {
-							throw error;
-						}
-					})
+					});
+				} else {
+					interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
 				}
 			});
 		}).catch(console.error);

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -20,19 +20,10 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 		database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
 			hunter.decrement("xp");
-			if (hunter.seasonParticipationId) {
-				const seasonParticipation = await database.models.SeasonParticipation.findByPk(hunter.seasonParticipationId)
+			const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+			const [seasonParticipation, participationCreated] = await database.models.SeasonParticipation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });
+			if (!participationCreated) {
 				seasonParticipation.decrement("xp");
-			} else {
-				const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
-				const seasonParticpation = await database.models.SeasonParticipation.create({
-					userId: hunter.userId,
-					companyId: interaction.guildId,
-					seasonId: season.id,
-					xp: -1
-				});
-				hunter.seasonParticipationId = seasonParticpation.id;
-				hunter.save();
 			}
 			getRankUpdates(interaction.guild);
 		})

--- a/source/selects/bountytakedown.js
+++ b/source/selects/bountytakedown.js
@@ -24,11 +24,11 @@ module.exports = new SelectWrapper(mainId, 3000,
 				const seasonParticipation = await database.models.SeasonParticipation.findByPk(hunter.seasonParticipationId)
 				seasonParticipation.decrement("xp");
 			} else {
-				const company = await database.models.Company.findOne({ where: { id: interaction.guildId } });
+				const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 				const seasonParticpation = await database.models.SeasonParticipation.create({
 					userId: hunter.userId,
-					companyId: company.id,
-					seasonId: company.seasonId,
+					companyId: interaction.guildId,
+					seasonId: season.id,
 					xp: -1
 				});
 				hunter.seasonParticipationId = seasonParticpation.id;

--- a/source/selects/modtakedown.js
+++ b/source/selects/modtakedown.js
@@ -25,11 +25,11 @@ module.exports = new SelectWrapper(mainId, 3000,
 					const seasonParticipation = await database.models.SeasonParticipation.findByPk(poster.seasonParticipationId)
 					seasonParticipation.decrement("xp");
 				} else {
-					const company = await database.models.Company.findOne({ where: { id: interaction.guildId } });
+					const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 					const seasonParticpation = await database.models.SeasonParticipation.create({
 						userId: poster.userId,
-						companyId: company.id,
-						seasonId: company.seasonId,
+						companyId: interaction.guildId,
+						seasonId: season.id,
 						xp: -1
 					});
 					poster.seasonParticipationId = seasonParticpation.id;


### PR DESCRIPTION
Summary
-------
- resolve circular association between Company and Season (by removing `Company.seasonId` and `Company.lastSeasonId`)
- replace `Hunter.seasonParticipationId` with more detailed queries
- replace `Toast.recipeients` and `Toast.rewardedRecipient` virtuals with associations
- move `Hunter.seasonDQCount` to `SeasonParticipation.dqCount`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] toast's calculation of rewarded recipients still works properly
- [x] seconding toasts still work properly
- [x] tested /bounty complete
- [x] tested /evergreen complete
- [x] tested /moderation disqualify
- [x] tested /moderation penalty
- [x] tested /season-end
- [x] tested /stats (other)
- [x] tested /stats (self)
- [x] tested seasonal scoreboard
- [x] tested /bounty take-down
- [x] tested /moderation take-down

Issue
-----
Closes #91