### PR TITLE
#196: fix `/bounty complete` attempts to modify an archived thread

### DIFF
--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -116,7 +116,10 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 
 			if (bounty.Company.bountyBoardId) {
 				interaction.guild.channels.fetch(bounty.Company.bountyBoardId).then(bountyBoard => {
-					bountyBoard.threads.fetch(bounty.postingId).then(thread => {
+					bountyBoard.threads.fetch(bounty.postingId).then(async thread => {
+						if (thread.archived) {
+							await thread.setArchived(false, "bounty completed");
+						}
 						thread.setAppliedTags([bounty.Company.bountyBoardCompletedTagId]);
 						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
 					})

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -69,9 +69,10 @@ exports.Bounty = class extends Model {
 			const poster = await database.models.Hunter.findOne({ where: { userId: this.userId, companyId: this.companyId } });
 			return guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 				return bountyBoard.threads.fetch(this.postingId);
-			}).then(thread => {
-				return thread.setArchived(false, "Unarchived to update posting");
-			}).then(thread => {
+			}).then(async thread => {
+				if (thread.archived) {
+					await thread.setArchived(false, "Unarchived to update posting");
+				}
 				thread.edit({ name: this.title });
 				return thread.fetchStarterMessage();
 			}).then(posting => {


### PR DESCRIPTION
Summary
-------
- fix attempts to modify archived threads in `/bounty complete` if thread is archived before completion
- created logic to avoid unnecessary unarchive requests

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] using `/bounty complete` on bounties whose threads are already archived doesn't crash

Issue
-----
Closes #196