### PR TITLE
#275: remove custom handling for "Known Issues" section of version notes

### DIFF
--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -217,33 +217,19 @@ async function buildVersionEmbed() {
 	const data = await fs.promises.readFile('./ChangeLog.md', { encoding: 'utf8' });
 	const dividerRegEx = /## .+ Version/g;
 	const changesStartRegEx = /\.\d+:/g;
-	const knownIssuesStartRegEx = /### Known Issues/g;
 	let titleStart = dividerRegEx.exec(data).index;
 	changesStartRegEx.exec(data);
-	let knownIssuesStart;
-	let knownIssueStartResult = knownIssuesStartRegEx.exec(data);
-	if (knownIssueStartResult) {
-		knownIssuesStart = knownIssueStartResult.index;
-	}
-	let knownIssuesEnd = dividerRegEx.exec(data).index;
+	let sectionEnd = dividerRegEx.exec(data).index;
 
-	const embed = new EmbedBuilder().setColor(Colors.Blurple)
+	return new EmbedBuilder().setColor(Colors.Blurple)
 		.setAuthor(module.exports.ihpAuthorPayload)
 		.setTitle(data.slice(titleStart + 3, changesStartRegEx.lastIndex))
 		.setURL('https://discord.gg/JxqE9EpKt9')
 		.setThumbnail('https://cdn.discordapp.com/attachments/545684759276421120/734099622846398565/newspaper.png')
+		.setDescription(data.slice(changesStartRegEx.lastIndex, sectionEnd).slice(0, MAX_EMBED_DESCRIPTION_LENGTH))
+		.addFields({ name: "Become a Sponsor", value: "Chip in for server costs or get premium features by sponsoring [BountyBot on GitHub](https://github.com/Imaginary-Horizons-Productions/BountyBot)" })
 		.setFooter(randomFooterTip())
 		.setTimestamp();
-
-	if (knownIssuesStart && knownIssuesStart < knownIssuesEnd) {
-		// Known Issues section found
-		embed.setDescription(data.slice(changesStartRegEx.lastIndex, knownIssuesStart).slice(0, MAX_EMBED_DESCRIPTION_LENGTH))
-			.addFields({ name: "Known Issues", value: data.slice(knownIssuesStart + 16, knownIssuesEnd) });
-	} else {
-		// Known Issues section not found
-		embed.setDescription(data.slice(changesStartRegEx.lastIndex, knownIssuesEnd).slice(0, MAX_EMBED_DESCRIPTION_LENGTH));
-	}
-	return embed.addFields({ name: "Become a Sponsor", value: "Chip in for server costs or get premium features by sponsoring [BountyBot on GitHub](https://github.com/Imaginary-Horizons-Productions/BountyBot)" });
 }
 
 /** If the guild has a scoreboard reference channel, update the embed in it


### PR DESCRIPTION
Summary
-------
- remove custom handling for "Known Issues" section of version notes

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] tested on PotL

Issue
-----
Closes #275