### PR TITLE
#183: add links to commands in description and in feedback messages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # BountyBot Change Log
 ## BountyBot Version 2.5.0:
 - Bounty board forums created by `/create-default` now have 👀 as a default reaction
+- BountyBot now provides shortcut links when mentioning its own commands
 
 ## BountyBot Version 2.4.0:
 - Ephemeral messages in multi-step processes now clean themselves up

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder, MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { Op } = require('sequelize');
-const { MAX_MESSAGE_CONTENT_LENGTH } = require('../constants');
+const { MAX_MESSAGE_CONTENT_LENGTH, commandIds } = require('../constants');
 const { getRankUpdates } = require('../util/scoreUtil');
 const { timeConversion } = require('../util/textUtil');
 const { updateScoreboard } = require('../util/embedUtil');
@@ -111,7 +111,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				text += `\n\n__**Rewards**__\n- ${levelTexts.join("\n- ")}`;
 			}
 			if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
-				text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+				text = `Message overflow! Many people (?) probably gained many things (?). Use </stats:${commandIds.stats}> to look things up.`;
 			}
 			interaction.message.thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 			updateScoreboard(await database.models.Company.findByPk(interaction.guildId), interaction.guild, database);

--- a/source/commands/about.js
+++ b/source/commands/about.js
@@ -1,12 +1,13 @@
 const { EmbedBuilder, Colors } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { BOUNTYBOT_INVITE_URL } = require('../constants');
+const { BOUNTYBOT_INVITE_URL, commandIds } = require('../constants');
 
 const mainId = "about";
 module.exports = new CommandWrapper(mainId, "Get BountyBot's description and contributors", null, false, true, 3000,
 	/** Get BountyBot's description and contributors */
 	(interaction, database, runMode) => {
 		const avatarURL = interaction.client.user.avatarURL();
+		console.log(commandIds);
 		interaction.reply({
 			embeds: [
 				new EmbedBuilder().setColor(Colors.Blurple)

--- a/source/commands/bounty/addcompleters.js
+++ b/source/commands/bounty/addcompleters.js
@@ -1,6 +1,7 @@
 const { CommandInteraction } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { extractUserIdsFromMentions } = require("../../util/textUtil");
+const { commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -60,7 +61,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	bounty.updatePosting(interaction.guild, bounty.Company, database);
 
 	interaction.reply({
-		content: `The following bounty hunters have been added as completers to **${bounty.title}**: <@${validatedCompleterIds.join(">, <@")}>\n\nThey will recieve the reward XP when you \`/bounty complete\`.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: <@${bannedIds.join(">, ")}>` : ""}`,
+		content: `The following bounty hunters have been added as completers to **${bounty.title}**: <@${validatedCompleterIds.join(">, <@")}>\n\nThey will recieve the reward XP when you </bounty complete:${commandIds.bounty}>.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: <@${bannedIds.join(">, ")}>` : ""}`,
 		ephemeral: true
 	});
 };

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -4,7 +4,7 @@ const { Bounty } = require("../../models/bounties/Bounty");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions, timeConversion } = require("../../util/textUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
-const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
+const { MAX_MESSAGE_CONTENT_LENGTH, commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -22,7 +22,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 
 	// disallow completion within 5 minutes of creating bounty
 	if (runMode === "prod" && new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {
-		interaction.reply({ content: "Bounties cannot be completed within 5 minutes of their posting. You can `/bounty add-completers` so you won't forget instead.", ephemeral: true });
+		interaction.reply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can </bounty add-completers:${commandIds.bounty}> so you won't forget instead.`, ephemeral: true });
 		return;
 	}
 
@@ -57,7 +57,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	}
 
 	if (validatedCompleterIds.length < 1) {
-		interaction.reply({ content: "There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use `/bounty take-down`.", ephemeral: true })
+		interaction.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use </bounty take-down:${commandIds.bounty}>.`, ephemeral: true })
 		return;
 	}
 
@@ -107,7 +107,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			text += `\n\n__**Rewards**__\n- ${levelTexts.join("\n- ")}`;
 		}
 		if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
-			text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+			text = `Message overflow! Many people (?) probably gained many things (?). Use </stats:${commandIds.stats}> to look things up.`;
 		}
 
 		bounty.asEmbed(interaction.guild, poster.level, bounty.Company.festivalMultiplierString(), true, database).then(embed => {

--- a/source/commands/bounty/edit.js
+++ b/source/commands/bounty/edit.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, CommandInteraction, ModalBuilder, TextInputBuilder, TextInputStyle, GuildScheduledEventEntityType } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { getNumberEmoji, trimForSelectOptionDescription, timeConversion, textsHaveAutoModInfraction, trimForModalTitle } = require("../../util/textUtil");
-const { SKIP_INTERACTION_HANDLING, YEAR_IN_MS } = require("../../constants");
+const { SKIP_INTERACTION_HANDLING, YEAR_IN_MS, commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -196,7 +196,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 
 				bounty.updatePosting(modalSubmission.guild, bounty.Company, database);
 
-				modalSubmission.update({ content: "Bounty edited! You can use `/bounty showcase` to let other bounty hunters know about the changes.", embeds: [bountyEmbed], components: [] });
+				modalSubmission.update({ content: `Bounty edited! You can use </bounty showcase:${commandIds.bounty}> to let other bounty hunters know about the changes.`, embeds: [bountyEmbed], components: [] });
 			}).catch(console.error);
 		});
 	})

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -3,7 +3,7 @@ const { Sequelize } = require("sequelize");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { Hunter } = require("../../models/users/Hunter");
 const { getNumberEmoji, timeConversion, textsHaveAutoModInfraction } = require("../../util/textUtil");
-const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS } = require("../../constants");
+const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS, commandIds } = require("../../constants");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 
@@ -216,7 +216,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 							bounty.save()
 						});
 					} else {
-						interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
+						interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with </create-default bounty-board-forum:${commandIds["create-default"]}>?`, ephemeral: true });
 					}
 				});
 			}).catch(console.error);

