### PR TITLE
#134: Make rewards thread messages silent

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,11 +2,11 @@
 ## BountyBot Version 2.0.1:
 - Fixed the join link not asking for all needed permissions
 - `/bounty list` defaults to your own bounties
+- Posts to rewards threads are now silent
 
 ### Known Issues
 - When a Toast's Recipient Seconds that toast, they aren't filtered out of getting XP again
 - Seconding a toast doesn't update the scoreboard reference channel
-- Posts to rewards threads aren't silenced
 - Rewards thread messages are missing some line breaks
 - Functionality to permanently revoke access to BountyBot isn't usable yet
 - The channel created by `/create-default scoreboard-reference` isn't immediately usable as a reference channel

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { Op } = require('sequelize');
 const { MAX_MESSAGE_CONTENT_LENGTH } = require('../constants');
@@ -104,7 +104,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
 				text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
 			}
-			interaction.message.thread.send(text);
+			interaction.message.thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 		})
 	}
 );

--- a/source/commands/bounty.js
+++ b/source/commands/bounty.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { PermissionFlagsBits, ActionRowBuilder, StringSelectMenuBuilder, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { updateScoreboard } = require('../util/embedUtil');
 const { getRankUpdates } = require('../util/scoreUtil');
@@ -411,7 +411,7 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 							if (company.bountyBoardId) {
 								interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 									bountyBoard.threads.fetch(bounty.postingId).then(thread => {
-										thread.send(text);
+										thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 									})
 								})
 							} else {

--- a/source/commands/event.js
+++ b/source/commands/event.js
@@ -26,7 +26,7 @@ module.exports = new CommandWrapper(mainId, "Manage a server-wide event that mul
 	(interaction, database, runMode) => {
 		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
 			switch (interaction.options.getSubcommand()) {
-				case subcommands[0].name: // open-event
+				case subcommands[0].name: // start
 					const multiplier = interaction.options.getInteger(subcommands[0].optionsInput[0].name);
 					if (multiplier < 2) {
 						interaction.reply({ content: `Multiplier must be an integer that is 2 or more.`, ephemeral: true })
@@ -42,7 +42,7 @@ module.exports = new CommandWrapper(mainId, "Manage a server-wide event that mul
 					})
 					interaction.reply(company.sendAnnouncement({ content: `An XP multiplier event has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
 					break;
-				case subcommands[1].name: // close-event
+				case subcommands[1].name: // close
 					company.update({ "eventMultiplier": 1 });
 					interaction.guild.members.fetchMe().then(bountyBot => {
 						bountyBot.setNickname(null);

--- a/source/commands/evergreen.js
+++ b/source/commands/evergreen.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, StringSelectMenuBuilder } = require('discord.js');
+const { PermissionFlagsBits, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, StringSelectMenuBuilder, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { Bounty } = require('../models/bounties/Bounty');
 const { updateScoreboard } = require('../util/embedUtil');
@@ -323,7 +323,7 @@ module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed a
 								if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
 									text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
 								}
-								thread.send(text);
+								thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 							})
 							updateScoreboard(company, interaction.guild, database);
 						});

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const { Op } = require('sequelize');
 const { SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH } = require('../constants');
 const { CommandWrapper } = require('../classes');
@@ -199,7 +199,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 						if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
 							text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
 						}
-						thread.send(text);
+						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 						updateScoreboard(company, interaction.guild, database);
 					})
 				}


### PR DESCRIPTION
Summary
-------
- make rewards thread messages silent

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /toast
- [x] /evergreen complete
- [x] second toast
- [x] /bounty complete

Issue
-----
Closes #134