### PR TITLE
#130: fix /create-default scoreboard not eligible as reference channel

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 - A toast's seconder is always filtered out of eligibility for xp
 - Improved the formatting on rewards messages
 - Renamed `/event` to `/festival` to disambiguate with Discord Scheduled Events
+- Fixed the `/create-default scoreboard-reference` to immediately be usable as a reference channel
 
 ## BountyBot Version 2.0.1:
 - Fixed the join link not asking for all needed permissions

--- a/source/commands/create-default.js
+++ b/source/commands/create-default.js
@@ -100,11 +100,12 @@ module.exports = new CommandWrapper(mainId, "Create a Discord resource for use b
 					permissionOverwrites: [
 						{
 							id: interaction.client.user,
-							allow: [PermissionFlagsBits.SendMessages],
+							allow: [PermissionFlagsBits.SendMessages, PermissionFlagsBits.ManageMessages],
 							type: OverwriteType.Member
 						},
 						{
 							id: interaction.guildId,
+							allow: [PermissionFlagsBits.ViewChannel],
 							deny: [PermissionFlagsBits.SendMessages]
 						}
 					],


### PR DESCRIPTION
Summary
-------
- set `@everyone`'s SendMessages to true to allow created text channels to be used as reference channels

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] isolated permission difference on IHC

Issue
-----
Closes #130