### PR TITLE
#207: add XP Boost items

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # BountyBot Change Log
+## BountyBot Version 2.6.1:
+- Added XP Boosts: use them to gain XP in the used server
+
 ## BountyBot Version 2.6.0:
 ### Items
 Items are consumables that are associated with a Discord account (rather than a server). They drop from bounties and do cool things when used.

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -5,7 +5,7 @@ const { Bounty } = require('../models/bounties/Bounty');
 const { updateScoreboard } = require('../util/embedUtil');
 const { getRankUpdates } = require('../util/scoreUtil');
 const { commandMention } = require('../util/textUtil');
-const { getItemNames } = require('../items/_itemDictionary');
+const { rollItemDrop } = require('../items/_itemDictionary');
 
 const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -86,14 +86,13 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							}
 							hunter.othersFinished++;
 							hunter.save();
-							if (Math.random() * 8 >= 7) {
-								const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
-								const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
-								const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
+							const droppedItem = rollItemDrop(1 / 8);
+							if (droppedItem) {
+								const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: droppedItem });
 								if (!itemWasCreated) {
 									itemRow.increment();
 								}
-								levelTexts.push(`<@${hunter.userId}> has found a **${rolledItem}**!`);
+								levelTexts.push(`<@${hunter.userId}> has found a **${droppedItem}**!`);
 							}
 						}
 
@@ -104,14 +103,13 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						}
 						poster.mineFinished++;
 						poster.save();
-						if (Math.random() * 4 >= 3) {
-							const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
-							const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
-							const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
+						const droppedItem = rollItemDrop(1 / 4);
+						if (droppedItem) {
+							const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: droppedItem });
 							if (!itemWasCreated) {
 								itemRow.increment();
 							}
