### PR TITLE
#293: fix crashes when using /toast, /bounty complete, or seconding a toast in a thread

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Server Goals are BountyBot objectives everyone on the server contributes to. A g
 ### Other Changes
 - New items: Goal Initializer, Progress-in-a-Can
 - Added Festival and Raffle indicators to the scoreboard, removed /server-bonuses
+- Fixed crashes when toasting, completing bounties, or seconding toasts in threads
 ## BountyBot Version 2.8.0:
 ### Context Menu Options
 - Added the following BountyBot functionality to the Apps dropdown when right-clicking on a User or Message:

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -126,7 +126,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
 				text = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
 			}
-			interaction.message.thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
+			if (interaction.channel.isThread()) {
+				interaction.channel.send({ content: text, flags: MessageFlags.SuppressNotifications });
+			} else {
+				interaction.message.thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
+			}
 			updateScoreboard(await database.models.Company.findByPk(interaction.guildId), interaction.guild, database);
 		})
 

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -105,15 +105,14 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		} else {
 			acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
 			interaction.editReply(acknowledgeOptions).then(message => {
-				message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
-					thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
-				})
-			}).catch(error => {
-				// Ignore Missing Access errors, they only prevent the making of the thread
-				if (error.code !== 50001) {
-					console.error(error);
+				if (interaction.channel.isThread()) {
+					interaction.channel.send({ content: text, flags: MessageFlags.SuppressNotifications });
+				} else {
+					message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
+						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
+					})
 				}
-			});
+			})
 		}
 
 		updateScoreboard(bounty.Company, interaction.guild, database);

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -156,25 +156,29 @@ async function raiseToast(interaction, database, toasteeIds, toastText, imageURL
 		],
 		fetchReply: true
 	}).then(message => {
-		message.startThread({ name: "Rewards" }).then(thread => {
-			if (rewardedRecipients.length > 0) {
-				getRankUpdates(interaction.guild, database).then(rankUpdates => {
-					const multiplierString = company.festivalMultiplierString();
-					let text = `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString} *Critical Toast!*` : ""}`;
-					if (rankUpdates.length > 0) {
-						text += `\n\n__**Rank Ups**__\n- ${rankUpdates.join("\n- ")}`;
-					}
-					if (rewardTexts.length > 0) {
-						text += `\n\n__**Rewards**__\n- ${rewardTexts.join("\n- ")}`;
-					}
-					if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
-						text = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
-					}
-					thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
-					updateScoreboard(company, interaction.guild, database);
-				})
-			}
-		});
+		if (rewardedRecipients.length > 0) {
+			getRankUpdates(interaction.guild, database).then(rankUpdates => {
+				const multiplierString = company.festivalMultiplierString();
+				let text = `__**XP Gained**__\n${rewardedRecipients.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString} *Critical Toast!*` : ""}`;
+				if (rankUpdates.length > 0) {
+					text += `\n\n__**Rank Ups**__\n- ${rankUpdates.join("\n- ")}`;
+				}
+				if (rewardTexts.length > 0) {
+					text += `\n\n__**Rewards**__\n- ${rewardTexts.join("\n- ")}`;
+				}
+				if (text.length > MAX_MESSAGE_CONTENT_LENGTH) {
+					text = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
+				}
+				if (interaction.channel.isThread()) {
+					interaction.channel.send({ content: text, flags: MessageFlags.SuppressNotifications });
+				} else {
+					message.startThread({ name: "Rewards" }).then(thread => {
+						thread.send({ content: text, flags: MessageFlags.SuppressNotifications });
+					})
+				}
+				updateScoreboard(company, interaction.guild, database);
+			});
+		}
 	});
 }
 


### PR DESCRIPTION
Summary
-------
- fix crashes when using /toast, /bounty complete, or seconding a toast in a thread

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /toast from a thread now posts rewards in the thread instead of trying to create a thread in a thread
- [x] Seconding a toast in a thread now posts rewards in the thread instead of looking for the thread in a thread
- [x] /bounty complete (without bounty board) now posts rewards in the thread instead of trying to create a thread in a thread

Issue
-----
Closes #293