### PR TITLE
#182: add "showcase" button to bounty threads

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 ## BountyBot Version 2.5.0:
 - Bounty board forums created by `/create-default` now have 👀 as a default reaction
 - BountyBot now provides shortcut links when mentioning its own commands
-- Threads on the bounty board now include Complete, Add Completers, Remove Completers, and Take Down buttons
+- Threads on the bounty board now include Complete, Add Completers, Remove Completers, Showcase, and Take Down buttons
 - Bounty descriptions are now optional
 - Adding a description, image, or start and end timestamps each add a 1 XP bonus to the poster's XP on completion
 

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -7,6 +7,7 @@ for (const file of [
 	"bbaddcompleters.js",
 	"bbcomplete.js",
 	"bbremovecompleters.js",
+	"bbshowcase.js",
 	"bbtakedown.js",
 	"secondtoast.js"
 ]) {

--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -18,6 +18,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					new ActionRowBuilder().addComponents(
 						new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
 							.setPlaceholder("Select bounty hunters...")
+							.setMaxValues(5)
 					)
 				],
 				fetchReply: true,

--- a/source/buttons/bbremovecompleters.js
+++ b/source/buttons/bbremovecompleters.js
@@ -19,6 +19,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					new ActionRowBuilder().addComponents(
 						new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
 							.setPlaceholder("Select bounty hunters...")
+							.setMaxValues(5)
 					)
 				],
 				fetchReply: true,

--- a/source/buttons/bbshowcase.js
+++ b/source/buttons/bbshowcase.js
@@ -1,0 +1,65 @@
+const { ActionRowBuilder, ChannelSelectMenuBuilder, ChannelType, PermissionFlagsBits } = require('discord.js');
+const { ButtonWrapper } = require('../classes');
+const { SKIP_INTERACTION_HANDLING } = require('../constants');
+const { timeConversion } = require('../util/textUtil');
+
+const mainId = "bbshowcase";
+module.exports = new ButtonWrapper(mainId, 3000,
+	(interaction, [bountyId], database, runMode) => {
+		database.models.Bounty.findByPk(bountyId).then(async bounty => {
+			if (bounty.userId !== interaction.user.id) {
+				interaction.reply({ content: "Only the bounty poster can showcase the bounty.", ephemeral: true });
+				return;
+			}
+
+			const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
+			const nextShowcaseInMS = new Date(poster.lastShowcaseTimestamp).valueOf() + timeConversion(1, "w", "ms");
+			if (Date.now() < nextShowcaseInMS) {
+				interaction.reply({ content: `You can showcase another bounty in <t:${Math.floor(nextShowcaseInMS / 1000)}:R>.`, ephemeral: true });
+				return;
+			}
+
+			interaction.reply({
+				content: "Which channel should this bounty be showcased in?",
+				components: [
+					new ActionRowBuilder().addComponents(
+						new ChannelSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
+							.setPlaceholder("Select channel...")
+							.setChannelTypes(ChannelType.GuildText)
+					)
+				],
+				fetchReply: true,
+				ephemeral: true
+			}).then(reply => {
+				const collector = reply.createMessageComponentCollector({ max: 1 });
+
+				collector.on("collect", async (collectedInteraction) => {
+					const showcaseChannel = collectedInteraction.channels.first();
+					if (!showcaseChannel.members.has(collectedInteraction.client.user.id)) {
+						collectedInteraction.reply({ content: "BountyBot is not in the selected channel.", ephemeral: true });
+						return;
+					}
+
+					if (!showcaseChannel.permissionsFor(collectedInteraction.user.id).has(PermissionFlagsBits.ViewChannel & PermissionFlagsBits.SendMessages)) {
+						collectedInteraction.reply({ content: "You must have permission to view and send messages in the selected channel to showcase a bounty in it.", ephemeral: true });
+						return;
+					}
+
+					bounty.increment("showcaseCount");
+					await bounty.save().then(bounty => bounty.reload());
+					const company = await database.models.Company.findByPk(collectedInteraction.guildId);
+					bounty.updatePosting(collectedInteraction.guild, company, database);
+					poster.lastShowcaseTimestamp = new Date();
+					poster.save();
+					bounty.asEmbed(collectedInteraction.guild, poster.level, company.festivalMultiplierString(), false, database).then(embed => {
+						showcaseChannel.send({ content: `${collectedInteraction.member} increased the reward on their bounty!`, embeds: [embed] });
+					})
+				})
+
+				collector.on("end", () => {
+					interaction.deleteReply();
+				})
+			})
+		})
+	}
+);

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -224,8 +224,11 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 											.setStyle(ButtonStyle.Primary)
 											.setLabel("Credit Hunters"),
 										new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${bounty.id}`)
-											.setStyle(ButtonStyle.Primary)
+											.setStyle(ButtonStyle.Secondary)
 											.setLabel("Uncredit Hunters"),
+										new ButtonBuilder().setCustomId(`bbshowcase${SAFE_DELIMITER}${bounty.id}`)
+											.setStyle(ButtonStyle.Primary)
+											.setLabel("Showcase this Bounty"),
 										new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
 											.setStyle(ButtonStyle.Danger)
 											.setLabel("Take Down")

--- a/source/commands/create-default/bountyboardforum.js
+++ b/source/commands/create-default/bountyboardforum.js
@@ -63,8 +63,11 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 								.setStyle(ButtonStyle.Primary)
 								.setLabel("Credit Hunters"),
 							new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${bounty.id}`)
-								.setStyle(ButtonStyle.Primary)
+								.setStyle(ButtonStyle.Secondary)
 								.setLabel("Uncredit Hunters"),
+							new ButtonBuilder().setCustomId(`bbshowcase${SAFE_DELIMITER}${bounty.id}`)
+								.setStyle(ButtonStyle.Primary)
+								.setLabel("Showcase this Bounty"),
 							new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
 								.setStyle(ButtonStyle.Danger)
 								.setLabel("Take Down")

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -92,8 +92,11 @@ exports.Bounty = class extends Model {
 										.setStyle(ButtonStyle.Primary)
 										.setLabel("Credit Hunters"),
 									new ButtonBuilder().setCustomId(`bbremovecompleters${SAFE_DELIMITER}${this.id}`)
-										.setStyle(ButtonStyle.Primary)
+										.setStyle(ButtonStyle.Secondary)
 										.setLabel("Uncredit Hunters"),
+									new ButtonBuilder().setCustomId(`bbshowcase${SAFE_DELIMITER}${this.id}`)
+										.setStyle(ButtonStyle.Primary)
+										.setLabel("Showcase this Bounty"),
 									new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${this.id}`)
 										.setStyle(ButtonStyle.Danger)
 										.setLabel("Take Down")


### PR DESCRIPTION
Summary
-------
- add "showcase" button to bounty threads

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Showcase bounty board button checks for relevant permissions, increases a bounty's showcase count, and posts in the selected channel

Issue
-----
Closes #182 