### PR TITLE
#232: add Unidentified Item and Loot Box

### DIFF
--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -5,7 +5,7 @@ const { Bounty } = require('../models/bounties/Bounty');
 const { updateScoreboard } = require('../util/embedUtil');
 const { getRankUpdates } = require('../util/scoreUtil');
 const { commandMention, timeConversion } = require('../util/textUtil');
-const { rollItemDrop } = require('../items/_itemDictionary');
+const { rollItemDrop } = require('../util/itemUtil');
 
 const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -5,7 +5,7 @@ const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions, timeConversion, commandMention } = require("../../util/textUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
-const { rollItemDrop } = require("../../items/_itemDictionary");
+const { rollItemDrop } = require("../../util/itemUtil");
 
 /**
  * @param {CommandInteraction} interaction

--- a/source/items/_itemDictionary.js
+++ b/source/items/_itemDictionary.js
@@ -9,6 +9,7 @@ const ITEM_NAMES = [];
 
 for (const file of [
 	"bonus-bounty-showcase.js",
+	"loot-box.js",
 	"profile-colorizer-aqua.js",
 	"profile-colorizer-blue.js",
 	"profile-colorizer-blurple.js",
@@ -38,6 +39,7 @@ for (const file of [
 	"profile-colorizer-red.js",
 	"profile-colorizer-white.js",
 	"profile-colorizer-yellow.js",
+	"unidentified-item.js",
 	"xp-boost-epic.js",
 	"xp-boost-legendary.js",
 	"xp-boost.js"
@@ -51,29 +53,6 @@ for (const file of [
 /** @param {string[]} exclusions */
 exports.getItemNames = function (exclusions) {
 	return ITEM_NAMES.filter(name => !exclusions.includes(name));
-}
-
-/** pool picker range: 0-120
- * @type {Record<number, string[]>} key as theshold to get to pool defined by string array
- */
-const DROP_TABLE = {
-	90: ["XP Boost", "Bonus Bounty Showcase"],
-	0: exports.getItemNames(["XP Boost", "Epic XP Boost", "Legendary XP Boost", "Bonus Bounty Showcase"])
-};
-
-/** @param {number} dropRate as a decimal between 0 and 1 (exclusive) */
-exports.rollItemDrop = function (dropRate) {
-	if (Math.random() < dropRate) {
-		const poolThresholds = Object.keys(DROP_TABLE).map(unparsed => parseFloat(unparsed)).sort((a, b) => b - a);
-		const poolRandomNumber = Math.random() * 120;
-		for (const threshold of poolThresholds) {
-			if (poolRandomNumber > threshold) {
-				const pool = DROP_TABLE[threshold];
-				return pool[Math.floor(Math.random() * pool.length)];
-			}
-		}
-	}
-	return null;
 }
 
 /** @param {string} itemName */

--- a/source/items/loot-box.js
+++ b/source/items/loot-box.js
@@ -1,0 +1,17 @@
+const { Item } = require("../classes");
+const { rollItemDrop } = require("../util/itemUtil");
+const { commandMention } = require("../util/textUtil");
+
+const itemName = "Loot Box";
+module.exports = new Item(itemName, "Unboxes into 2 random items!", 3000,
+	async (interaction, database) => {
+		const rolledItems = [rollItemDrop(1), rollItemDrop(1)];
+		for (const droppedItem of rolledItems) {
+			const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ where: { userId: interaction.user.id, itemName: droppedItem } });
+			if (!itemWasCreated) {
+				itemRow.increment("count");
+			}
+		}
+		interaction.reply({ content: `Inside the Loot Box was a **${rolledItems[0]}** and a **${rolledItems[1]}**! Use one with ${commandMention("item")}?`, ephemeral: true });
+	}
+);

--- a/source/items/unidentified-item.js
+++ b/source/items/unidentified-item.js
@@ -1,0 +1,15 @@
+const { Item } = require("../classes");
+const { rollItemDrop } = require("../util/itemUtil");
+const { commandMention } = require("../util/textUtil");
+
+const itemName = "Unidentified Item";
+module.exports = new Item(itemName, "Rolls as a random item!", 3000,
+	async (interaction, database) => {
+		const rolledItem = rollItemDrop(1);
+		const [itemRow, itemWasCreated] = await database.models.Item.findOrCreate({ where: { userId: interaction.user.id, itemName: rolledItem } });
+		if (!itemWasCreated) {
+			itemRow.increment("count");
+		}
+		interaction.reply({ content: `The unidentified item was a **${rolledItem}**! Use it with ${commandMention("item")}?`, ephemeral: true });
+	}
+);

--- a/source/util/itemUtil.js
+++ b/source/util/itemUtil.js
@@ -1,0 +1,58 @@
+/** pool picker range: 0-120
+ * @type {Record<number, string[]>} key as theshold to get to pool defined by string array
+ */
+const DROP_TABLE = {
+	90: [
+		"XP Boost",
+		"Bonus Bounty Showcase"
+	],
+	0: [
+		"Aqua Profile Colorizer",
+		"Blue Profile Colorizer",
+		"Blurple Profile Colorizer",
+		"Dark Aqua Profile Colorizer",
+		"Dark Blue Profile Colorizer",
+		"Dark But Not Black Profile Colorizer",
+		"Darker Grey Profile Colorizer",
+		"Dark Gold Profile Colorizer",
+		"Dark Green Profile Colorizer",
+		"Dark Grey Profile Colorizer",
+		"Dark Navy Profile Colorizer",
+		"Dark Orange Profile Colorizer",
+		"Dark Purple Profile Colorizer",
+		"Dark Red Profile Colorizer",
+		"Dark Vivid Pink Profile Colorizer",
+		"Default Profile Colorizer",
+		"Fuchsia Profile Colorizer",
+		"Gold Profile Colorizer",
+		"Green Profile Colorizer",
+		"Grey Profile Colorizer",
+		"Greyple Profile Colorizer",
+		"Light Grey Profile Colorizer",
+		"Luminous Vivid Pink Profile Colorizer",
+		"Orange Profile Colorizer",
+		"Purple Profile Colorizer",
+		"Red Profile Colorizer",
+		"White Profile Colorizer",
+		"Yellow Profile Colorizer",
+	]
+};
+
+/** @param {number} dropRate as a decimal between 0 and 1 (exclusive) */
+function rollItemDrop(dropRate) {
+	if (Math.random() < dropRate) {
+		const poolThresholds = Object.keys(DROP_TABLE).map(unparsed => parseFloat(unparsed)).sort((a, b) => b - a);
+		const poolRandomNumber = Math.random() * 120;
+		for (const threshold of poolThresholds) {
+			if (poolRandomNumber > threshold) {
+				const pool = DROP_TABLE[threshold];
+				return pool[Math.floor(Math.random() * pool.length)];
+			}
+		}
+	}
+	return null;
+}
+
+module.exports = {
+	rollItemDrop
+}


### PR DESCRIPTION
Summary
-------
- add Unidentified Item and Loot Box items
- changed drop table to explicit whitelist to avoid circular dependency
- quick sanity checking implies drop table frequencies aren't inverted and all pools appear reachable

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Loot Box drops two items
- [x] Unidentified Item rerolls into an item

Issue
-----
Closes #232 