--- a/source/commands/bounty/takedown.js
+++ b/source/commands/bounty/takedown.js
@@ -1,7 +1,7 @@
 const { CommandInteraction, ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { trimForSelectOptionDescription, getNumberEmoji } = require("../../util/textUtil");
-const { SKIP_INTERACTION_HANDLING } = require("../../constants");
+const { SKIP_INTERACTION_HANDLING, commandIds } = require("../../constants");
 const { getRankUpdates } = require("../../util/scoreUtil");
 
 /**
@@ -22,7 +22,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		});
 
 		interaction.reply({
-			content: "If you'd like to change the title, description, image, or time of your bounty, you can use `/bounty edit` instead.",
+			content: `If you'd like to change the title, description, image, or time of your bounty, you can use </bounty edit:${commandIds.bounty}> instead.`,
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -4,7 +4,7 @@ const { Bounty } = require("../../models/bounties/Bounty");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions } = require("../../util/textUtil");
-const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
+const { MAX_MESSAGE_CONTENT_LENGTH, commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -97,7 +97,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 					text += `\n\n__**Rewards**__\n- ${levelTexts.join("\n- ")}`;
 				}
 				if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
-					text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+					text = `Message overflow! Many people (?) probably gained many things (?). Use </stats:${commandIds.stats}> to look things up.`;
 				}
 				thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 			})

--- a/source/commands/evergreen/post.js
+++ b/source/commands/evergreen/post.js
@@ -1,6 +1,6 @@
 const { CommandInteraction, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle } = require("discord.js");
 const { Sequelize } = require("sequelize");
-const { MAX_EMBEDS_PER_MESSAGE, MAX_EMBED_TITLE_LENGTH, SKIP_INTERACTION_HANDLING } = require("../../constants");
+const { MAX_EMBEDS_PER_MESSAGE, MAX_EMBED_TITLE_LENGTH, SKIP_INTERACTION_HANDLING, commandIds } = require("../../constants");
 const { textsHaveAutoModInfraction, timeConversion } = require("../../util/textUtil");
 const { generateBountyBoardThread } = require("../../util/scoreUtil");
 
@@ -105,7 +105,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 					bounty.save()
 				});
 			} else {
-				interaction.followUp({ content: "Looks like your server doesn't have a bounty board channel. Make one with `/create-default bounty-board-forum`?", ephemeral: true });
+				interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with </create-default bounty-board-forum:${commandIds["create-default"]}>?`, ephemeral: true });
 			}
 		});
 	}).catch(console.error)

--- a/source/commands/evergreen/takedown.js
+++ b/source/commands/evergreen/takedown.js
@@ -1,7 +1,7 @@
 const { CommandInteraction, ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { getNumberEmoji, trimForSelectOptionDescription } = require("../../util/textUtil");
-const { SKIP_INTERACTION_HANDLING } = require("../../constants");
+const { SKIP_INTERACTION_HANDLING, commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -21,7 +21,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	});
 
 	interaction.reply({
-		content: "If you'd like to change the title, description, or image of an evergreen bounty, you can use `/evergreen edit` instead.",
+		content: `If you'd like to change the title, description, or image of an evergreen bounty, you can use </evergreen edit:${commandIds.evergreen}> instead.`,
 		components: [
 			new ActionRowBuilder().addComponents(
 				new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)

--- a/source/commands/rank/add.js
+++ b/source/commands/rank/add.js
@@ -1,7 +1,7 @@
 const { CommandInteraction } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { getRankUpdates } = require("../../util/scoreUtil");
-const { MAX_EMBED_FIELD_COUNT } = require("../../constants");
+const { MAX_EMBED_FIELD_COUNT, commandIds } = require("../../constants");
 
 /**
  * @param {CommandInteraction} interaction
@@ -14,7 +14,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	const newThreshold = interaction.options.getNumber("variance-threshold");
 	const existingThresholds = ranks.map(rank => rank.varianceThreshold);
 	if (existingThresholds.includes(newThreshold)) {
-		interaction.reply({ content: `There is already a rank at the ${newThreshold} standard deviations threshold for this server. If you'd like to change the role or rankmoji for that rank, you can use \`/rank edit\`.`, ephemeral: true });
+		interaction.reply({ content: `There is already a rank at the ${newThreshold} standard deviations threshold for this server. If you'd like to change the role or rankmoji for that rank, you can use </rank edit:${commandIds.rank}>.`, ephemeral: true });
 		return;
 	}
 

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -183,7 +183,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 							text += `\n\n__**Rewards**__\n- ${levelTexts.join("\n- ")}`;
 						}
 						if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
-							text = "Message overflow! Many people (?) probably gained many things (?). Use `/stats` to look things up.";
+							text = `Message overflow! Many people (?) probably gained many things (?). Use </stats:${commandIds.stats}> to look things up.`;
 						}
 						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 						updateScoreboard(company, interaction.guild, database);

--- a/source/commands/tutorial.js
+++ b/source/commands/tutorial.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder, Colors } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { ihpAuthorPayload, randomFooterTip } = require('../util/embedUtil');
-const { BOUNTYBOT_INVITE_URL } = require('../constants');
+const { BOUNTYBOT_INVITE_URL, commandIds } = require('../constants');
 
 const mainId = "tutorial";
 module.exports = new CommandWrapper(mainId, "Get tips for starting with BountyBot", null, false, true, 3000,
@@ -16,10 +16,10 @@ module.exports = new CommandWrapper(mainId, "Get tips for starting with BountyBo
 				embed.setTitle("Bounty Hunter Starting Tips")
 					.setDescription("BountyBot allows server members to post objectives as bounties and awards XP to the bounty hunters who complete them. Here's how you can get started:")
 					.addFields(
-						{ name: "Post a Bounty", value: "You can set up a bounty by using `/bounty post`. After the bounty is completed, credit the completers with `/bounty complete`." },
-						{ name: "Raise a Toast", value: "You may want to thank someone for something you don't have a bounty for or congratulate someone for a job well done. The \`/toast\` command makes a nice message and grants the recipient XP!" },
-						{ name: "Check for Posted Bounties", value: "Check if the server has a bounty board forum channel. Otherwise, you can use `/bounty list` to get lists of open bounties." },
-						{ name: "Other Features", value: "To get a list of all BountyBot's commands, use `/commands`." }
+						{ name: "Post a Bounty", value: `You can set up a bounty by using </bounty post:${commandIds.bounty}>. After the bounty is completed, credit the completers with </bounty complete:${commandIds.bounty}>.` },
+						{ name: "Raise a Toast", value: `You may want to thank someone for something you don't have a bounty for or congratulate someone for a job well done. The </toast:${commandIds.toast}> command makes a nice message and grants the recipient XP!` },
+						{ name: "Check for Posted Bounties", value: `Check if the server has a bounty board forum channel. Otherwise, you can use </bounty list:${commandIds.bounty}> to get lists of open bounties.` },
+						{ name: "Other Features", value: `To get a list of all BountyBot's commands, use </commands:${commandIds.commands}>.` }
 					)
 				break;
 			case "server":
@@ -27,10 +27,10 @@ module.exports = new CommandWrapper(mainId, "Get tips for starting with BountyBo
 					.setDescription("Following are some suggestions for setting up BountyBot on your server. NOTE: If you kick BountyBot, it will delete all data related to your server from the database.")
 					.addFields(
 						{ name: "Join Link", value: `Add BountyBot to your server with [this link](${BOUNTYBOT_INVITE_URL}).` },
-						{ name: "/create-default", value: "The `/create-default` command can create a bounty board forum channel, a reference channel for the scoreboard, or roles for showing off seasonal ranks." },
+						{ name: "/create-default", value: `The </create-default:${commandIds["create-default"]}> command can create a bounty board forum channel, a reference channel for the scoreboard, or roles for showing off seasonal ranks.` },
 						{ name: "/raffle announce-upcoming", value: "You can have BountyBot randomly select a user by seasonal rank or by level. Bounty hunters will likely appreciate if you announce the timing or eligibility for upcoming raffles ahead of time." },
 						{ name: "/config-server", value: "You can set the notification type for BountyBot announcement messages (eg \"Should bounty posts start with @everyone, @here, etc?\")." },
-						{ name: "/config-premium", value: "Premium members can change the XP coefficient for bounty hunter level-ups or the max number of slots a bounty hunter can have. Use `/premium` for more information." }
+						{ name: "/config-premium", value: `Premium members can change the XP coefficient for bounty hunter level-ups or the max number of slots a bounty hunter can have. Use </premium:${commandIds.premium}> for more information.` }
 					)
 				break;
 		}

--- a/source/constants.js
+++ b/source/constants.js
@@ -32,6 +32,7 @@ module.exports = {
 	announcementsChannelId,
 	lastPostedVersion,
 	premium: require("../config/premium.json"),
+	commandIds: {},
 
 	// Internal Constants
 	BOUNTYBOT_INVITE_URL: "https://discord.com/api/oauth2/authorize?client_id=536330483852771348&permissions=18135835404336&scope=bot%20applications.commands",


### PR DESCRIPTION
Summary
-------
- add links to commands in description and in feedback messages

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] clicking a provided command link (eg in `/tutorial`) shortcuts to using the link in the chat
- [x] command ids are dynamically updated based on run mode

Issue
-----
Closes #183 