-							levelTexts.push(`<@${poster.userId}> has found a **${rolledItem}**!`);
+							levelTexts.push(`<@${poster.userId}> has found a **${droppedItem}**!`);
 						}
 
 						getRankUpdates(collectedInteraction.guild, database).then(async rankUpdates => {

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -87,7 +87,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							hunter.othersFinished++;
 							hunter.save();
 							if (Math.random() * 8 >= 7) {
-								const itemNames = getItemNames();
+								const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
 								const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
 								const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
 								if (!itemWasCreated) {
@@ -105,7 +105,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						poster.mineFinished++;
 						poster.save();
 						if (Math.random() * 4 >= 3) {
-							const itemNames = getItemNames();
+							const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
 							const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
 							const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
 							if (!itemWasCreated) {

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -1,6 +1,4 @@
-const { CommandInteraction } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { Sequelize } = require('sequelize');
 
 /** @type {string[]} */
 exports.commandFiles = [

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -5,7 +5,7 @@ const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions, timeConversion, commandMention } = require("../../util/textUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
-const { getItemNames } = require("../../items/_itemDictionary");
+const { rollItemDrop } = require("../../items/_itemDictionary");
 
 /**
  * @param {CommandInteraction} interaction
@@ -89,14 +89,13 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		}
 		hunter.othersFinished++;
 		hunter.save();
-		if (Math.random() * 8 >= 7) {
-			const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
-			const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
-			const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
+		const droppedItem = rollItemDrop(1 / 8);
+		if (droppedItem) {
+			const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: droppedItem });
 			if (!itemWasCreated) {
 				itemRow.increment();
 			}
-			levelTexts.push(`<@${hunter.userId}> has found a **${rolledItem}**!`);
+			levelTexts.push(`<@${hunter.userId}> has found a **${droppedItem}**!`);
 		}
 	}
 
@@ -107,14 +106,13 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	}
 	poster.mineFinished++;
 	poster.save();
-	if (Math.random() * 4 >= 3) {
-		const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
-		const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
-		const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
+	const droppedItem = rollItemDrop(1 / 4);
+	if (droppedItem) {
+		const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: droppedItem });
 		if (!itemWasCreated) {
 			itemRow.increment();
 		}
-		levelTexts.push(`<@${poster.userId}> has found a **${rolledItem}**!`);
+		levelTexts.push(`<@${poster.userId}> has found a **${droppedItem}**!`);
 	}
 
 	getRankUpdates(interaction.guild, database).then(rankUpdates => {

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -90,7 +90,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		hunter.othersFinished++;
 		hunter.save();
 		if (Math.random() * 8 >= 7) {
-			const itemNames = getItemNames();
+			const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
 			const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
 			const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
 			if (!itemWasCreated) {
@@ -108,7 +108,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	poster.mineFinished++;
 	poster.save();
 	if (Math.random() * 4 >= 3) {
-		const itemNames = getItemNames();
+		const itemNames = getItemNames(["Epic XP Boost", "Legendary XP Boost"]);
 		const rolledItem = itemNames[Math.floor(Math.random()) * itemNames.length];
 		const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ userId: interaction.user.id, itemName: rolledItem });
 		if (!itemWasCreated) {

--- a/source/commands/item.js
+++ b/source/commands/item.js
@@ -45,6 +45,6 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 		name: "item-name",
 		description: "The item to look up details on",
 		required: true,
-		autocomplete: getItemNames().map(name => ({ name, value: name }))
+		autocomplete: getItemNames([]).map(name => ({ name, value: name }))
 	}
 );

--- a/source/items/_itemDictionary.js
+++ b/source/items/_itemDictionary.js
@@ -52,6 +52,29 @@ exports.getItemNames = function (exclusions) {
 	return ITEM_NAMES.filter(name => !exclusions.includes(name));
 }
 
+/** pool picker range: 0-120
+ * @type {Record<number, string[]>} key as theshold to get to pool defined by string array
+ */
+const DROP_TABLE = {
+	90: ["XP Boost"],
+	0: exports.getItemNames(["XP Boost", "Epic XP Boost", "Legendary XP Boost"])
+};
+
+/** @param {number} dropRate as a decimal between 0 and 1 (exclusive) */
+exports.rollItemDrop = function (dropRate) {
+	if (Math.random() < dropRate) {
+		const poolThresholds = Object.keys(DROP_TABLE).map(unparsed => parseFloat(unparsed)).sort((a, b) => b - a);
+		const poolRandomNumber = Math.random() * 120;
+		for (const threshold of poolThresholds) {
+			if (poolRandomNumber > threshold) {
+				const pool = DROP_TABLE[threshold];
+				return pool[Math.floor(Math.random() * pool.length)];
+			}
+		}
+	}
+	return null;
+}
+
 /** @param {string} itemName */
 exports.getItemDescription = function (itemName) {
 	return ITEMS[itemName].description;

--- a/source/items/_itemDictionary.js
+++ b/source/items/_itemDictionary.js
@@ -36,7 +36,10 @@ for (const file of [
 	"profile-colorizer-purple.js",
 	"profile-colorizer-red.js",
 	"profile-colorizer-white.js",
-	"profile-colorizer-yellow.js"
+	"profile-colorizer-yellow.js",
+	"xp-boost-epic.js",
+	"xp-boost-legendary.js",
+	"xp-boost.js"
 ]) {
 	/** @type {Item} */
 	const item = require(`./${file}`);
@@ -44,8 +47,9 @@ for (const file of [
 	ITEM_NAMES.push(item.name);
 }
 
-exports.getItemNames = function () {
-	return ITEM_NAMES;
+/** @param {string[]} exclusions */
+exports.getItemNames = function (exclusions) {
+	return ITEM_NAMES.filter(name => !exclusions.includes(name));
 }
 
 /** @param {string} itemName */

--- a/source/items/xp-boost-epic.js
+++ b/source/items/xp-boost-epic.js
@@ -1,0 +1,21 @@
+const { Item } = require("../classes");
+
+const itemName = "Epic XP Boost";
+const xpValue = 25;
+module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`,
+	(interaction, database) => {
+		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+			hunter.addXP(interaction.guild.name, xpValue, true, database).then(levelTexts => {
+				getRankUpdates(interaction.guild, database).then(rankUpdates => {
+					hunter.save();
+					let result = `${interaction.member} used an XP Boost and gained ${xpValue} XP.`;
+					const allMessages = rankUpdates.concat(levelTexts);
+					if (allMessages.length > 0) {
+						result += `\n- ${allMessages.join("\n- ")}`;
+					}
+					interaction.reply({ content: result });
+				})
+			});
+		})
+	}
+);

--- a/source/items/xp-boost-legendary.js
+++ b/source/items/xp-boost-legendary.js
@@ -1,0 +1,22 @@
+const { Item } = require("../classes");
+const { getRankUpdates } = require("../util/scoreUtil");
+
+const itemName = "Legendary XP Boost";
+const xpValue = 75;
+module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`,
+	(interaction, database) => {
+		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+			hunter.addXP(interaction.guild.name, xpValue, true, database).then(levelTexts => {
+				getRankUpdates(interaction.guild, database).then(rankUpdates => {
+					hunter.save();
+					let result = `${interaction.member} used an XP Boost and gained ${xpValue} XP.`;
+					const allMessages = rankUpdates.concat(levelTexts);
+					if (allMessages.length > 0) {
+						result += `\n- ${allMessages.join("\n- ")}`;
+					}
+					interaction.reply({ content: result });
+				})
+			});
+		})
+	}
+);

--- a/source/items/xp-boost.js
+++ b/source/items/xp-boost.js
@@ -1,0 +1,21 @@
+const { Item } = require("../classes");
+
+const itemName = "XP Boost";
+const xpValue = 5;
+module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`,
+	(interaction, database) => {
+		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+			hunter.addXP(interaction.guild.name, xpValue, true, database).then(levelTexts => {
+				getRankUpdates(interaction.guild, database).then(rankUpdates => {
+					hunter.save();
+					let result = `${interaction.member} used an XP Boost and gained ${xpValue} XP.`;
+					const allMessages = rankUpdates.concat(levelTexts);
+					if (allMessages.length > 0) {
+						result += `\n- ${allMessages.join("\n- ")}`;
+					}
+					interaction.reply({ content: result });
+				})
+			});
+		})
+	}
+);


### PR DESCRIPTION
Summary
-------
- added XP Boost, Epic XP Boost, and Legendary XP Boost items; these add XP to the hunter in the used guild
- item drops now roll a pool (eg colorizers vs xp boosts) before rolling which item in the pool to award the user

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] XP Boost items grant xp when used
- [x] item drops rolled both pools, relatively close to the designed frequency

Issue
-----
Closes #207 