### PR TITLE
#225: removing completers leaves audit message in bounty board thread

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Fixed a bug where a hunter would gain XP for seconding a toast they were originally a recipient of
 - Added a label for when a toast or seconding is a critical toast (awards the toaster XP)
 - Adding completers to a bounty now sends a public message in the bounty board's thread (if it exists)
+- Removing completers from a bounty now sends a public message in the bounty board's thread (if it exists)
 - Editing a bounty now sends a message to mark the time of the edit in the bounty board's thread (if it exists)
 - Fixed several crashs when handling bounties lacking descriptions
 

--- a/source/buttons/bbremovecompleters.js
+++ b/source/buttons/bbremovecompleters.js
@@ -2,6 +2,7 @@ const { ActionRowBuilder, UserSelectMenuBuilder } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { Op } = require('sequelize');
+const { listifyEN } = require('../util/textUtil');
 
 const mainId = "bbremovecompleters";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -38,8 +39,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						interaction.message.edit({ embeds: [embed], components: bounty.generateBountyBoardButtons() })
 					});
 
+					collectedInteraction.channel.send({ content: `${listifyEN(removedIds.map(id => `<@${id}>`))} ${removedIds.length === 1 ? "has" : "have"} been removed as ${removedIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
 					collectedInteraction.reply({
-						content: `The following bounty hunters have been removed as completers from **${bounty.title}**: <@${removedIds.join(">, ")}>`,
+						content: `The listed bounty hunter(s) will no longer recieve credit when this bounty is completed.`,
 						ephemeral: true
 					});
 				})


### PR DESCRIPTION
Summary
-------
- removing completers leaves audit message in bounty board thread

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] removing completer via thread button sends message in thread
- [x] /bounty remove-completer sends message in thread if extent
- [x] /bounty remove-completer doesn't crash if bounty board doesn't exist

Issue
-----
Closes #225