### PR TITLE
#224 & #229: send a audit message in bounty board thread on add completers, implement listifyEN

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 - `/item` now previews the color of Profile Colorizers in its own embed
 - Fixed a bug where a hunter would gain XP for seconding a toast they were originally a recipient of
 - Added a label for when a toast or seconding is a critical toast (awards the toaster XP)
+- Adding completers to a bounty now sends a public message in the bounty board's thread (if it exists)
 - Editing a bounty now sends a message to mark the time of the edit in the bounty board's thread (if it exists)
 - Fixed several crashs when handling bounties lacking descriptions
 

--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, UserSelectMenuBuilder } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
-const { commandMention } = require('../util/textUtil');
+const { commandMention, listifyEN, congratulationBuilder } = require('../util/textUtil');
 
 const mainId = "bbaddcompleters";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -70,8 +70,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						interaction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
 					});
 
+					collectedInteraction.channel.send({ content: `${listifyEN(validatedCompleterIds.map(id => `<@${id}>`))} ${validatedCompleterIds.length === 1 ? "has" : "have"} been added as ${validatedCompleterIds.length === 1 ? "a completer" : "completers"} of this bounty! ${congratulationBuilder()}!` });
 					collectedInteraction.reply({
-						content: `The following bounty hunters have been added as completers to **${bounty.title}**: <@${validatedCompleterIds.join(">, <@")}>\n\nThey will recieve the reward XP when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: <@${bannedIds.join(">, ")}>` : ""}`,
+						content: `Completers have been added to **${bounty.title}**! They will recieve the reward XP when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: <@${bannedIds.join(">, ")}>` : ""}`,
 						ephemeral: true
 					});
 				})

--- a/source/commands/create-default/bountyboardforum.js
+++ b/source/commands/create-default/bountyboardforum.js
@@ -54,7 +54,7 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 					name: bounty.title,
 					message: {
 						embeds: [bountyEmbed],
-						components: new ActionRowBuilder().addComponents(
+						components: [new ActionRowBuilder().addComponents(
 							new ButtonBuilder().setCustomId(`bbcomplete${SAFE_DELIMITER}${bounty.id}`)
 								.setStyle(ButtonStyle.Success)
 								.setLabel("Complete")
@@ -71,7 +71,7 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 							new ButtonBuilder().setCustomId(`bbtakedown${SAFE_DELIMITER}${bounty.id}`)
 								.setStyle(ButtonStyle.Danger)
 								.setLabel("Take Down")
-						)
+						)]
 					},
 					appliedTags: [openTagId]
 				})

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -2,7 +2,7 @@ const { PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const { Op } = require('sequelize');
 const { SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH } = require('../constants');
 const { CommandWrapper } = require('../classes');
-const { extractUserIdsFromMentions, textsHaveAutoModInfraction, timeConversion, commandMention } = require('../util/textUtil');
+const { extractUserIdsFromMentions, textsHaveAutoModInfraction, timeConversion, commandMention, listifyEN } = require('../util/textUtil');
 const { getRankUpdates } = require('../util/scoreUtil');
 const { updateScoreboard } = require('../util/embedUtil');
 
@@ -67,7 +67,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		embed.setColor("e5b271")
 			.setThumbnail(company.toastThumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
 			.setTitle(toastText)
-			.setDescription(`A toast to <@${nonBotToasteeIds.join(">, <@")}>!`)
+			.setDescription(`A toast to ${listifyEN(nonBotToasteeIds.map(id => `<@${id}>`))}!`)
 			.setFooter({ text: interaction.member.displayName, iconURL: interaction.user.avatarURL() });
 
 		// Make database entities

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -191,6 +191,31 @@ async function textsHaveAutoModInfraction(channel, member, texts, context) {
 	return shouldBlockMessage;
 }
 
+/** Formats string array into Oxford English list syntax
+ *  @param {string[]} texts
+ *  @param {boolean} isMutuallyExclusive
+ */
+function listifyEN(texts, isMutuallyExclusive) {
+	if (texts.length > 2) {
+		const textsSansLast = texts.slice(0, texts.length - 1);
+		if (isMutuallyExclusive) {
+			return `${textsSansLast.join(", ")}, or ${texts[texts.length - 1]}`;
+		} else {
+			return `${textsSansLast.join(", ")}, and ${texts[texts.length - 1]}`;
+		}
+	} else if (texts.length === 2) {
+		if (isMutuallyExclusive) {
+			return texts.join(" or ");
+		} else {
+			return texts.join(" and ");
+		}
+	} else if (texts.length === 1) {
+		return texts[0];
+	} else {
+		return "";
+	}
+}
+
 /** @param {string} text */
 function trimForSelectOptionDescription(text) {
 	if (text.length > 100) {
@@ -217,6 +242,7 @@ module.exports = {
 	timeConversion,
 	extractUserIdsFromMentions,
 	textsHaveAutoModInfraction,
+	listifyEN,
 	trimForSelectOptionDescription,
 	trimForModalTitle
 };


### PR DESCRIPTION
Summary
-------
- send a audit message in bounty board thread on add completers
- implement listifyEN
- fix crash in /create-default bounty-board-forum

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] add completers thread button sends a public congratulatory message
- [x] /bounty add-completers sends a public congratulatory message in bounty board thread if it exists
- [x] /bounty add-completers doesn't crash if bounty board thread doesn't exist
- [x] /toast uses listified syntax for toastees in embed

Issue
-----
Closes #224, Closes #229