### PR TITLE
#179: add "Complete" button to bounty board threads

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -143,7 +143,7 @@ client.on(Events.InteractionCreate, interaction => {
 				return;
 			}
 
-			interactionWrapper.execute(interaction, args, database);
+			interactionWrapper.execute(interaction, args, database, runMode);
 		}
 	})
 });

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -4,6 +4,7 @@ const { ButtonWrapper } = require("../classes");
 const buttonDictionary = {};
 
 for (const file of [
+	"bbcomplete.js",
 	"secondtoast.js"
 ]) {
 	/** @type {ButtonWrapper} */

--- a/source/buttons/_button_blueprint.js
+++ b/source/buttons/_button_blueprint.js
@@ -3,7 +3,7 @@ const { ButtonWrapper } = require('../classes');
 const mainId = "";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Specs */
-	(interaction, args, database) => {
+	(interaction, args, database, runMode) => {
 
 	}
 );

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -1,0 +1,125 @@
+const { MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { ButtonWrapper } = require('../classes');
+const { MAX_MESSAGE_CONTENT_LENGTH, SKIP_INTERACTION_HANDLING } = require('../constants');
+const { Bounty } = require('../models/bounties/Bounty');
+const { updateScoreboard } = require('../util/embedUtil');
+const { getRankUpdates } = require('../util/scoreUtil');
+const { commandMention } = require('../util/textUtil');
+
+const mainId = "bbcomplete";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [bountyId], database, runMode) => {
+		database.models.Bounty.findByPk(bountyId).then(async bounty => {
+			await interaction.deferReply({ ephemeral: true });
+			if (bounty.userId !== interaction.user.id) {
+				interaction.editReply({ content: "Only the bounty poster can mark a bounty completed." });
+				return;
+			}
+
+			// Early-out if no completers
+			const completerIds = (await database.models.Completion.findAll({ where: { bountyId: bounty.id } })).map(reciept => reciept.userId);
+			const completerMembers = (await interaction.guild.members.fetch({ user: completerIds })).values();
+			const validatedHunterIds = [];
+			const validatedHunters = [];
+			for (const member of completerMembers) {
+				if (runMode !== "prod" || !member.user.bot) {
+					const memberId = member.id;
+					await database.models.User.findOrCreate({ where: { id: memberId } });
+					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: interaction.guildId } });
+					if (!hunter.isBanned) {
+						validatedHunterIds.push(memberId);
+						validatedHunters.push(hunter);
+					}
+				}
+			}
+
+			if (validatedHunters.length < 1) {
+				interaction.editReply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.` })
+				return;
+			}
+
+			// disallow completion within 5 minutes of creating bounty
+			const now = new Date();
+			if (runMode === "prod" && now < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {
+				interaction.editReply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can ${commandMention("bounty add-completers")} so you won't forget instead.` });
+				return;
+			}
+
+			interaction.editReply({
+				content: `Credit <@${validatedHunterIds.join(">, <@")}> with the completion of this bounty?`,
+				components: [
+					new ActionRowBuilder().addComponents(
+						new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}confirm`)
+							.setStyle(ButtonStyle.Success)
+							.setEmoji("✔")
+							.setLabel("Confirm"),
+						new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}cancel`)
+							.setStyle(ButtonStyle.Secondary)
+							.setEmoji("❌")
+							.setLabel("Cancel")
+					)
+				]
+			}).then(reply => {
+				const collector = reply.createMessageComponentCollector({ max: 1 });
+
+				collector.on("collect", async collectedInteraction => {
+					if (collectedInteraction.customId === `${SKIP_INTERACTION_HANDLING}confirm`) {
+						const season = await database.models.Season.findOne({ where: { companyId: collectedInteraction.guildId, isCurrentSeason: true } });
+						season.increment("bountiesCompleted");
+
+						bounty.state = "completed";
+						bounty.completedAt = now;
+						bounty.save();
+
+						const poster = await database.models.Hunter.findOne({ where: { userId: collectedInteraction.user.id, companyId: collectedInteraction.guildId } });
+						const bountyBaseValue = Bounty.calculateReward(poster.level, bounty.slotNumber, bounty.showcaseCount);
+						const company = await database.models.Company.findByPk(collectedInteraction.guildId);
+						const bountyValue = bountyBaseValue * company.festivalMultiplier;
+						database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
+
+						let levelTexts = [];
+						for (const hunter of validatedHunters) {
+							const completerLevelTexts = await hunter.addXP(collectedInteraction.guild.name, bountyValue, true, database);
+							if (completerLevelTexts.length > 0) {
+								levelTexts = levelTexts.concat(completerLevelTexts);
+							}
+							hunter.othersFinished++;
+							hunter.save();
+						}
+
+						const posterXP = Math.ceil(validatedHunters.length / 2) * company.festivalMultiplier;
+						const posterLevelTexts = await poster.addXP(collectedInteraction.guild.name, posterXP, true, database);
+						if (posterLevelTexts.length > 0) {
+							levelTexts = levelTexts.concat(posterLevelTexts);
+						}
+						poster.mineFinished++;
+						poster.save();
+
+						getRankUpdates(collectedInteraction.guild, database).then(rankUpdates => {
+							const multiplierString = company.festivalMultiplierString();
+							let text = `__**XP Gained**__\n${validatedHunterIds.map(id => `<@${id}> + ${bountyBaseValue} XP${multiplierString}`).join("\n")}\n${collectedInteraction.member} + ${posterXP} XP${multiplierString}`;
+							if (rankUpdates.length > 0) {
+								text += `\n\n__**Rank Ups**__\n- ${rankUpdates.join("\n- ")}`;
+							}
+							if (levelTexts.length > 0) {
+								text += `\n\n__**Rewards**__\n- ${levelTexts.join("\n- ")}`;
+							}
+							if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
+								text = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
+							}
+
+							collectedInteraction.channel.setAppliedTags([company.bountyBoardCompletedTagId]);
+							collectedInteraction.reply({ content: text, flags: MessageFlags.SuppressNotifications });
+							bounty.updatePosting(collectedInteraction.guild, company, database);
+							updateScoreboard(company, collectedInteraction.guild, database);
+						});
+					}
+				})
+
+				collector.on("end", () => {
+					interaction.deleteReply();
+				})
+			});
+		})
+	}
+);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -9,7 +9,7 @@ const { updateScoreboard } = require('../util/embedUtil');
 const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Provide each recipient of a toast an extra XP, roll crit toast for author, and update embed */
