### PR TITLE
#202: fix crash when using bounty board buttons

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,10 +5,11 @@ Items are consumables that are associated with a Discord account (rather than a 
 - Look up which items you've found with `/inventory` then use them with `/item`
 - Added Profile Colorizers: these come in many different colors and allow you to change the color of your profile in the server they're used in
 
-### Balance
+### Other Changes
 - A toast's raiser is no longer considered recieving secondings on that toast.
    - This lead to weird incentives to be the first to toast an event/achievement to get the secondings and not second toasts by competitors.
    - In the case of raising a toast to all members of a group from within a group, having someone else raise a toast to the first toast's raiser will achieve the same effect.
+- Fixed crashes when using bounty board thread buttons
 
 ## BountyBot Version 2.5.1:
 - Fixed a crash

--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -65,9 +65,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					const company = await database.models.Company.findByPk(collectedInteraction.guildId);
 					bounty.asEmbed(collectedInteraction.guild, poster.level, company.festivalMultiplierString(), false, database).then(async embed => {
 						if (collectedInteraction.channel.archived) {
-							await collectedInteraction.channel.setArchived(false, "bounty complete");
+							await collectedInteraction.channel.setArchived(false, "completers added to bounty");
 						}
-						collectedInteraction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
+						interaction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
 					});
 
 					collectedInteraction.reply({

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -133,7 +133,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							collectedInteraction.channel.setAppliedTags([company.bountyBoardCompletedTagId]);
 							collectedInteraction.reply({ content: text, flags: MessageFlags.SuppressNotifications });
 							bounty.asEmbed(collectedInteraction.guild, poster.level, company.festivalMultiplierString(), true, database).then(embed => {
-								collectedInteraction.message.edit({ embeds: [embed], components: [] });
+								interaction.message.edit({ embeds: [embed], components: [] });
 								collectedInteraction.channel.setArchived(true, "bounty completed");
 							})
 							updateScoreboard(company, collectedInteraction.guild, database);

--- a/source/buttons/bbremovecompleters.js
+++ b/source/buttons/bbremovecompleters.js
@@ -33,9 +33,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					const company = await database.models.Company.findByPk(collectedInteraction.guildId);
 					bounty.asEmbed(collectedInteraction.guild, poster.level, company.festivalMultiplierString(), false, database).then(async embed => {
 						if (collectedInteraction.channel.archived) {
-							await collectedInteraction.channel.setArchived(false, "bounty complete");
+							await collectedInteraction.channel.setArchived(false, "completers removed from bounty");
 						}
-						collectedInteraction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
+						interaction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
 					});
 
 					collectedInteraction.reply({

--- a/source/buttons/bbshowcase.js
+++ b/source/buttons/bbshowcase.js
@@ -52,9 +52,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					poster.save();
 					bounty.asEmbed(collectedInteraction.guild, poster.level, company.festivalMultiplierString(), false, database).then(async embed => {
 						if (collectedInteraction.channel.archived) {
-							await collectedInteraction.channel.setArchived(false, "bounty complete");
+							await collectedInteraction.channel.setArchived(false, "bounty showcased");
 						}
-						collectedInteraction.message.edit({ embeds: [embed] });
+						interaction.message.edit({ embeds: [embed] });
 						showcaseChannel.send({ content: `${collectedInteraction.member} increased the reward on their bounty!`, embeds: [embed] });
 					})
 				})


### PR DESCRIPTION
Summary
-------
- fix crash when using bounty board buttons

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] bounty board thread buttons no longer crash bot

Issue
-----
Closes #202 