### PR TITLE
#285: add goal moderation commands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Server Goals are BountyBot objectives everyone on the server contributes to. A g
 
 ### Other Changes
 - New items: Goal Initializer, Progress-in-a-Can
+- New commands: `/moderation revoke-contributions`, `/moderation revoke-goal-bonus`
 - Added Festival and Raffle indicators to the scoreboard, removed /server-bonuses
 - Fixed crashes when toasting, completing bounties, or seconding toasts in threads
 ## BountyBot Version 2.8.0:

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -85,7 +85,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					bounty.asEmbed(collectedInteraction.guild, poster.level, bounty.Company.festivalMultiplierString(), true, database).then(async embed => {
 						if (goalProgress.gpContributed > 0) {
 							const goal = await database.models.Goal.findOne({ where: { companyId: interaction.guildId } });
-							const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+							const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 							embed.addFields({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${Math.min(progress, goal.requiredContributions)}/${goal.requiredContributions} GP` });
 						}
 						interaction.message.edit({ embeds: [embed], components: [] });

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -118,7 +118,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		const goalProgressFieldIndex = embed.data.fields?.findIndex(field => field.name === "Server Goal");
 		if (goalProgressFieldIndex !== -1) {
 			const goal = await database.models.Goal.findOne({ where: { companyId: interaction.guildId, state: "ongoing" } });
-			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 			embed.spliceFields(goalProgressFieldIndex, 1, { name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${Math.min(progress, goal.requiredContributions)}/${goal.requiredContributions} GP` });
 		}
 		interaction.update({ embeds: [embed] });

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -77,7 +77,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	bounty.asEmbed(interaction.guild, poster.level, bounty.Company.festivalMultiplierString(), true, database).then(async embed => {
 		if (goalProgress.gpContributed > 0) {
 			const goal = await database.models.Goal.findOne({ where: { companyId: interaction.guildId } });
-			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 			embed.addFields({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${Math.min(progress, goal.requiredContributions)}/${goal.requiredContributions} GP` });
 		}
 		const acknowledgeOptions = { content: `${userMention(bounty.userId)}'s bounty, ` };

--- a/source/commands/item.js
+++ b/source/commands/item.js
@@ -40,7 +40,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 		}).then(reply => {
 			const collector = reply.createMessageComponentCollector({ max: 1 });
 			collector.on("collect", (collectedInteration) => {
-				if (Date.now() < collectedInteration.member.joinedTimestamp + timeConversion(1, "d", "ms")) {
+				if (runMode === "prod" && Date.now() < collectedInteration.member.joinedTimestamp + timeConversion(1, "d", "ms")) {
 					collectedInteration.reply({ content: `Items cannot be used in servers that have been joined less than 24 hours ago.`, flags: [MessageFlags.Ephemeral] });
 					return;
 				}

--- a/source/commands/item.js
+++ b/source/commands/item.js
@@ -40,7 +40,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 		}).then(reply => {
 			const collector = reply.createMessageComponentCollector({ max: 1 });
 			collector.on("collect", (collectedInteration) => {
-				if (Date.now() > collectedInteration.member.joinedTimestamp + timeConversion(1, "d", "ms")) {
+				if (Date.now() < collectedInteration.member.joinedTimestamp + timeConversion(1, "d", "ms")) {
 					collectedInteration.reply({ content: `Items cannot be used in servers that have been joined less than 24 hours ago.`, flags: [MessageFlags.Ephemeral] });
 					return;
 				}

--- a/source/commands/moderation/gppenalty.js
+++ b/source/commands/moderation/gppenalty.js
@@ -9,8 +9,8 @@ const { commandMention } = require("../../util/textUtil");
  * @param {...unknown} args
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
-	const penaltyValue = Math.abs(interaction.options.get("penalty", true));
-	const goal = await database.models.Goal.findOne({ where: { companyId, state: "ongoing" } });
+	const penaltyValue = Math.abs(interaction.options.get("penalty", true).value);
+	const goal = await database.models.Goal.findOne({ where: { companyId: interaction.guildId, state: "ongoing" } });
 	if (!goal) {
 		interaction.reply({ content: `There isn't an open Server Goal to penalize. You can use ${commandMention("moderation revoke-goal-bonus")} to revoke Goal Completion Item Find Bonus for bounty hunters.`, flags: [MessageFlags.Ephemeral] });
 		return;

--- a/source/commands/moderation/gppenalty.js
+++ b/source/commands/moderation/gppenalty.js
@@ -1,0 +1,36 @@
+const { CommandInteraction, MessageFlags } = require("discord.js");
+const { Sequelize } = require("sequelize");
+const { commandMention } = require("../../util/textUtil");
+
+/**
+ * @param {CommandInteraction} interaction
+ * @param {Sequelize} database
+ * @param {string} runMode
+ * @param {...unknown} args
+ */
+async function executeSubcommand(interaction, database, runMode, ...args) {
+	const penaltyValue = Math.abs(interaction.options.get("penalty", true));
+	const goal = await database.models.Goal.findOne({ where: { companyId, state: "ongoing" } });
+	if (!goal) {
+		interaction.reply({ content: `There isn't an open Server Goal to penalize. You can use ${commandMention("moderation revoke-goal-bonus")} to revoke Goal Completion Item Find Bonus for bounty hunters.`, flags: [MessageFlags.Ephemeral] });
+		return;
+	}
+	await database.models.Contribution.create({ goalId: goal.id, userId: interaction.user.id, value: -1 * penaltyValue });
+	interaction.reply({ content: `The Server Goal's GP has been reduced by ${penaltyValue} GP.` });
+};
+
+module.exports = {
+	data: {
+		name: "gp-penalty",
+		description: "Reduce the GP of the open Server Goal",
+		optionsInput: [
+			{
+				type: "Integer",
+				name: "penalty",
+				description: "The amount of GP to subtract from the Server Goal",
+				required: true
+			}
+		]
+	},
+	executeSubcommand
+};

--- a/source/commands/moderation/index.js
+++ b/source/commands/moderation/index.js
@@ -4,11 +4,13 @@ const { createSubcommandMappings } = require('../../util/fileUtil.js');
 
 const mainId = "moderation";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
-	"userreport.js",
-	"takedown.js",
+	"bountybotban.js",
+	"gppenalty.js",
+	"revokegoalbonus.js",
 	"seasondisqualify.js",
-	"xppenalty.js",
-	"bountybotban.js"
+	"takedown.js",
+	"userreport.js",
+	"xppenalty.js"
 ]);
 module.exports = new CommandWrapper(mainId, "BountyBot moderation tools", PermissionFlagsBits.ManageRoles, false, [InteractionContextType.Guild], 3000,
 	(interaction, database, runMode) => {

--- a/source/commands/moderation/revokegoalbonus.js
+++ b/source/commands/moderation/revokegoalbonus.js
@@ -8,14 +8,19 @@ const { Sequelize } = require("sequelize");
  * @param {...unknown} args
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
-	const user = interaction.options.get("revokee", true);
-	const hunter = await database.models.Hunter.findOne({ where: { userId: user.id, companyId: interaction.guildId } });
+	const revokeOption = interaction.options.get("revokee", true);
+	const hunter = await database.models.Hunter.findOne({ where: { userId: revokeOption.value, companyId: interaction.guildId } });
 	if (!hunter) {
-		interaction.reply({ content: `${user} hasn't interacted with BountyBot yet.`, flags: [MessageFlags.Ephemeral] });
+		interaction.reply({ content: `${userMention(revokeOption.value)} hasn't interacted with BountyBot yet.`, flags: [MessageFlags.Ephemeral] });
 		return;
 	}
-	hunter.update("itemFindBoost", false);
-	interaction.reply({ content: `${user}'s Goal Contribution item find boost has been revoked.`, flags: [MessageFlags.Ephemeral] });
+	if (hunter.itemFindBoost) {
+		hunter.update({ "itemFindBoost": false });
+		interaction.reply({ content: `${userMention(revokeOption.value)}'s Goal Contribution item find boost has been revoked.`, flags: [MessageFlags.Ephemeral] });
+		revokeOption.user.send({ content: `Your Item Find Bonus in ${interaction.guild} was revoked by ${interaction.user}.` });
+	} else {
+		interaction.reply({ content: `${userMention(revokeOption.value)} doesn't have Goal Contribution item find boost.`, flags: [MessageFlags.Ephemeral] });
+	}
 };
 
 module.exports = {

--- a/source/commands/moderation/revokegoalbonus.js
+++ b/source/commands/moderation/revokegoalbonus.js
@@ -1,0 +1,35 @@
+const { CommandInteraction, MessageFlags, userMention } = require("discord.js");
+const { Sequelize } = require("sequelize");
+
+/**
+ * @param {CommandInteraction} interaction
+ * @param {Sequelize} database
+ * @param {string} runMode
+ * @param {...unknown} args
+ */
+async function executeSubcommand(interaction, database, runMode, ...args) {
+	const user = interaction.options.get("revokee", true);
+	const hunter = await database.models.Hunter.findOne({ where: { userId: user.id, companyId: interaction.guildId } });
+	if (!hunter) {
+		interaction.reply({ content: `${user} hasn't interacted with BountyBot yet.`, flags: [MessageFlags.Ephemeral] });
+		return;
+	}
+	hunter.update("itemFindBoost", false);
+	interaction.reply({ content: `${user}'s Goal Contribution item find boost has been revoked.`, flags: [MessageFlags.Ephemeral] });
+};
+
+module.exports = {
+	data: {
+		name: "revoke-goal-bonus",
+		description: "Revoke Goal contribution item find bonus",
+		optionsInput: [
+			{
+				type: "User",
+				name: "revokee",
+				description: "The bounty hunter for whom to revoke item find bonus",
+				required: true
+			}
+		]
+	},
+	executeSubcommand
+};

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -75,7 +75,7 @@ async function raiseToast(interaction, database, toasteeIds, toastText, imageURL
 		}
 		if (progressData.gpContributed > 0) {
 			const goal = await database.models.Goal.findOne({ where: { companyId: interaction.guildId } });
-			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+			const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 			embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${Math.min(progress, goal.requiredContributions)}/${goal.requiredContributions} GP` });
 		}
 	}

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -123,7 +123,7 @@ async function buildSeasonalScoreboardEmbed(guild, database) {
 	const fields = [];
 	const goal = await database.models.Goal.findOne({ where: { companyId: guild.id, state: "ongoing" } });
 	if (goal) {
-		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 		fields.push({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${progress}/${goal.requiredContributions} Goal Points` });
 	}
 	if (company.festivalMultiplier !== 1) {
@@ -183,7 +183,7 @@ async function buildOverallScoreboardEmbed(guild, database) {
 	const fields = [];
 	const goal = await database.models.Goal.findOne({ where: { companyId: guild.id, state: "ongoing" } });
 	if (goal) {
-		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } });
+		const progress = await database.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
 		fields.push({ name: "Server Goal", value: `${generateTextBar(progress, goal.requiredContributions, 15)} ${progress}/${goal.requiredContributions} Goal Points` });
 	}
 	if (company.festivalMultiplier !== 1) {


### PR DESCRIPTION
Summary
-------
- add `/moderation revoke-goal-bonus` and `/moderation gp-penalty`
- fix validation for recent join item disable
- fix no contributions on goal showing as null instead of 0

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] revoke-goal-bonus provides different response if revokee doesn't have bonus
- [x] revoke-goal sets bonus to false
- [x] revoke-goal sends revokee notification message
- [x] gp-penalty reduces goal's gp

Issue
-----
Closes #285