### PR TITLE
#80: add "most seconded toast"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,15 @@
 # BountyBot Change Log
+## BountyBot Version 2.3.0:
+- Each bounty hunter's most seconded toast (starting from this update) will be shown off in their `/stats`
+- Completed bounties will now archive their posting threads on the bounty board forum
+- Fixed a crash when editing a bounty whose thread has been archived
+
 ## BountyBot Version 2.2.0:
 - The default created bounty board now includes the `Open` and `Completed` tags for searching for open bounties
 - The Platinum, Gold, and Silver default rank roles are now hoisted (displays its members separately)
 - Fixed a crash when using `/evergreen complete` on multiple completers
 - Fixed `/season-end` not updating the scoreboard and not removing ranks roles
 - Fixed a crash when editing a bounty whose thread has been archived
-- Fixed a crash when editing a bounty whose title is too long
 
 ## BountyBot Version 2.1.1:
 - Fixed several crashes

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -30,6 +30,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 
 		seconder.toastSeconded++;
+		originalToast.increment("secondings");
 
 		let recipientIds = originalToast.Recipients.map(reciept => reciept.recipientId);
 		recipientIds.push(originalToast.senderId);

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -25,6 +25,10 @@ exports.initModel = function (sequelize) {
 		},
 		imageURL: {
 			type: DataTypes.STRING,
+		},
+		secondings: {
+			type: DataTypes.BIGINT,
+			defaultValue: 0
 		}
 	}, {
 		sequelize,

--- a/source/scripts/migrations/v2.3.0/migration.js
+++ b/source/scripts/migrations/v2.3.0/migration.js
@@ -1,0 +1,7 @@
+const { DataTypes } = require("sequelize");
+const { connectToDatabase } = require("../../../../database.js");
+
+connectToDatabase("migration").then(async database => {
+	const queryInterface = database.getQueryInterface();
+	queryInterface.addColumn("Toast", "secondings", { type: DataTypes.BIGINT, defaultValue: 0 });
+});


### PR DESCRIPTION
Summary
-------
- added Most Seconded Toast to /stats (both self and others)
- reorganized stats embeds (both self and others) to be more readable
- fix crash on viewing own stats

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Most Seconded Toast field can be viewed on both self and others stats embeds

Issue
-----
Closes #80 