### PR TITLE
#77: use forum thread tags to allow searching for open bounties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # BountyBot Change Log
+## BountyBot Version 2.2.0:
+- The default created bounty board now includes the `Open` and `Completed` tags for searching for open bounties
+
 ## BountyBot Version 2.1.1:
 - Fixed several crashes
 

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -1,4 +1,4 @@
-const { CommandInteraction } = require("discord.js");
+const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { updateScoreboard } = require("../../util/embedUtil");
@@ -114,6 +114,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			if (bounty.Company.bountyBoardId) {
 				interaction.guild.channels.fetch(bounty.Company.bountyBoardId).then(bountyBoard => {
 					bountyBoard.threads.fetch(bounty.postingId).then(thread => {
+						thread.setAppliedTags([bounty.Company.bountyBoardCompletedTagId])
 						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 					})
 				})

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -68,6 +68,12 @@ exports.initModel = function (sequelize) {
 		bountyBoardId: {
 			type: DataTypes.STRING
 		},
+		bountyBoardOpenTagId: {
+			type: DataTypes.STRING
+		},
+		bountyBoardCompletedTagId: {
+			type: DataTypes.STRING
+		},
 		evergreenThreadId: {
 			type: DataTypes.STRING
 		},

--- a/source/scripts/migrations/v2.1.0/migration.js
+++ b/source/scripts/migrations/v2.1.0/migration.js
@@ -1,0 +1,8 @@
+const { DataTypes } = require("sequelize");
+const { connectToDatabase } = require("../../../../database.js");
+
+connectToDatabase("migration").then(async database => {
+	const queryInterface = database.getQueryInterface();
+	queryInterface.addColumn("Company", "bountyBoardOpenTagId", { type: DataTypes.STRING });
+	queryInterface.addColumn("Company", "bountyBoardCompletedTagId", { type: DataTypes.STRING });
+});

--- a/source/selects/bountypost.js
+++ b/source/selects/bountypost.js
@@ -168,7 +168,8 @@ module.exports = new SelectWrapper(mainId, 3000,
 					modalSubmission.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 						return bountyBoard.threads.create({
 							name: bounty.title,
-							message: { embeds: [bountyEmbed] }
+							message: { embeds: [bountyEmbed] },
+							appliedTags: [company.bountyBoardOpenTagId]
 						})
 					}).then(posting => {
 						bounty.postingId = posting.id;

--- a/source/util/scoreUtil.js
+++ b/source/util/scoreUtil.js
@@ -122,7 +122,7 @@ async function getRankUpdates(guild, database) {
 					const hunter = allHunters.find(hunter => member.id === hunter.userId);
 					const rankRoleId = ranks[hunter.rank]?.roleId;
 					if (rankRoleId) {
-						await member.roles.add(rankRoleId);
+						await member.roles.add(rankRoleId).catch(console.error);
 						destinationRole = await guild.roles.fetch(rankRoleId);
 					}
 					// Note: higher ranks are lower value
@@ -144,7 +144,8 @@ async function getRankUpdates(guild, database) {
 function generateBountyBoardThread(threadManager, embeds, company) {
 	return threadManager.create({
 		name: "Evergreen Bounties",
-		message: { embeds }
+		message: { embeds },
+		appliedTags: [company.bountyBoardOpenTagId]
 	}).then(thread => {
 		company.evergreenThreadId = thread.id;
 		company.save();


### PR DESCRIPTION
Summary
-------
- use forum thread tags to allow searching for open bounties

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] the evergreen thread is marked with the Open tag
- [x] new bounties are marked with the Open tag
- [x] when completed bounties lose the Open tag and gain the Completed tag

Issue
-----
Closes #77