### PR TITLE
#110: fix crash if creating Hunter if associated User already exists

### DIFF
--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -21,10 +21,10 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
+		await database.models.User.findOrCreate({ id: interaction.user.id });
 		const [seconder] = await database.models.Hunter.findOrCreate({
 			where: { userId: interaction.user.id, companyId: interaction.guildId },
-			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },
-			include: database.models.Hunter.User //TODO #110 crashes if user already exists, but hunter doesn't
+			defaults: { isRankEligible: interaction.member.manageable }
 		});
 		seconder.toastSeconded++;
 

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -103,10 +103,10 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 			case subcommands[0].name: // post
 				database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(async ([{ maxSimBounties }]) => {
 					const userId = interaction.user.id;
+					await database.models.User.findOrCreate({ where: { id: userId } });
 					const [hunter] = await database.models.Hunter.findOrCreate({
 						where: { userId, companyId: interaction.guildId },
-						defaults: { isRankEligible: interaction.member.manageable, User: { id: userId } },
-						include: database.models.Hunter.User //TODO #110 crashes if user already exists, but hunter doesn't
+						defaults: { isRankEligible: interaction.member.manageable }
 					});
 					const existingBounties = await database.models.Bounty.findAll({ where: { userId, companyId: interaction.guildId, state: "open" } });
 					const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
@@ -248,10 +248,10 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 					for (const member of completerMembers) {
 						const memberId = member.id;
 						if (!existingCompleterIds.includes(memberId)) {
+							await database.models.User.findOrCreate({ where: { id: memberId } });
 							const [hunter] = await database.models.Hunter.findOrCreate({
 								where: { userId: memberId, companyId: interaction.guildId },
-								defaults: { isRankEligible: member.manageable, User: { id: memberId } },
-								include: database.models.Hunter.User  //TODO #110 crashes if user already exists, but hunter doesn't
+								defaults: { isRankEligible: member.manageable }
 							});
 							if (hunter.isBanned) {
 								bannedIds.push(memberId);
@@ -347,10 +347,10 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 					for (const member of completerMembers) {
 						if (!member.user.bot) {
 							const memberId = member.id;
+							await database.models.User.findOrCreate({ where: { id: memberId } });
 							const [hunter] = await database.models.Hunter.findOrCreate({
 								where: { userId: memberId, companyId: interaction.guildId },
-								defaults: { isRankEligible: member.manageable, User: { id: memberId } },
-								include: database.models.Hunter.User //TODO #110 crashes if user already exists, but hunter doesn't
+								defaults: { isRankEligible: member.manageable }
 							});
 							if (!hunter.isBanned) {
 								validatedCompleterIds.push(memberId);

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -259,10 +259,10 @@ module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed a
 					for (const member of completerMembers) {
 						if (!member.user.bot) {
 							const memberId = member.id;
+							await database.models.User.findOrCreate({ where: { id: memberId } });
 							const [hunter] = await database.models.Hunter.findOrCreate({
 								where: { userId: memberId, companyId: interaction.guildId },
-								defaults: { isRankEligible: member.manageable, User: { id: memberId } },
-								include: database.models.Hunter.User //TODO #110 crashes if user already exists, but hunter doesn't
+								defaults: { isRankEligible: member.manageable }
 							});
 							if (!hunter.isBanned) {
 								validatedCompleterIds.push(memberId);

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -121,10 +121,10 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 		const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 		season.increment("toastsRaised");
+		await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
 		const [sender] = await database.models.Hunter.findOrCreate({
 			where: { userId: interaction.user.id, companyId: interaction.guildId },
-			defaults: { isRankEligible: interaction.member.manageable, User: { id: interaction.user.id } },
-			include: database.models.Hunter.User //TODO #110 crashes if user already exists, but hunter doesn't
+			defaults: { isRankEligible: interaction.member.manageable }
 		});
 		sender.toastsRaised++;
 		const toast = await database.models.Toast.create({ companyId: interaction.guildId, senderId: interaction.user.id, text: toastText, imageURL });


### PR DESCRIPTION
Summary
-------
- fix crash if creating Hunter while associated User already exists

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used `/reset all-hunter-stats` to reach "User but no Hunter" state, made sure `/bounty post` didn't crash

Issue
-----
Closes #110