### PR TITLE
#127: /bounty list defaults to own bounties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # BountyBot Change Log
 ## BountyBot Version 2.0.1:
 - Fixed the join link not asking for all needed permissions
+- `/bounty list` defaults to your own bounties
 
 ### Known Issues
 - When a Toast's Recipient Seconds that toast, they aren't filtered out of getting XP again

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -86,13 +86,13 @@ const subcommands = [
 	},
 	{
 		name: "list",
-		description: "List all of a hunter's open bounties",
+		description: "List all of a hunter's open bounties (default: your own)",
 		optionsInput: [
 			{
 				type: "User",
 				name: "bounty-hunter",
 				description: "The bounty hunter to show open bounties for",
-				required: true
+				required: false
 			}
 		]
 	}
@@ -452,7 +452,7 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 				})
 				break;
 			case subcommands[8].name: // list
-				const listUserId = interaction.options.getUser(subcommands[8].optionsInput[0].name).id;
+				const listUserId = interaction.options.getUser(subcommands[8].optionsInput[0].name)?.id ?? interaction.user.id;
 				database.models.Bounty.findAll({ where: { userId: listUserId, companyId: interaction.guildId, state: "open" }, order: [["slotNumber", "ASC"]] }).then(async existingBounties => {
 					if (existingBounties.length < 1) {
 						interaction.reply({ content: `<@${listUserId}> doesn't have any open bounties posted.`, ephemeral: true });


### PR DESCRIPTION
Summary
-------
- /bounty list defaults to own bounties

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used /bounty list without user argument

Issue
-----
Closes #127