### PR TITLE
#121: update discord.js to v6.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"dependencies": {
 				"discord.js": "^14.14.1",
-				"sequelize": "^6.32.1",
+				"sequelize": "^6.35.1",
 				"sqlite3": "^5.1.6"
 			}
 		},
@@ -1065,9 +1065,9 @@
 			}
 		},
 		"node_modules/pg-connection-string": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
-			"integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+			"integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
 		},
 		"node_modules/promise-inflight": {
 			"version": "1.0.1",
@@ -1155,9 +1155,9 @@
 			"optional": true
 		},
 		"node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -1169,9 +1169,9 @@
 			}
 		},
 		"node_modules/sequelize": {
-			"version": "6.32.1",
-			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
-			"integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
+			"version": "6.35.1",
+			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.35.1.tgz",
+			"integrity": "sha512-UlP5k33nJsN11wCDLaWZXw9bB8w4ESKc5QmG6D04qMimwBwKVNeqRJiaaBlEJdtg8cRK+OJh95dliP+uEi+g9Q==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1182,14 +1182,14 @@
 				"@types/debug": "^4.1.8",
 				"@types/validator": "^13.7.17",
 				"debug": "^4.3.4",
-				"dottie": "^2.0.4",
+				"dottie": "^2.0.6",
 				"inflection": "^1.13.4",
 				"lodash": "^4.17.21",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.43",
-				"pg-connection-string": "^2.6.0",
+				"pg-connection-string": "^2.6.1",
 				"retry-as-promised": "^7.0.4",
-				"semver": "^7.5.1",
+				"semver": "^7.5.4",
 				"sequelize-pool": "^7.1.0",
 				"toposort-class": "^1.0.1",
 				"uuid": "^8.3.2",
@@ -2352,9 +2352,9 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
 		},
 		"pg-connection-string": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
-			"integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+			"integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -2413,29 +2413,29 @@
 			"optional": true
 		},
 		"semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
 		},
 		"sequelize": {
-			"version": "6.32.1",
-			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
-			"integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
+			"version": "6.35.1",
+			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.35.1.tgz",
+			"integrity": "sha512-UlP5k33nJsN11wCDLaWZXw9bB8w4ESKc5QmG6D04qMimwBwKVNeqRJiaaBlEJdtg8cRK+OJh95dliP+uEi+g9Q==",
 			"requires": {
 				"@types/debug": "^4.1.8",
 				"@types/validator": "^13.7.17",
 				"debug": "^4.3.4",
-				"dottie": "^2.0.4",
+				"dottie": "^2.0.6",
 				"inflection": "^1.13.4",
 				"lodash": "^4.17.21",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.43",
-				"pg-connection-string": "^2.6.0",
+				"pg-connection-string": "^2.6.1",
 				"retry-as-promised": "^7.0.4",
-				"semver": "^7.5.1",
+				"semver": "^7.5.4",
 				"sequelize-pool": "^7.1.0",
 				"toposort-class": "^1.0.1",
 				"uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"discord.js": "^14.14.1",
-		"sequelize": "^6.32.1",
+		"sequelize": "^6.35.1",
 		"sqlite3": "^5.1.6"
 	}
 }

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -52,7 +52,7 @@ exports.Hunter = class extends Model {
 		if (this.level > previousLevel) {
 			const rewards = [];
 			for (let level = previousLevel + 1; level <= this.level; level++) {
-				rewards.push(this.levelUpReward(level, company.maxSimBounties, false));
+				rewards.push(...this.levelUpReward(level, company.maxSimBounties, false));
 			}
 			levelTexts.push(`${congratulationBuilder()}, <@${this.userId}>! You have leveled up to level **${this.level}**!\n\t- ${rewards.join('\n\t- ')}`);
 		}
@@ -65,19 +65,19 @@ exports.Hunter = class extends Model {
 	}
 
 	levelUpReward(level, maxSlots, futureReward = true) {
-		let text = "";
+		const texts = [];
 		if (level % 2) {
-			text += `Your bounties in odd-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
+			texts.push(`Your bounties in odd-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`);
 		} else {
-			text += `Your bounties in even-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`;
+			texts.push(`Your bounties in even-numbered slots ${futureReward ? "will increase" : "have increased"} in value.`);
 		}
 		const currentSlots = this.maxSlots(maxSlots);
 		if (currentSlots < maxSlots) {
 			if (level == 3 + 12 * Math.floor((currentSlots - 2) / 2) + 7 * ((currentSlots - 2) % 2)) {
-				text += ` You ${futureReward ? "will" : "have"} unlock${futureReward ? "" : "ed"} bounty slot #${currentSlots}.`;
+				texts.push(` You ${futureReward ? "will" : "have"} unlock${futureReward ? "" : "ed"} bounty slot #${currentSlots}.`);
 			};
 		}
-		return text;
+		return texts;
 	}
 }
 


### PR DESCRIPTION
Summary
-------
- update discord.js to v6.35.1
- split level-up reward texts onto new lines

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/stats`, `/bounty post`, and `/bounty complete` all still interact with the database correctly

Issue
-----
Closes #121