### PR TITLE
#181: add "Take Down" button to bounty board threads

### DIFF
--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -5,6 +5,7 @@ const buttonDictionary = {};
 
 for (const file of [
 	"bbcomplete.js",
+	"bbtakedown.js",
 	"secondtoast.js"
 ]) {
 	/** @type {ButtonWrapper} */

--- a/source/buttons/bbtakedown.js
+++ b/source/buttons/bbtakedown.js
@@ -1,0 +1,52 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { ButtonWrapper } = require('../classes');
+const { SKIP_INTERACTION_HANDLING } = require('../constants');
+const { getRankUpdates } = require('../util/scoreUtil');
+
+const mainId = "bbtakedown";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [bountyId], database, runMode) => {
+		database.models.Bounty.findByPk(bountyId).then(async bounty => {
+			await interaction.deferReply({ ephemeral: true });
+			if (bounty.userId !== interaction.user.id) {
+				interaction.editReply({ content: "Only the bounty poster can take down their bounty." });
+				return;
+			}
+
+			interaction.editReply({
+				content: `Really take down this bounty?`,
+				components: [
+					new ActionRowBuilder().addComponents(
+						new ButtonBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}confirm`)
+							.setStyle(ButtonStyle.Success)
+							.setEmoji("✔")
+							.setLabel("Confirm")
+					)
+				]
+			}).then(reply => {
+				const collector = reply.createMessageComponentCollector({ max: 1 });
+
+				collector.on("collect", async collectedInteraction => {
+					const bounty = await database.models.Bounty.findByPk(bountyId, { include: database.models.Bounty.Company });
+					bounty.state = "deleted";
+					bounty.save();
+					database.models.Completion.destroy({ where: { bountyId: bounty.id } });
+					interaction.channel.delete("Bounty taken down by poster");
+					bounty.destroy();
+
+					database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
+						hunter.decrement("xp");
+						const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+						const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });
+						if (!participationCreated) {
+							participation.decrement("xp");
+						}
+						getRankUpdates(interaction.guild, database);
+					})
+
+					collectedInteraction.reply({ content: "Your bounty has been taken down.", ephemeral: true });
+				})
+			});
+		})
+	}
+);

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -214,11 +214,15 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 							return bountyBoard.threads.create({
 								name: bounty.title,
 								message: {
-									embeds: [bountyEmbed], components: [new ActionRowBuilder().addComponents(
+									embeds: [bountyEmbed],
+									components: [new ActionRowBuilder().addComponents(
 										new ButtonBuilder().setCustomId(`bbcomplete${SAFE_DELIMITER}${bounty.id}`)
 											.setStyle(ButtonStyle.Success)
 											.setLabel("Complete")
-											.setDisabled(true)
+											.setDisabled(true),
+										new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
+											.setStyle(ButtonStyle.Danger)
+											.setLabel("Take Down")
 									)]
 								},
 								appliedTags: [company.bountyBoardOpenTagId]

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -87,7 +87,10 @@ exports.Bounty = class extends Model {
 									new ButtonBuilder().setCustomId(`bbcomplete${SAFE_DELIMITER}${this.id}`)
 										.setStyle(ButtonStyle.Success)
 										.setLabel("Complete")
-										.setDisabled(new Date() < new Date(new Date(this.createdAt) + timeConversion(5, "m", "ms")))
+										.setDisabled(new Date() < new Date(new Date(this.createdAt) + timeConversion(5, "m", "ms"))),
+									new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${this.id}`)
+										.setStyle(ButtonStyle.Danger)
+										.setLabel("Take Down")
 								)
 							]
 						});


### PR DESCRIPTION
Summary
-------
- add "Take Down" button to bounty board threads

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] bounty board Take Down thread button removes the bounty and thread

Issue
-----
Closes #181