### PR TITLE
#153: Convert `/bounty edit` feedback to ephemeral

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # BountyBot Change Log
+## BountyBot Version 2.1.0:
+- Made `/bounty edit` feedback ephemeral so that it can't be used as a non-rate limited showcase
+
 ## BountyBot Version 2.0.2:
 - A toast's seconder is always filtered out of eligibility for xp
 - Improved the formatting on rewards messages

--- a/source/selects/bountyedit.js
+++ b/source/selects/bountyedit.js
@@ -170,8 +170,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 			bounty.updatePosting(modalSubmission.guild, bounty.Company, database);
 
-			modalSubmission.update({ content: "Bounty edited!", components: [] });
-			modalSubmission.channel.send(bounty.Company.sendAnnouncement({ content: `${modalSubmission.member} has edited one of their bounties:`, embeds: [bountyEmbed] }));
+			modalSubmission.update({ content: "Bounty edited!", embeds: [bountyEmbed], components: [] });
 		}).catch(console.error);
 	}
 );


### PR DESCRIPTION
Summary
-------
- convert `/bounty edit` feedback to ephemeral

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used `/bounty edit`

Issue
-----
Closes #153