### PR TITLE
#205: redesign responses to bounty completion

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 # BountyBot Change Log
 ## BountyBot Version 2.6.1:
 - Added XP Boosts: use them to gain XP in the used server
+- The bot now announces when a bounty has been completed publically (so other bounty hunters know)
+- The complete button on the bounty board now takes an input of a which channel to announce the bounty's completion in
+- Completing a bounty without a bounty board now stows rewards lists in a thread
 
 ## BountyBot Version 2.6.0:
 ### Items

--- a/source/buttons/bbshowcase.js
+++ b/source/buttons/bbshowcase.js
@@ -23,7 +23,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				content: "Which channel should this bounty be showcased in?",
 				components: [
 					new ActionRowBuilder().addComponents(
-						new ChannelSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}`)
+						new ChannelSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
 							.setPlaceholder("Select channel...")
 							.setChannelTypes(ChannelType.GuildText)
 					)


### PR DESCRIPTION
Summary
-------
- if no bounty board, place rewards in thread
- if bounty board and completed by slash command, mention completion in non-ephemeral message
- change bounty board completion button to take channel as input in which to announce bounty completion
- fix several crashes associated with item drops

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested completion via slash command without bounty board
- [x] tested completion via slash command with bounty board
- [x] tested completion via bounty board button

Issue
-----
Closes #205 