### PR TITLE
#172: defer reply on `/bounty complete` to avoid "Unknown interaction" error

### DIFF
--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -60,6 +60,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		return;
 	}
 
+	interaction.deferReply({ ephemeral: true });
 	season.increment("bountiesCompleted");
 
 	bounty.state = "completed";
@@ -121,7 +122,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			} else {
 				replyPayload.content = text;
 			}
-			interaction.reply(replyPayload);
+			interaction.editReply(replyPayload);
 		}).then(() => {
 			return bounty.updatePosting(interaction.guild, bounty.Company, database);
 		}).then(thread => {


### PR DESCRIPTION
Summary
-------
- use `.deferReply()` in `/bounty complete` to avoid unknown interaction error 

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty complete` completes a bounty without errors

Issue
-----
Closes #172