### PR TITLE
#282: switch from goal progress only by correct type to Goal Points

### DIFF
--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -1,11 +1,5 @@
 const { Item } = require("../classes");
 
-const GOAL_TYPE_MAP = {
-	bounties: { text: (count) => `complete ${count} bounties!`, coefficient: 1 },
-	toasts: { text: (count) => `raise ${count} toasts!`, coefficient: 10 },
-	secondings: { text: (count) => `second ${count} toasts!`, coefficient: 5 }
-};
-
 const itemName = "Goal Initializer";
 module.exports = new Item(itemName, "Begin a Server Goal if there isn't already one running", 3000,
 	async (interaction, database) => {
@@ -20,9 +14,9 @@ module.exports = new Item(itemName, "Begin a Server Goal if there isn't already 
 		const goalType = eligibleTypes[Math.floor(Math.random() * eligibleTypes.length)];
 		const previousSeason = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isPreviousSeason: true } });
 		const activeHunters = previousSeason ? (await database.models.Participation.findOne({ where: { seasonId: season.id }, order: [["placement", "DESC"]] })).placement : 3;
-		const requiredContributions = activeHunters * GOAL_TYPE_MAP[goalType].coefficient;
+		const requiredContributions = activeHunters * 20;
 		await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
 		await database.models.Goal.create({ companyId: interaction.guildId, type: goalType, requiredContributions });
-		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has started a Server Goal to ${GOAL_TYPE_MAP[goalType].text(requiredContributions)}` }));
+		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));
 	}
 );

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -1,5 +1,11 @@
 const { Sequelize, Op } = require("sequelize");
 
+const GOAL_POINT_MAP = {
+	"bounties": 10,
+	"toasts": 1,
+	"secondings": 2
+};
+
 /**
  * @param {string} companyId
  * @param {"bounties" | "toasts" | "secondings"} progressType
@@ -13,24 +19,25 @@ async function progressGoal(companyId, progressType, userId, database) {
 		contributorIds: []
 	};
 	const goal = await database.models.Goal.findOne({ where: { companyId, state: "ongoing" } });
-	const goalProgressed = goal?.type === progressType;
-	if (goalProgressed) {
-		returnData.gpContributed = 1;
-		await database.models.Contribution.create({ goalId: goal.id, userId });
-		const [hunter] = await database.models.Hunter.findOrCreate({ where: { companyId, userId } });
-		hunter.increment("goalContributions");
-		const [season] = await database.models.Season.findOrCreate({ where: { companyId, isCurrentSeason: true } });
-		const [participation] = await database.models.Participation.findOrCreate({ where: { companyId, userId, seasonId: season.id } });
-		participation.increment("goalContributions");
-		const contributions = await database.models.Contribution.findAll({ where: { goalId: goal.id } });
-		returnData.goalCompleted = goal.requiredContributions <= contributions.length;
-		if (returnData.goalCompleted) {
-			returnData.contributorIds = [...new Set(contributions.map(contribution => contribution.userId))];
-			database.models.Hunter.update({ itemFindBoost: true }, { where: { userId: { [Op.in]: returnData.contributorIds } } });
-			goal.update({ state: "completed" });
-		} else {
-			returnData.contributorIds.push(userId);
-		}
+	returnData.gpContributed = GOAL_POINT_MAP[progressType];
+	if (goal?.type === progressType) {
+		returnData.gpContributed *= 2;
+	}
+	await database.models.User.findOrCreate({ where: { id: userId } });
+	await database.models.Contribution.create({ goalId: goal.id, userId, value: returnData.gpContributed });
+	const [hunter] = await database.models.Hunter.findOrCreate({ where: { companyId, userId } });
+	hunter.increment("goalContributions");
+	const [season] = await database.models.Season.findOrCreate({ where: { companyId, isCurrentSeason: true } });
+	const [participation] = await database.models.Participation.findOrCreate({ where: { companyId, userId, seasonId: season.id } });
+	participation.increment("goalContributions");
+	const contributions = await database.models.Contribution.findAll({ where: { goalId: goal.id } });
+	returnData.goalCompleted = goal.requiredContributions <= contributions.length;
+	if (returnData.goalCompleted) {
+		returnData.contributorIds = [...new Set(contributions.map(contribution => contribution.userId))];
+		database.models.Hunter.update({ itemFindBoost: true }, { where: { userId: { [Op.in]: returnData.contributorIds } } });
+		goal.update({ state: "completed" });
+	} else {
+		returnData.contributorIds.push(userId);
 	}
 	return returnData;
 }

--- a/source/models/companies/Contribution.js
+++ b/source/models/companies/Contribution.js
@@ -18,6 +18,10 @@ exports.initModel = function (sequelize) {
 		userId: {
 			type: DataTypes.STRING,
 			allowNull: false
+		},
+		value: {
+			type: DataTypes.BIGINT,
+			allowNull: false
 		}
 	}, {
 		sequelize,

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -77,12 +77,6 @@ async function buildCompanyStatsEmbed(guild, database) {
 		.setTimestamp()
 }
 
-const GOAL_LOCALIZATION = {
-	bounties: "Bounties Completed",
-	toasts: "Toasts Raised",
-	secondings: "Toasts Seconded"
-};
-
 /** A seasonal scoreboard orders a company's hunters by their seasonal xp
  * @param {Guild} guild
  * @param {Sequelize} database
@@ -129,8 +123,8 @@ async function buildSeasonalScoreboardEmbed(guild, database) {
 	const fields = [];
 	const goal = await database.models.Goal.findOne({ where: { companyId: guild.id, state: "ongoing" } });
 	if (goal) {
-		const contributions = await database.models.Contribution.findAll({ where: { goalId: goal.id } });
-		fields.push({ name: "Server Goal", value: `${generateTextBar(contributions.length, goal.requiredContributions, 15)} ${contributions.length}/${goal.requiredContributions} ${GOAL_LOCALIZATION[goal.type]}` });
+		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+		fields.push({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${progress}/${goal.requiredContributions} Goal Points` });
 	}
 	if (company.festivalMultiplier !== 1) {
 		fields.push({ name: "XP Festival", value: `An XP multiplier festival is currently active for ${company.festivalMultiplierString()}.` });
@@ -189,8 +183,8 @@ async function buildOverallScoreboardEmbed(guild, database) {
 	const fields = [];
 	const goal = await database.models.Goal.findOne({ where: { companyId: guild.id, state: "ongoing" } });
 	if (goal) {
-		const contributions = await database.models.Contribution.findAll({ where: { goalId: goal.id } });
-		fields.push({ name: "Server Goal", value: `${generateTextBar(contributions.length, goal.requiredContributions, 15)} ${contributions.length}/${goal.requiredContributions} ${GOAL_LOCALIZATION[goal.type]}` });
+		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+		fields.push({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${progress}/${goal.requiredContributions} Goal Points` });
 	}
 	if (company.festivalMultiplier !== 1) {
 		fields.push({ name: "XP Festival", value: `An XP multiplier festival is currently active for ${company.festivalMultiplierString()}.` });


### PR DESCRIPTION
Summary
-------
- switch from goal progress only by correct type to Goal Points

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] started new goal, contributed to it with both toasts (non-doubled) and secondings (doubled)

Issue
-----
Closes #282