### PR TITLE
#239: Migrate Light Green Profile Colorizers to Light Grey Profile Colorizers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ When a season ends, the following bounty hunters will be recognized in the end o
 - Bounty Thumbnail: allows a bounty's poster to add a thumbnail image to one of their bounties (also increasing completion XP for the poster)
 ### Other Changes
 - Fixed `/bounty complete` mentioning the bounty board instead of the completed bounty's thread
+- Converted all Light Green Profile Colorizers (which were unusable) to Light Grey Profile Colorizers
 
 ## BountyBot Version 2.7.1:
 - Added cooldowns to items, these are applied per user

--- a/source/scripts/migrations/v2.8.0/migration2.js
+++ b/source/scripts/migrations/v2.8.0/migration2.js
@@ -1,0 +1,13 @@
+const { connectToDatabase } = require("../../../../database.js");
+
+connectToDatabase("migration").then(database => {
+	database.models.Item.findAll().then(async itemRows => {
+		for (const row of itemRows) {
+			if (row.itemName === "Light Green Profile Colorizer") {
+				const [destinationRow, wasCreated] = await database.models.Item.findOrCreate({ where: { userId: row.userId, itemName: "Light Grey Profile Colorizer" } });
+				destinationRow.increment("count", { by: wasCreated ? row.count - 1 : row.count });
+				row.destroy();
+			}
+		}
+	})
+});


### PR DESCRIPTION
Summary
-------
- Migrate Light Green Profile Colorizers to Light Grey Profile Colorizers

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Light Green Profile Colorizers increment the Light Grey Profile Colorizer row for the owning user (if user has Light Greys already)
- [x] Light Green Profile Colorizers create a new row if user doesn't already have Light Greys

Issue
-----
Closes #239