### PR TITLE
#180: add "Credit Bounty Hunters" and "Uncredit Bounty Hunters" buttons to bounty board threads

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 ## BountyBot Version 2.5.0:
 - Bounty board forums created by `/create-default` now have 👀 as a default reaction
 - BountyBot now provides shortcut links when mentioning its own commands
-- Threads on the bounty board now include Complete and Take Down buttons
+- Threads on the bounty board now include Complete, Add Completers, Remove Completers, and Take Down buttons
 - Bounty descriptions are now optional
 - Adding a description, image, or start and end timestamps each add a 1 XP bonus to the poster's XP on completion
 

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -4,7 +4,9 @@ const { ButtonWrapper } = require("../classes");
 const buttonDictionary = {};
 
 for (const file of [
+	"bbaddcompleters.js",
 	"bbcomplete.js",
+	"bbremovecompleters.js",
 	"bbtakedown.js",
 	"secondtoast.js"
 ]) {

--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -1,0 +1,78 @@
+const { ActionRowBuilder, UserSelectMenuBuilder } = require('discord.js');
+const { ButtonWrapper } = require('../classes');
+const { SKIP_INTERACTION_HANDLING } = require('../constants');
+const { commandMention } = require('../util/textUtil');
+
+const mainId = "bbaddcompleters";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [bountyId], database, runMode) => {
+		database.models.Bounty.findByPk(bountyId).then(async bounty => {
+			if (bounty.userId !== interaction.user.id) {
+				interaction.reply({ content: "Only the bounty poster can add completers.", ephemeral: true });
+				return;
+			}
+
+			interaction.reply({
+				content: "Which bounty hunters should be credited with completing the bounty?",
+				components: [
+					new ActionRowBuilder().addComponents(
+						new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
+							.setPlaceholder("Select bounty hunters...")
+					)
+				],
+				fetchReply: true,
+				ephemeral: true
+			}).then(reply => {
+				const collector = reply.createMessageComponentCollector({ max: 1 });
+
+				collector.on("collect", async (collectedInteraction) => {
+					const validatedCompleterIds = [];
+					const existingCompletions = await database.models.Completion.findAll({ where: { bountyId: bounty.id, companyId: collectedInteraction.guildId } });
+					const existingCompleterIds = existingCompletions.map(completion => completion.userId);
+					const bannedIds = [];
+					for (const member of collectedInteraction.members.values()) {
+						const memberId = member.id;
+						if (!existingCompleterIds.includes(memberId)) {
+							await database.models.User.findOrCreate({ where: { id: memberId } });
+							const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: collectedInteraction.guildId } });
+							if (hunter.isBanned) {
+								bannedIds.push(memberId);
+								continue;
+							}
+							if (memberId !== interaction.user.id && (runMode !== "prod" || !member.user.bot)) {
+								existingCompleterIds.push(memberId);
+								validatedCompleterIds.push(memberId);
+							}
+						}
+					}
+
+					if (validatedCompleterIds.length < 1) {
+						collectedInteraction.reply({ content: "Could not find any new non-bot completers.", ephemeral: true });
+						return;
+					}
+
+					const rawCompletions = [];
+					for (const userId of validatedCompleterIds) {
+						rawCompletions.push({
+							bountyId: bounty.id,
+							userId,
+							companyId: collectedInteraction.guildId
+						})
+					}
+					database.models.Completion.bulkCreate(rawCompletions);
+					const company = await database.models.Company.findByPk(collectedInteraction.guildId);
+					bounty.updatePosting(collectedInteraction.guild, company, database);
+
+					collectedInteraction.reply({
+						content: `The following bounty hunters have been added as completers to **${bounty.title}**: <@${validatedCompleterIds.join(">, <@")}>\n\nThey will recieve the reward XP when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: <@${bannedIds.join(">, ")}>` : ""}`,
+						ephemeral: true
+					});
+				})
+
+				collector.on("end", () => {
+					interaction.deleteReply();
+				})
+			})
+		})
+	}
+);

--- a/source/buttons/bbremovecompleters.js
+++ b/source/buttons/bbremovecompleters.js
@@ -1,0 +1,47 @@
+const { ActionRowBuilder, UserSelectMenuBuilder } = require('discord.js');
+const { ButtonWrapper } = require('../classes');
+const { SKIP_INTERACTION_HANDLING } = require('../constants');
+const { commandMention } = require('../util/textUtil');
+const { Op } = require('sequelize');
+
+const mainId = "bbremovecompleters";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [bountyId], database, runMode) => {
+		database.models.Bounty.findByPk(bountyId).then(async bounty => {
+			if (bounty.userId !== interaction.user.id) {
+				interaction.reply({ content: "Only the bounty poster can remove completers.", ephemeral: true });
+				return;
+			}
+
+			interaction.reply({
+				content: "Which bounty hunters should be removed from bounty credit?",
+				components: [
+					new ActionRowBuilder().addComponents(
+						new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
+							.setPlaceholder("Select bounty hunters...")
+					)
+				],
+				fetchReply: true,
+				ephemeral: true
+			}).then(reply => {
+				const collector = reply.createMessageComponentCollector({ max: 1 });
+
+				collector.on("collect", async (collectedInteraction) => {
+					const removedIds = collectedInteraction.members.map((_, key) => key);
+					database.models.Completion.destroy({ where: { bountyId: bounty.id, userId: { [Op.in]: removedIds } } });
+					const company = await database.models.Company.findByPk(collectedInteraction.guildId);
+					bounty.updatePosting(collectedInteraction.guild, company, database);
+
+					collectedInteraction.reply({
+						content: `The following bounty hunters have been removed as completers from **${bounty.title}**: <@${removedIds.join(">, ")}>`,
+						ephemeral: true
+					});
+				})
+
+				collector.on("end", () => {
+					interaction.deleteReply();
+				})
+			})
+		})
+	}
+);

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -220,6 +220,12 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 											.setStyle(ButtonStyle.Success)
 											.setLabel("Complete")
 											.setDisabled(true),
+										new ButtonBuilder().setCustomId(`bbaddcompleters${SAFE_DELIMITER}${bounty.id}`)
+											.setStyle(ButtonStyle.Primary)
+											.setLabel("Credit Hunters"),
+										new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${bounty.id}`)
+											.setStyle(ButtonStyle.Primary)
+											.setLabel("Uncredit Hunters"),
 										new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
 											.setStyle(ButtonStyle.Danger)
 											.setLabel("Take Down")

--- a/source/commands/create-default/bountyboardforum.js
+++ b/source/commands/create-default/bountyboardforum.js
@@ -1,7 +1,9 @@
-const { CommandInteraction, PermissionFlagsBits, SortOrderType, ForumLayoutType, ChannelType, OverwriteType } = require("discord.js");
+const { CommandInteraction, PermissionFlagsBits, SortOrderType, ForumLayoutType, ChannelType, OverwriteType, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { generateBountyBoardThread } = require("../../util/scoreUtil");
 const { Company } = require("../../models/companies/Company");
+const { SAFE_DELIMITER } = require("../../constants");
+const { timeConversion } = require("../../util/textUtil");
 
 /**
  * @param {CommandInteraction} interaction
@@ -50,7 +52,24 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 			}).then(bountyEmbed => {
 				return bountyBoard.threads.create({
 					name: bounty.title,
-					message: { embeds: [bountyEmbed] },
+					message: {
+						embeds: [bountyEmbed],
+						components: new ActionRowBuilder().addComponents(
+							new ButtonBuilder().setCustomId(`bbcomplete${SAFE_DELIMITER}${bounty.id}`)
+								.setStyle(ButtonStyle.Success)
+								.setLabel("Complete")
+								.setDisabled(new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))),
+							new ButtonBuilder().setCustomId(`bbaddcompleters${SAFE_DELIMITER}${bounty.id}`)
+								.setStyle(ButtonStyle.Primary)
+								.setLabel("Credit Hunters"),
+							new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${bounty.id}`)
+								.setStyle(ButtonStyle.Primary)
+								.setLabel("Uncredit Hunters"),
+							new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
+								.setStyle(ButtonStyle.Danger)
+								.setLabel("Take Down")
+						)
+					},
 					appliedTags: [openTagId]
 				})
 			}).then(posting => {

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -88,6 +88,12 @@ exports.Bounty = class extends Model {
 										.setStyle(ButtonStyle.Success)
 										.setLabel("Complete")
 										.setDisabled(new Date() < new Date(new Date(this.createdAt) + timeConversion(5, "m", "ms"))),
+									new ButtonBuilder().setCustomId(`bbaddcompleters${SAFE_DELIMITER}${this.id}`)
+										.setStyle(ButtonStyle.Primary)
+										.setLabel("Credit Hunters"),
+									new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${this.id}`)
+										.setStyle(ButtonStyle.Primary)
+										.setLabel("Uncredit Hunters"),
 									new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${this.id}`)
 										.setStyle(ButtonStyle.Danger)
 										.setLabel("Take Down")


### PR DESCRIPTION
Summary
-------
- Add "Credit Bounty Hunters" button
- Add "Uncredit bounty Hunters" button

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] "Credit Bounty Hunters" button creates a completion for the selected bounty hunters
- [x] "Uncredit Bounty Hunters" button deletes the completion for the selected bounty hunters

Issue
-----
Closes #180