### PR TITLE
#163: fix crash on edit bounty with archived thread

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 # BountyBot Change Log
 ## BountyBot Version 2.2.0:
 - The default created bounty board now includes the `Open` and `Completed` tags for searching for open bounties
+- The Platinum, Gold, and Silver default rank roles are now hoisted (displays its members separately)
+- Fixed a crash when using `/evergreen complete` on multiple completers
+- Fixed `/season-end` not updating the scoreboard and not removing ranks roles
+- Fixed a crash when editing a bounty whose thread has been archived
 
 ## BountyBot Version 2.1.1:
 - Fixed several crashes

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -67,6 +67,8 @@ exports.Bounty = class extends Model {
 			guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 				return bountyBoard.threads.fetch(this.postingId);
 			}).then(thread => {
+				return thread.setArchived(false, "Unarchived for /bounty edit");
+			}).then(thread => {
 				thread.edit({ name: this.title });
 				return thread.fetchStarterMessage();
 			}).then(posting => {


### PR DESCRIPTION
Summary
-------
- fix crash on edit bounty with archived thread

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] bounty with archived thread on board no longer crashes when edited (timestamp or not)

Notes
-------
Discord channel name edit rate limiting seems to cause thread name updates to be skipped if many edits are made quickly.

Issue
-----
Closes #163 