### PR TITLE
Fixes #93

### DIFF
--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -157,15 +157,15 @@ async function textsHaveAutoModInfraction(channel, member, texts, context) {
 			continue;
 		}
 
-		//TODO #93 use rule.triggerMetaData.allowList
 		const hasRegexTrigger = texts.some(text => rule.triggerMetadata.regexPatterns.some(regex => new RegExp(regex).test(text)));
 		const hasKeywordFilter = texts.some(text => rule.triggerMetadata.keywordFilter.some(regex => new RegExp(regex).test(text)));
+		const hasAllowListFilter = texts.some(text => rule.triggerMetadata.allowList.some(regex => new RegExp(regex).test(text)))
 		//TODO #94 fetch Discord presets from enum
 		const exceedsMentionLimit = texts.some(text => {
 			text.match(/<@[\d&]+>/)?.length > rule.triggerMetadata.mentionTotalLimit
 		});
-		for (const action of rule.actions) {
-			if (hasRegexTrigger || hasKeywordFilter || exceedsMentionLimit) {
+		if (((hasRegexTrigger || hasKeywordFilter) && !hasAllowListFilter) || exceedsMentionLimit) {
+			for (const action of rule.actions) {
 				switch (action.type) {
 					case AutoModerationActionType.SendAlertMessage:
 						if (action.metadata.channelId) {


### PR DESCRIPTION
Summary
-------
- implemented rule.triggerMetaData.allowList
- changed condition order to reduce cognitive and computational load

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] bot still blocks bounty posts with banned words/phrases that do not have the full allowed phrase/word
- [X] bot allows bounty posts which use the allowed phrase/word, even if that phrase/word uses a banned phrase/word

Issue
-----
Closes #93
