### PR TITLE
#321: move embed building out of `raiseToast()`

### DIFF
--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -1,14 +1,15 @@
-const { MessageFlags, ActionRowBuilder, ChannelType, ChannelSelectMenuBuilder, EmbedBuilder, userMention, ComponentType, DiscordjsErrorCodes } = require('discord.js');
+const { MessageFlags, ActionRowBuilder, ChannelType, ChannelSelectMenuBuilder, userMention, ComponentType, DiscordjsErrorCodes } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { updateScoreboard } = require('../util/embedUtil');
 const { getRankUpdates } = require('../util/scoreUtil');
-const { commandMention, timeConversion, congratulationBuilder, listifyEN, generateTextBar } = require('../util/textUtil');
+const { commandMention, timeConversion, generateTextBar } = require('../util/textUtil');
 const { completeBounty } = require('../logic/bounties');
 const { Hunter } = require('../models/users/Hunter');
 const { findLatestGoalProgress } = require('../logic/goals');
 const { Bounty } = require('../models/bounties/Bounty');
 const { findOrCreateCompany } = require('../logic/companies');
+const { Goal } = require('../models/companies/Goal');
 
 const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -90,13 +91,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					})
 				const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${interaction.channel}, was completed!` };
 				if (goalUpdate.goalCompleted) {
-					announcementOptions.embeds = [
-						new EmbedBuilder().setColor("e5b271")
-							.setTitle("Server Goal Completed")
-							.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-							.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-							.addFields({ name: "Contributors", value: listifyEN(goalUpdate.contributorIds.map(id => userMention(id))) })
-					];
+					announcementOptions.embeds = [Goal.generateCompletionEmbed(goalUpdate.contributorIds)];
 				}
 				collectedInteraction.channels.first().send(announcementOptions).catch(error => {
 					//Ignore Missing Permissions errors, user selected channel bot cannot post in

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -1,11 +1,12 @@
-const { EmbedBuilder, MessageFlags, userMention } = require('discord.js');
+const { EmbedBuilder, MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { Op } = require('sequelize');
 const { getRankUpdates } = require('../util/scoreUtil');
-const { timeConversion, congratulationBuilder, listifyEN, generateTextBar } = require('../util/textUtil');
+const { timeConversion, generateTextBar } = require('../util/textUtil');
 const { updateScoreboard } = require('../util/embedUtil');
 const { progressGoal, findLatestGoalProgress } = require('../logic/goals');
 const { Seconding } = require('../models/toasts/Seconding');
+const { Goal } = require('../models/companies/Goal');
 
 const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -141,13 +142,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		if (progressData.goalCompleted) {
 			interaction.channel.send({
-				embeds: [
-					new EmbedBuilder().setColor("e5b271")
-						.setTitle("Server Goal Completed")
-						.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-						.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-						.addFields({ name: "Contributors", value: listifyEN(progressData.contributorIds.map(id => userMention(id))) })
-				]
+				embeds: [Goal.generateCompletionEmbed(progressData.contributorIds)]
 			});
 		}
 	}

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -1,13 +1,14 @@
-const { CommandInteraction, MessageFlags, EmbedBuilder, userMention, channelMention, bold } = require("discord.js");
+const { CommandInteraction, MessageFlags, userMention, channelMention, bold } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { updateScoreboard } = require("../../util/embedUtil");
-const { extractUserIdsFromMentions, timeConversion, commandMention, congratulationBuilder, listifyEN, generateTextBar } = require("../../util/textUtil");
+const { extractUserIdsFromMentions, timeConversion, commandMention, generateTextBar } = require("../../util/textUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { completeBounty } = require("../../logic/bounties");
 const { Hunter } = require("../../models/users/Hunter");
 const { findLatestGoalProgress } = require("../../logic/goals");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { Goal } = require("../../models/companies/Goal");
 
 /**
  * @param {CommandInteraction} interaction
@@ -80,13 +81,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 		}
 		const acknowledgeOptions = { content: `${userMention(bounty.userId)}'s bounty, ` };
 		if (goalUpdate.goalCompleted) {
-			acknowledgeOptions.embeds = [
-				new EmbedBuilder().setColor("e5b271")
-					.setTitle("Server Goal Completed")
-					.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-					.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-					.addFields({ name: "Contributors", value: listifyEN(goalUpdate.contributorIds.map(id => userMention(id))) })
-			];
+			acknowledgeOptions.embeds = [Goal.generateCompletionEmbed(goalUpdate.contributorIds)];
 		}
 
 		if (company.bountyBoardId) {

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -1,10 +1,11 @@
-const { CommandInteraction, MessageFlags, EmbedBuilder, userMention } = require("discord.js");
+const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { updateScoreboard } = require("../../util/embedUtil");
-const { extractUserIdsFromMentions, congratulationBuilder, listifyEN, generateTextBar } = require("../../util/textUtil");
+const { extractUserIdsFromMentions, generateTextBar } = require("../../util/textUtil");
 const { progressGoal, findLatestGoalProgress } = require("../../logic/goals");
+const { Goal } = require("../../models/companies/Goal");
 
 /**
  * @param {CommandInteraction} interaction
@@ -99,13 +100,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 			}
 		}
 		if (wasGoalCompleted) {
-			acknowledgeOptions.embeds.push(
-				new EmbedBuilder().setColor("e5b271")
-					.setTitle("Server Goal Completed")
-					.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-					.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-					.addFields({ name: "Contributors", value: listifyEN([...finalContributorIds.keys()].map(id => userMention(id))) })
-			);
+			acknowledgeOptions.embeds.push(Goal.generateCompletionEmbed([...finalContributorIds.keys()]));
 		}
 		return interaction.reply(acknowledgeOptions);
 	}).then(response => {

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -1,13 +1,14 @@
-const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, ButtonBuilder, ButtonStyle, EmbedBuilder, userMention } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
 const { raiseToast } = require('../logic/toasts.js');
-const { textsHaveAutoModInfraction } = require('../util/textUtil');
+const { textsHaveAutoModInfraction, congratulationBuilder, listifyEN, generateTextBar } = require('../util/textUtil');
 const { updateScoreboard } = require('../util/embedUtil.js');
 const { findOrCreateCompany } = require('../logic/companies.js');
 const { findOrCreateBountyHunter } = require('../logic/hunters.js');
 const { getRankUpdates } = require('../util/scoreUtil.js');
 const { Toast } = require('../models/toasts/Toast.js');
+const { progressGoal, findLatestGoalProgress } = require('../logic/goals.js');
 
 const mainId = "Raise a Toast";
 module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
@@ -54,7 +55,36 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				return;
 			}
 
-			const { embeds, toastId, rewardedHunterIds, rewardTexts, critValue } = await raiseToast(modalSubmission.guild, company, modalSubmission.member, sender, [interaction.targetId], toastText);
+			const { toastId, rewardedHunterIds, rewardTexts, critValue } = await raiseToast(modalSubmission.guild, company, modalSubmission.member, sender, [interaction.targetId], toastText);
+			const embeds = [
+				new EmbedBuilder().setColor("e5b271")
+					.setThumbnail(company.toastThumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
+					.setTitle(toastText)
+					.setDescription(`A toast to ${userMention(interaction.targetId)}!`)
+					.setFooter({ text: modalSubmission.member.displayName, iconURL: modalSubmission.user.avatarURL() })
+			];
+
+			if (rewardedHunterIds.length > 0) {
+				const goalUpdate = await progressGoal(modalSubmission.guild.id, "toasts", modalSubmission.user.id);
+				if (goalUpdate.gpContributed > 0) {
+					rewardTexts.push(`This toast contributed ${goalUpdate.gpContributed} GP to the Server Goal!`);
+					if (goalUpdate.goalCompleted) {
+						embeds.push(new EmbedBuilder().setColor("e5b271")
+							.setTitle("Server Goal Completed")
+							.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
+							.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
+							.addFields({ name: "Contributors", value: listifyEN(goalUpdate.contributorIds.map(id => userMention(id))) })
+						);
+					}
+					const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(interaction.guild.id);
+					if (goalId !== null) {
+						embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+					} else {
+						embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
+					}
+				}
+			}
+
 			modalSubmission.reply({
 				embeds,
 				components: [

--- a/source/items/progress-in-a-can.js
+++ b/source/items/progress-in-a-can.js
@@ -1,7 +1,7 @@
-const { EmbedBuilder, userMention, MessageFlags } = require("discord.js");
+const { userMention, MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
 const { progressGoal } = require("../logic/goals");
-const { congratulationBuilder, listifyEN } = require("../util/textUtil");
+const { Goal } = require("../models/companies/Goal");
 
 const itemName = "Progress-in-a-Can";
 module.exports = new Item(itemName, "Add a contribution to the currently running Server Goal", 3000,
@@ -14,13 +14,7 @@ module.exports = new Item(itemName, "Add a contribution to the currently running
 		const progressData = await progressGoal(interaction.guildId, goal.type, interaction.user.id);
 		const resultPayload = { content: `${userMention(interaction.user.id)}'s Progress-in-a-Can contributed ${progressData.gpContributed} GP the Server Goal!` };
 		if (progressData.goalCompleted) {
-			resultPayload.embeds = [
-				new EmbedBuilder().setColor("e5b271")
-					.setTitle("Server Goal Completed")
-					.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-					.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-					.addFields({ name: "Contributors", value: listifyEN(progressData.contributorIds.map(id => userMention(id))) })
-			];
+			resultPayload.embeds = [Goal.generateCompletionEmbed(progressData.contributorIds)];
 		}
 		interaction.channel.send(resultPayload);
 	}

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -1,7 +1,6 @@
-const { EmbedBuilder, userMention, Guild, GuildMember } = require("discord.js");
+const { Guild, GuildMember } = require("discord.js");
 const { Sequelize, Op } = require("sequelize");
-const { timeConversion, listifyEN, congratulationBuilder, generateTextBar } = require("../util/textUtil");
-const { progressGoal, findLatestGoalProgress } = require("./goals");
+const { timeConversion } = require("../util/textUtil");
 const { Company } = require("../models/companies/Company");
 const { Hunter } = require("../models/users/Hunter");
 const { findOrCreateBountyHunter } = require("./hunters");
@@ -23,17 +22,6 @@ function setDB(database) {
  * @param {string | null} imageURL
  */
 async function raiseToast(guild, company, sender, senderHunter, toasteeIds, toastText, imageURL = null) {
-	const embeds = [
-		new EmbedBuilder().setColor("e5b271")
-			.setThumbnail(company.toastThumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
-			.setTitle(toastText)
-			.setDescription(`A toast to ${listifyEN(toasteeIds.map(id => userMention(id)))}!`)
-			.setFooter({ text: sender.displayName, iconURL: sender.user.avatarURL() })
-	];
-	if (imageURL) {
-		embeds[0].setImage(imageURL);
-	}
-
 	// Make database entities
 	const recentToasts = await db.models.Toast.findAll({ where: { companyId: guild.id, senderId: sender.id, createdAt: { [Op.gt]: new Date(new Date() - 2 * timeConversion(1, "d", "ms")) } }, include: db.models.Toast.Recipients });
 	let rewardsAvailable = 10;
@@ -67,26 +55,6 @@ async function raiseToast(guild, company, sender, senderHunter, toasteeIds, toas
 	season.increment("toastsRaised");
 
 	const rewardTexts = [];
-	if (rewardsAvailable > 0) {
-		const progressData = await progressGoal(guild.id, "toasts", sender.id);
-		if (progressData.gpContributed > 0) {
-			rewardTexts.push(`This toast contributed ${progressData.gpContributed} GP to the Server Goal!`);
-			if (progressData.goalCompleted) {
-				embeds.push(new EmbedBuilder().setColor("e5b271")
-					.setTitle("Server Goal Completed")
-					.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
-					.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
-					.addFields({ name: "Contributors", value: listifyEN(progressData.contributorIds.map(id => userMention(id))) })
-				);
-			}
-			const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(guild.id);
-			if (goalId !== null) {
-				embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
-			} else {
-				embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
-			}
-		}
-	}
 	senderHunter.increment("toastsRaised");
 	const toast = await db.models.Toast.create({ companyId: guild.id, senderId: sender.id, text: toastText, imageURL });
 	const rawRecipients = [];
@@ -148,7 +116,7 @@ async function raiseToast(guild, company, sender, senderHunter, toasteeIds, toas
 		participation.increment({ xp: critValue, toastsRaised: 1 });
 	}
 
-	return { toastId: toast.id, rewardedHunterIds, rewardTexts, critValue, embeds };
+	return { toastId: toast.id, rewardedHunterIds, rewardTexts, critValue };
 }
 
 module.exports = {

--- a/source/models/companies/Goal.js
+++ b/source/models/companies/Goal.js
@@ -1,4 +1,6 @@
+const { EmbedBuilder, userMention } = require('discord.js');
 const { Model, Sequelize, DataTypes } = require('sequelize');
+const { congratulationBuilder, listifyEN } = require('../../util/textUtil');
 
 /** A Goal for which all bounty hunters in a company contribute to */
 class Goal extends Model {
@@ -6,6 +8,15 @@ class Goal extends Model {
 		models.Goal.Contributions = models.Goal.hasMany(models.Contribution, {
 			foreignKey: "goalId"
 		})
+	}
+
+	/** @param {string[]} contributorIds */
+	static generateCompletionEmbed(contributorIds) {
+		return new EmbedBuilder().setColor("e5b271")
+			.setTitle("Server Goal Completed")
+			.setThumbnail("https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&")
+			.setDescription(`${congratulationBuilder()}, the Server Goal was completed! Contributors have double chance to find items on their next bounty completion.`)
+			.addFields({ name: "Contributors", value: listifyEN(contributorIds.map(id => userMention(id))) })
 	}
 }
 

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -1,7 +1,7 @@
-const { userMention, italic, heading } = require('discord.js');
+const { userMention, italic, heading, EmbedBuilder, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { Model, Sequelize, DataTypes } = require('sequelize');
-const { MAX_MESSAGE_CONTENT_LENGTH } = require('../../constants');
-const { commandMention } = require('../../util/textUtil');
+const { MAX_MESSAGE_CONTENT_LENGTH, SAFE_DELIMITER } = require('../../constants');
+const { commandMention, listifyEN } = require('../../util/textUtil');
 
 /** This model represents a toast raised for a group of bounty hunters */
 class Toast extends Model {
@@ -18,6 +18,30 @@ class Toast extends Model {
 		models.Toast.Secondings = models.Toast.hasMany(models.Seconding, {
 			foreignKey: "toastId"
 		});
+	}
+
+	/**
+	 * @param {string?} thumbnailURL
+	 * @param {string} toastText
+	 * @param {string[]} recipientIds
+	 * @param {GuildMember} senderMember
+	 */
+	static generateEmbed(thumbnailURL, toastText, recipientIds, senderMember) {
+		return new EmbedBuilder().setColor("e5b271")
+			.setThumbnail(thumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
+			.setTitle(toastText)
+			.setDescription(`A toast to ${listifyEN(recipientIds.map(id => userMention(id)))}!`)
+			.setFooter({ text: senderMember.displayName, iconURL: senderMember.user.avatarURL() });
+	}
+
+	/** @param {string} toastId */
+	static generateSecondingActionRow(toastId) {
+		return new ActionRowBuilder().addComponents(
+			new ButtonBuilder().setCustomId(`secondtoast${SAFE_DELIMITER}${toastId}`)
+				.setLabel("Hear, hear!")
+				.setEmoji("🥂")
+				.setStyle(ButtonStyle.Primary)
+		)
 	}
 
 	/**


### PR DESCRIPTION
Summary
-------
- move embed building out of `raiseToast()`
- consolidated the generation of the following message payload components
   - toast embed
   - goal completion embed
   - toast seconding action row

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] toast by command still resolves
- [x] toast by context menu still resolves

Issue
-----
Closes #321