### PR TITLE
#184: add eyes emoji as default emoji in bounty board forum

### DIFF
--- a/source/commands/create-default/bountyboardforum.js
+++ b/source/commands/create-default/bountyboardforum.js
@@ -27,6 +27,7 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 			}
 		],
 		availableTags: [{ name: "Open", moderated: true }, { name: "Completed", moderated: true }],
+		defaultReactionEmoji: { name: "👀" },
 		defaultSortOrder: SortOrderType.CreationDate,
 		defaultForumLayout: ForumLayoutType.ListView,
 		reason: `/create-default bounty-board-forum by ${interaction.user}`


### PR DESCRIPTION
Summary
-------
- add eyes emoji as default emoji in bounty board forum

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- `/create-default bounty-board-forum` creates a forum with :eyes: as default emoji

Issue
-----
Closes #184 