### PR TITLE
#178: on completion, bounties grant their poster bonus XP for filled optional fields

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 ## BountyBot Version 2.5.0:
 - Bounty board forums created by `/create-default` now have 👀 as a default reaction
 - BountyBot now provides shortcut links when mentioning its own commands
+- Threads on the bounty board now include a Complete button
 - Bounty descriptions are now optional
+- Adding a description, image, or start and end timestamps each add a 1 XP bonus to the poster's XP on completion
 
 ## BountyBot Version 2.4.0:
 - Ephemeral messages in multi-step processes now clean themselves up

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -72,7 +72,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						bounty.save();
 
 						const poster = await database.models.Hunter.findOne({ where: { userId: collectedInteraction.user.id, companyId: collectedInteraction.guildId } });
-						const bountyBaseValue = Bounty.calculateReward(poster.level, bounty.slotNumber, bounty.showcaseCount);
+						const bountyBaseValue = Bounty.calculateCompleterReward(poster.level, bounty.slotNumber, bounty.showcaseCount);
 						const company = await database.models.Company.findByPk(collectedInteraction.guildId);
 						const bountyValue = bountyBaseValue * company.festivalMultiplier;
 						database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
@@ -87,8 +87,8 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							hunter.save();
 						}
 
-						const posterXP = Math.ceil(validatedHunters.length / 2) * company.festivalMultiplier;
-						const posterLevelTexts = await poster.addXP(collectedInteraction.guild.name, posterXP, true, database);
+						const posterXP = bounty.calculatePosterReward(validatedHunterIds.length);
+						const posterLevelTexts = await poster.addXP(collectedInteraction.guild.name, posterXP * company.festivalMultiplier, true, database);
 						if (posterLevelTexts.length > 0) {
 							levelTexts = levelTexts.concat(posterLevelTexts);
 						}

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -76,7 +76,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 
 	// poster guaranteed to exist, creating a bounty gives 1 XP
 	const poster = await database.models.Hunter.findOne({ where: { userId: posterId, companyId: interaction.guildId } });
-	const bountyBaseValue = Bounty.calculateReward(poster.level, slotNumber, bounty.showcaseCount);
+	const bountyBaseValue = Bounty.calculateCompleterReward(poster.level, slotNumber, bounty.showcaseCount);
 	const bountyValue = bountyBaseValue * bounty.Company.festivalMultiplier;
 	database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
 	let levelTexts = [];
@@ -90,8 +90,8 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		hunter.save();
 	}
 
-	const posterXP = Math.ceil(validatedCompleterIds.length / 2) * bounty.Company.festivalMultiplier;
-	const posterLevelTexts = await poster.addXP(interaction.guild.name, posterXP, true, database);
+	const posterXP = bounty.calculatePosterReward(validatedCompleterIds.length);
+	const posterLevelTexts = await poster.addXP(interaction.guild.name, posterXP * bounty.Company.festivalMultiplier, true, database);
 	if (posterLevelTexts.length > 0) {
 		levelTexts = levelTexts.concat(posterLevelTexts);
 	}

--- a/source/commands/bounty/edit.js
+++ b/source/commands/bounty/edit.js
@@ -82,7 +82,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 								.setLabel("Description")
 								.setRequired(false)
 								.setStyle(TextInputStyle.Paragraph)
-								.setPlaceholder("Bounties with clear instructions are easier to complete...")
+								.setPlaceholder("Get a 1 XP bonus on completion for the following: description, image URL, timestamps")
 								.setValue(bounty.description ?? "")
 						),
 						new ActionRowBuilder().addComponents(

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -24,7 +24,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 			slotOptions.push({
 				emoji: getNumberEmoji(slotNumber),
 				label: `Slot ${slotNumber}`,
-				description: `Reward: ${Bounty.calculateReward(hunter.level, slotNumber, 0)} XP`,
+				description: `Reward: ${Bounty.calculateCompleterReward(hunter.level, slotNumber, 0)} XP`,
 				value: slotNumber.toString()
 			})
 		}
@@ -82,7 +82,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 								.setLabel("Description")
 								.setRequired(false)
 								.setStyle(TextInputStyle.Paragraph)
-								.setPlaceholder("Bounties with clear instructions are easier to complete...")
+								.setPlaceholder("Get a 1 XP bonus on completion for the following: description, image URL, timestamps")
 						),
 						new ActionRowBuilder().addComponents(
 							new TextInputBuilder().setCustomId("imageURL")

--- a/source/commands/bounty/swap.js
+++ b/source/commands/bounty/swap.js
@@ -60,7 +60,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 									{
 										emoji: getNumberEmoji(i),
 										label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-										description: `XP Reward: ${Bounty.calculateReward(hunter.level, i, existingBounty?.showcaseCount ?? 0)}`,
+										description: `XP Reward: ${Bounty.calculateCompleterReward(hunter.level, i, existingBounty?.showcaseCount ?? 0)}`,
 										value: i.toString()
 									}
 								)
@@ -107,7 +107,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 					}
 
 					const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