-	async (interaction, [toastId], database) => {
+	async (interaction, [toastId], database, runMode) => {
 		await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
 		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
 		if (seconder.isBanned) {

--- a/source/classes/InteractionWrapper.js
+++ b/source/classes/InteractionWrapper.js
@@ -50,7 +50,7 @@ class ButtonWrapper extends InteractionWrapper {
 	/** IHP wrapper for button responses
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: ButtonInteraction, args: string[], database: Sequelize) => void} executeFunction
+	 * @param {(interaction: ButtonInteraction, args: string[], database: Sequelize, runMode: "prod" | "migration" | undefined) => void} executeFunction
 	 */
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);
@@ -133,7 +133,7 @@ class SelectWrapper extends InteractionWrapper {
 	/** IHP wrapper for any select responses
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: AnySelectMenuInteraction, args: string[], database: Sequelize) => void} executeFunction
+	 * @param {(interaction: AnySelectMenuInteraction, args: string[], database: Sequelize, runMode: "prod" | "migration" | undefined) => void} executeFunction
 	 */
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -1,9 +1,9 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, CommandInteraction, ModalBuilder, TextInputBuilder, TextInputStyle, GuildScheduledEventEntityType } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, CommandInteraction, ModalBuilder, TextInputBuilder, TextInputStyle, GuildScheduledEventEntityType, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { Hunter } = require("../../models/users/Hunter");
 const { getNumberEmoji, timeConversion, textsHaveAutoModInfraction, commandMention } = require("../../util/textUtil");
-const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS } = require("../../constants");
+const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS, SAFE_DELIMITER } = require("../../constants");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 
@@ -213,7 +213,14 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 						modalSubmission.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 							return bountyBoard.threads.create({
 								name: bounty.title,
-								message: { embeds: [bountyEmbed] },
+								message: {
+									embeds: [bountyEmbed], components: [new ActionRowBuilder().addComponents(
+										new ButtonBuilder().setCustomId(`bbcomplete${SAFE_DELIMITER}${bounty.id}`)
+											.setStyle(ButtonStyle.Success)
+											.setLabel("Complete")
+											.setDisabled(true)
+									)]
+								},
 								appliedTags: [company.bountyBoardOpenTagId]
 							})
 						}).then(posting => {

--- a/source/selects/_select_blueprint.js
+++ b/source/selects/_select_blueprint.js
@@ -3,7 +3,7 @@ const { SelectWrapper } = require('../classes');
 const mainId = "";
 module.exports = new SelectWrapper(mainId, 3000,
 	/** Specs */
-	(interaction, args, database) => {
+	(interaction, args, database, runMode) => {
 
 	}
 );


### PR DESCRIPTION
Summary
-------
- add "Complete" button to bounty board threads
- optimize `/bounty complete` to avoid fetching same hunters twice

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Complete button on bounty thread completes the bounty, and isn't enabled before bounty is completable
- [x] `/bounty complete` still works after optimizations

Issue
-----
Closes #179