### PR TITLE
#318: consolidate toast reward string compilation

### DIFF
--- a/migrations/20250217170845-renameToRequiredGP.js
+++ b/migrations/20250217170845-renameToRequiredGP.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		await queryInterface.sequelize.query(`ALTER TABLE Goal RENAME COLUMN requiredContributions TO requiredGP`);
+	},
+
+	async down(queryInterface, Sequelize) {
+		await queryInterface.sequelize.query(`ALTER TABLE Goal RENAME COLUMN requiredGP TO requiredContributions`);
+	}
+};

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -1,12 +1,13 @@
-const { PermissionFlagsBits, InteractionContextType, MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { PermissionFlagsBits, InteractionContextType, MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { extractUserIdsFromMentions, textsHaveAutoModInfraction } = require('../util/textUtil');
 const { raiseToast } = require('../logic/toasts.js');
 const { updateScoreboard } = require('../util/embedUtil.js');
-const { SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH } = require('../constants.js');
+const { SAFE_DELIMITER } = require('../constants.js');
 const { findOrCreateCompany } = require('../logic/companies.js');
 const { findOrCreateBountyHunter } = require('../logic/hunters.js');
 const { getRankUpdates } = require('../util/scoreUtil.js');
+const { Toast } = require('../models/toasts/Toast.js');
 
 const mainId = "toast";
 module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunter(s), usually granting +1 XP", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 30000,
@@ -78,17 +79,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 			let content = "";
 			if (rewardedHunterIds.length > 0) {
 				const rankUpdates = await getRankUpdates(interaction.guild, database);
-				const multiplierString = company.festivalMultiplierString();
-				content = `__**XP Gained**__\n${rewardedHunterIds.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString} *Critical Toast!*` : ""}`;
-				if (rankUpdates.length > 0) {
-					content += `\n\n__**Rank Ups**__\n- ${rankUpdates.join("\n- ")}`;
-				}
-				if (rewardTexts.length > 0) {
-					content += `\n\n__**Rewards**__\n- ${rewardTexts.join("\n- ")}`;
-				}
-				if (content.length > MAX_MESSAGE_CONTENT_LENGTH) {
-					content = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
-				}
+				content = Toast.generateRewardString(rewardedHunterIds, rankUpdates, rewardTexts, interaction.member.toString(), company.festivalMultiplierString(), critValue);
 			}
 
 			if (content) {

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -1,12 +1,13 @@
 const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
-const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH } = require('../constants');
+const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
 const { raiseToast } = require('../logic/toasts.js');
-const { textsHaveAutoModInfraction, commandMention } = require('../util/textUtil');
+const { textsHaveAutoModInfraction } = require('../util/textUtil');
 const { updateScoreboard } = require('../util/embedUtil.js');
 const { findOrCreateCompany } = require('../logic/companies.js');
 const { findOrCreateBountyHunter } = require('../logic/hunters.js');
 const { getRankUpdates } = require('../util/scoreUtil.js');
+const { Toast } = require('../models/toasts/Toast.js');
 
 const mainId = "Raise a Toast";
 module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
@@ -69,17 +70,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				let content = "";
 				if (rewardedHunterIds.length > 0) {
 					const rankUpdates = await getRankUpdates(interaction.guild, database);
-					const multiplierString = company.festivalMultiplierString();
-					content = `__**XP Gained**__\n${rewardedHunterIds.map(id => `<@${id}> + 1 XP${multiplierString}`).join("\n")}${critValue > 0 ? `\n${interaction.member} + ${critValue} XP${multiplierString} *Critical Toast!*` : ""}`;
-					if (rankUpdates.length > 0) {
-						content += `\n\n__**Rank Ups**__\n- ${rankUpdates.join("\n- ")}`;
-					}
-					if (rewardTexts.length > 0) {
-						content += `\n\n__**Rewards**__\n- ${rewardTexts.join("\n- ")}`;
-					}
-					if (content.length > MAX_MESSAGE_CONTENT_LENGTH) {
-						content = `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
-					}
+					content = Toast.generateRewardString(rewardedHunterIds, rankUpdates, rewardTexts, interaction.member.toString(), company.festivalMultiplierString(), critValue);
 				}
 
 				if (content) {

--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -15,9 +15,9 @@ module.exports = new Item(itemName, "Begin a Server Goal if there isn't already 
 		const goalType = eligibleTypes[Math.floor(Math.random() * eligibleTypes.length)];
 		const previousSeason = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isPreviousSeason: true } });
 		const activeHunters = previousSeason ? (await database.models.Participation.findOne({ where: { seasonId: season.id }, order: [["placement", "DESC"]] })).placement : 3;
-		const requiredContributions = activeHunters * 20;
+		const requiredGP = activeHunters * 20;
 		await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