-					interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member}'s bounty, **${sourceBounty.title}** is now worth ${Bounty.calculateReward(hunter.level, destinationSlot, sourceBounty.showcaseCount)} XP.` }));
+					interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member}'s bounty, **${sourceBounty.title}** is now worth ${Bounty.calculateCompleterReward(hunter.level, destinationSlot, sourceBounty.showcaseCount)} XP.` }));
 				}
 			})
 

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -69,7 +69,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	await database.models.Completion.bulkCreate(rawCompletions);
 
 	// Evergreen bounties are not eligible for showcase bonuses
-	const bountyBaseValue = Bounty.calculateReward(company.level, slotNumber, 0);
+	const bountyBaseValue = Bounty.calculateCompleterReward(company.level, slotNumber, 0);
 	const bountyValue = bountyBaseValue * company.festivalMultiplier;
 	database.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
 

--- a/source/commands/evergreen/swap.js
+++ b/source/commands/evergreen/swap.js
@@ -55,7 +55,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 									emoji: getNumberEmoji(bounty.slotNumber),
 									label: `Slot ${bounty.slotNumber}: ${bounty.title}`,
 									// Evergreen bounties are not eligible for showcase bonuses
-									description: `XP Reward: ${Bounty.calculateReward(hunter.level, bounty.slotNumber, 0)}`,
+									description: `XP Reward: ${Bounty.calculateCompleterReward(hunter.level, bounty.slotNumber, 0)}`,
 									value: bounty.id
 								}
 							);
@@ -107,7 +107,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 				}
 
 				// Evergreen bounties are not eligible for showcase bonuses
-				interaction.channel.send(`Some evergreen bounties have been swapped, **${sourceBounty.title}** is now worth ${Bounty.calculateReward(company.level, destinationSlot, 0)} XP and **${destinationBounty.title}** is now worth ${Bounty.calculateReward(company.level, sourceSlot, 0)} XP.`);
+				interaction.channel.send(`Some evergreen bounties have been swapped, **${sourceBounty.title}** is now worth ${Bounty.calculateCompleterReward(company.level, destinationSlot, 0)} XP and **${destinationBounty.title}** is now worth ${Bounty.calculateCompleterReward(company.level, sourceSlot, 0, 0).completerReward} XP.`);
 			}
 		})
 

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -38,7 +38,7 @@ exports.Bounty = class extends Model {
 				fields.push({ name: "Time", value: `<t:${event.scheduledStartTimestamp / 1000}> - <t:${event.scheduledEndTimestamp / 1000}>` });
 			}
 			if (!shouldOmitRewardsField) {
-				fields.push({ name: "Reward", value: `${exports.Bounty.calculateReward(posterLevel, this.slotNumber, this.showcaseCount)} XP${festivalMultiplierString}`, inline: true });
+				fields.push({ name: "Reward", value: `${exports.Bounty.calculateCompleterReward(posterLevel, this.slotNumber, this.showcaseCount)} XP${festivalMultiplierString}`, inline: true });
 			}
 
 			if (this.isEvergreen) {
@@ -97,9 +97,19 @@ exports.Bounty = class extends Model {
 		}
 	}
 
-	static calculateReward(posterLevel, slotNumber, showcaseCount) {
+	static calculateCompleterReward(posterLevel, slotNumber, showcaseCount) {
 		const showcaseMultiplier = 0.25 * showcaseCount + 1;
 		return Math.max(2, Math.floor((6 + 0.5 * posterLevel - 3 * slotNumber + 0.5 * slotNumber % 2) * showcaseMultiplier));
+	}
+
+	calculatePosterReward(hunterCount) {
+		let posterXP = Math.ceil(hunterCount / 2);
+		for (const property of ["description", "attachmentURL", "scheduledEventId"]) {
+			if (this[property] !== null) {
+				posterXP++;
+			}
+		}
+		return posterXP;
 	}
 }
 

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -18,7 +18,7 @@ const discordTips = [
 	"Server subscriptions cost more on mobile because the mobile app stores take a cut."
 ].map(text => ({ text, iconURL: discordIconURL }));
 /** @type {import("discord.js").EmbedFooterData[]} */
-const applicationSpecificTips = [
+const bountyBotTips = [
 	"You can showcase one of your bounties once a week to increase its rewards.",
 	"Send bug reports or feature requests with the \"/feedback\".",
 	"Bounties can't be completed until 5 minutes after they've been posted. Don't make them too easy!",
@@ -33,9 +33,10 @@ const applicationSpecificTips = [
 	"The Overjustification Effect means a small reward can be less motivating than no reward.",
 	"Manage bounties from within games with the Discord Overlay (default: Shift + Tab)!",
 	"Server level is based on total bounty hunter level--higher server level means better evergreen bounty rewards.",
-	"A bounty poster cannot complete their own bounty."
+	"A bounty poster cannot complete their own bounty.",
+	"Adding a description, image or time to a bounty all add 1 bonus XP for the poster."
 ].map(text => ({ text, iconURL: bountyBotIcon }));
-const tipPool = applicationSpecificTips.concat(applicationSpecificTips, discordTips);
+const tipPool = bountyBotTips.concat(bountyBotTips, discordTips);
 
 /** twice as likely to roll an application specific tip as a discord tip */
 function randomFooterTip() {


### PR DESCRIPTION
Summary
-------
- on completion of a bounty, grant the poster 1 bonus XP for each of: description, image URL, and timestamp set that are filled

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] a bounty with a description and no other optional fields provides 2 poster XP

Issue
-----
Closes #178 