-		await database.models.Goal.create({ companyId: interaction.guildId, type: goalType, requiredContributions });
+		await database.models.Goal.create({ companyId: interaction.guildId, type: goalType, requiredGP });
 		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));
 	}
 );

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -19,7 +19,7 @@ async function findLatestGoalProgress(companyId) {
 		return { goalId: null, requiredGP: 0, currentGP: 0 };
 	}
 	const currentGP = await db.models.Contribution.sum("value", { where: { goalId: goal.id } }) ?? 0;
-	return { goalId: goal.id, requiredGP: goal.requiredContributions, currentGP };
+	return { goalId: goal.id, requiredGP: goal.requiredGP, currentGP };
 }
 
 const GOAL_POINT_MAP = {
@@ -53,7 +53,7 @@ async function progressGoal(companyId, progressType, userId) {
 		const [participation] = await db.models.Participation.findOrCreate({ where: { companyId, userId, seasonId: season.id } });
 		participation.increment("goalContributions");
 		const contributions = await db.models.Contribution.findAll({ where: { goalId: goal.id } });
-		returnData.goalCompleted = goal.requiredContributions <= contributions.reduce((totalGP, contribution) => totalGP + contribution.value, 0);
+		returnData.goalCompleted = goal.requiredGP <= contributions.reduce((totalGP, contribution) => totalGP + contribution.value, 0);
 		if (returnData.goalCompleted) {
 			returnData.contributorIds = [...new Set(contributions.map(contribution => contribution.userId))];
 			db.models.Hunter.update({ itemFindBoost: true }, { where: { userId: { [Op.in]: returnData.contributorIds } } });

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -68,7 +68,7 @@ async function raiseToast(guild, company, sender, senderHunter, toasteeIds, toas
 
 	const rewardTexts = [];
 	if (rewardsAvailable > 0) {
-		const progressData = await progressGoal(interaction.guildId, "toasts", sender.id);
+		const progressData = await progressGoal(guild.id, "toasts", sender.id);
 		if (progressData.gpContributed > 0) {
 			rewardTexts.push(`This toast contributed ${progressData.gpContributed} GP to the Server Goal!`);
 			if (progressData.goalCompleted) {
@@ -79,7 +79,7 @@ async function raiseToast(guild, company, sender, senderHunter, toasteeIds, toas
 					.addFields({ name: "Contributors", value: listifyEN(progressData.contributorIds.map(id => userMention(id))) })
 				);
 			}
-			const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(interaction.guildId);
+			const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(guild.id);
 			if (goalId !== null) {
 				embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
 			} else {

--- a/source/models/companies/Goal.js
+++ b/source/models/companies/Goal.js
@@ -29,7 +29,7 @@ function initModel(sequelize) {
 			type: DataTypes.STRING,
 			allowNull: false
 		},
-		requiredContributions: {
+		requiredGP: {
 			type: DataTypes.BIGINT,
 			allowNull: false
 		}

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -1,4 +1,7 @@
+const { userMention, italic, heading } = require('discord.js');
 const { Model, Sequelize, DataTypes } = require('sequelize');
+const { MAX_MESSAGE_CONTENT_LENGTH } = require('../../constants');
+const { commandMention } = require('../../util/textUtil');
 
 /** This model represents a toast raised for a group of bounty hunters */
 class Toast extends Model {
@@ -15,6 +18,31 @@ class Toast extends Model {
 		models.Toast.Secondings = models.Toast.hasMany(models.Seconding, {
 			foreignKey: "toastId"
 		});
+	}
+
+	/**
+	 * @param {string[]} rewardedHunterIds
+	 * @param {string[]} rankUpdates
+	 * @param {string[]} rewardTexts
+	 * @param {string} senderMention
+	 * @param {string} multiplierString
+	 * @param {number} critValue
+	 */
+	static generateRewardString(rewardedHunterIds, rankUpdates, rewardTexts, senderMention, multiplierString, critValue) {
+		let rewardString = `${heading("XP Gained", 2)}\n${rewardedHunterIds.map(id => `${userMention(id)} +1 XP${multiplierString}`).join("\n")}`;
+		if (critValue > 0) {
+			rewardString += `\n${senderMention} + ${critValue} XP${multiplierString} ${italic("Critical Toast!")}`;
+		}
+		if (rankUpdates.length > 0) {
+			rewardString += `\n${heading("Rank Ups", 2)}\n- ${rankUpdates.join("\n- ")}`;
+		}
+		if (rewardTexts.length > 0) {
+			rewardString += `\n${heading("Rewards", 2)}\n- ${rewardTexts.join("\n- ")}`;
+		}
+		if (rewardString.length > MAX_MESSAGE_CONTENT_LENGTH) {
+			return `Message overflow! Many people (?) probably gained many things (?). Use ${commandMention("stats")} to look things up.`;
+		}
+		return rewardString;
 	}
 }
 


### PR DESCRIPTION
Summary
-------
- consolidate toast reward string compilation
- switch section heading styling from "bold + underline" to "heading2"
- fix crash in `raiseToast`
- based on `ntseng/issue313` to avoid conflict with database column rename

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] toast by slash command still completes
- [x] toast by context menu still completes

Issue
-----
Closes #318