### PR TITLE
apply logic layer endpoints to reduce frontend dependence on database

### DIFF
--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -4,6 +4,7 @@ const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { addCompleters } = require('../logic/bounties.js');
 const { listifyEN, congratulationBuilder, timeConversion } = require('../util/textUtil');
 const { Completion } = require('../models/bounties/Completion.js');
+const { findOrCreateBountyHunter } = require('../logic/hunters.js');
 
 /**
  * Updates the board posting for the bounty after adding the completers
@@ -57,8 +58,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				for (const member of collectedInteraction.members.values().filter(member => !existingCompleterIds.includes(member.id))) {
 					const memberId = member.id;
 					if (memberId === interaction.user.id || (runMode === "prod" && member.user.bot)) continue;
-					await database.models.User.findOrCreate({ where: { id: memberId } });
-					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: collectedInteraction.guildId } });
+					const [hunter] = await findOrCreateBountyHunter(memberId, collectedInteraction.guild.id);
 					if (hunter.isBanned) {
 						bannedIds.push(memberId);
 						continue;

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -9,6 +9,7 @@ const { Hunter } = require('../models/users/Hunter');
 const { findLatestGoalProgress } = require('../logic/goals');
 const { Bounty } = require('../models/bounties/Bounty');
 const { findOrCreateCompany } = require('../logic/companies');
+const { findOrCreateBountyHunter } = require('../logic/hunters');
 
 const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -33,8 +34,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			for (const member of completerMembers) {
 				if (runMode !== "prod" || !member.user.bot) {
 					const memberId = member.id;
-					await database.models.User.findOrCreate({ where: { id: memberId } });
-					const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: interaction.guildId } });
+					const [hunter] = await findOrCreateBountyHunter(memberId, interaction.guild.id);
 					if (!hunter.isBanned) {
 						validatedHunterIds.push(memberId);
 						validatedHunters.push(hunter);

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -9,7 +9,7 @@ const { Hunter } = require('../models/users/Hunter');
 const { findLatestGoalProgress } = require('../logic/goals');
 const { Bounty } = require('../models/bounties/Bounty');
 const { findOrCreateCompany } = require('../logic/companies');
-const { findOrCreateBountyHunter } = require('../logic/hunters');
+const { findOrCreateBountyHunter, findOneHunter } = require('../logic/hunters');
 
 const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -63,8 +63,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					)
 				]
 			}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
-				/** @type {Hunter} */
-				const poster = await database.models.Hunter.findOne({ where: { userId: bounty.userId, companyId: bounty.companyId } });
+				const poster = await findOneHunter(bounty.userId, bounty.companyId);
 				const { completerXP, posterXP, rewardTexts, goalUpdate } = await completeBounty(bounty, poster, validatedHunters, collectedInteraction.guild);
 				const rankUpdates = await getRankUpdates(collectedInteraction.guild, database);
 

--- a/source/buttons/bbremovecompleters.js
+++ b/source/buttons/bbremovecompleters.js
@@ -3,6 +3,7 @@ const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { Op } = require('sequelize');
 const { listifyEN, timeConversion } = require('../util/textUtil');
+const { findOneHunter } = require('../logic/hunters');
 
 const mainId = "bbremovecompleters";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -27,7 +28,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}).then(response => response.resource.message.awaitMessageComponent({ time: timeConversion(2, "m", "ms"), componentType: ComponentType.UserSelect })).then(async collectedInteraction => {
 				const removedIds = collectedInteraction.members.map((_, key) => key);
 				database.models.Completion.destroy({ where: { bountyId: bounty.id, userId: { [Op.in]: removedIds } } });
-				const poster = await database.models.Hunter.findOne({ where: { companyId: collectedInteraction.guildId, userId: collectedInteraction.user.id } });
+				const poster = await findOneHunter(collectedInteraction.user.id, collectedInteraction.guild.id);
 				const company = await database.models.Company.findByPk(collectedInteraction.guildId);
 				bounty.embed(collectedInteraction.guild, poster.level, false, company, await database.models.Completion.findAll({ where: { bountyId: bounty.id } }))
 					.then(async embed => {

--- a/source/buttons/bbshowcase.js
+++ b/source/buttons/bbshowcase.js
@@ -3,6 +3,7 @@ const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { timeConversion } = require('../util/textUtil');
 const { showcaseBounty } = require('../util/bountyUtil');
+const { findOneHunter } = require('../logic/hunters');
 
 const mainId = "bbshowcase";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -13,7 +14,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				return;
 			}
 
-			const poster = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
+			const poster = await findOneHunter(interaction.user.id, interaction.guild.id);
 			const nextShowcaseInMS = new Date(poster.lastShowcaseTimestamp).valueOf() + timeConversion(1, "w", "ms");
 			if (runMode === "prod" && Date.now() < nextShowcaseInMS) {
 				interaction.reply({ content: `You can showcase another bounty in <t:${Math.floor(nextShowcaseInMS / 1000)}:R>.`, flags: [MessageFlags.Ephemeral] });

--- a/source/buttons/bbtakedown.js
+++ b/source/buttons/bbtakedown.js
@@ -2,6 +2,7 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, ComponentTyp
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { getRankUpdates } = require('../util/scoreUtil');
+const { findOneHunter } = require('../logic/hunters');
 
 const mainId = "bbtakedown";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -30,7 +31,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				database.models.Completion.destroy({ where: { bountyId: bounty.id } });
 				bounty.destroy();
 
-				database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
+				findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 					hunter.decrement("xp");
 					const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 					const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -6,7 +6,7 @@ const { timeConversion, congratulationBuilder, listifyEN, generateTextBar } = re
 const { updateScoreboard } = require('../util/embedUtil');
 const { progressGoal, findLatestGoalProgress } = require('../logic/goals');
 const { Seconding } = require('../models/toasts/Seconding');
-const { findOrCreateBountyHunter } = require('../logic/hunters');
+const { findOrCreateBountyHunter, findOneHunter } = require('../logic/hunters');
 
 const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -43,7 +43,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		});
 		const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 		for (const userId of recipientIds) {
-			const hunter = await database.models.Hunter.findOne({ where: { userId, companyId: interaction.guildId } });
+			const hunter = await findOneHunter(userId, interaction.guild.id);
 			const recipientLevelTexts = await hunter.addXP(interaction.guild.name, 1, true, database);
 			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId, seasonId: season.id }, defaults: { xp: 1 } });
 			if (!participationCreated) {

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -6,13 +6,13 @@ const { timeConversion, congratulationBuilder, listifyEN, generateTextBar } = re
 const { updateScoreboard } = require('../util/embedUtil');
 const { progressGoal, findLatestGoalProgress } = require('../logic/goals');
 const { Seconding } = require('../models/toasts/Seconding');
+const { findOrCreateBountyHunter } = require('../logic/hunters');
 
 const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Provide each recipient of a toast an extra XP, roll crit toast for author, and update embed */
 	async (interaction, [toastId], database, runMode) => {
-		await database.models.User.findOrCreate({ where: { id: interaction.user.id } });
-		const [seconder] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
+		const [seconder] = await findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
 		if (seconder.isBanned) {
 			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
 			return;

--- a/source/commands/bounty/addcompleters.js
+++ b/source/commands/bounty/addcompleters.js
@@ -3,6 +3,7 @@ const { Sequelize } = require("sequelize");
 const { extractUserIdsFromMentions, listifyEN, commandMention, congratulationBuilder } = require("../../util/textUtil");
 const { addCompleters } = require("../../logic/bounties.js");
 const { Completion } = require("../../models/bounties/Completion.js");
+const { findOrCreateBountyHunter } = require("../../logic/hunters.js");
 
 /**
  * Updates the board posting for the bounty after adding the completers
@@ -60,8 +61,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	for (const member of completerMembers.filter(member => !existingCompleterIds.includes(member.id))) {
 		if (runMode === "prod" && member.user.bot) continue;
 		const memberId = member.id;
-		await database.models.User.findOrCreate({ where: { id: memberId } });
-		const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: interaction.guildId } });
+		const [hunter] = await findOrCreateBountyHunter(memberId, interaction.guild.id);
 		if (hunter.isBanned) {
 			bannedIds.push(memberId);
 			continue;

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -8,6 +8,7 @@ const { completeBounty } = require("../../logic/bounties");
 const { Hunter } = require("../../models/users/Hunter");
 const { findLatestGoalProgress } = require("../../logic/goals");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { findOrCreateBountyHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -47,8 +48,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	for (const member of completerMembers) {
 		if (runMode !== "prod" || !member.user.bot) {
 			const memberId = member.id;
-			await database.models.User.findOrCreate({ where: { id: memberId } });
-			const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: interaction.guildId } });
+			const [hunter] = await findOrCreateBountyHunter(memberId, interaction.guild.id);
 			if (!hunter.isBanned) {
 				validatedCompleterIds.push(memberId);
 				validatedHunters.push(hunter);

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -8,7 +8,7 @@ const { completeBounty } = require("../../logic/bounties");
 const { Hunter } = require("../../models/users/Hunter");
 const { findLatestGoalProgress } = require("../../logic/goals");
 const { findOrCreateCompany } = require("../../logic/companies");
-const { findOrCreateBountyHunter } = require("../../logic/hunters");
+const { findOrCreateBountyHunter, findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -62,8 +62,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 	}
 
 	await interaction.deferReply();
-	/** @type {Hunter} */
-	const poster = await database.models.Hunter.findOne({ where: { userId: bounty.userId, companyId: bounty.companyId } });
+	const poster = await findOneHunter(bounty.userId, bounty.companyId);
 	const { completerXP, posterXP, rewardTexts, goalUpdate } = await completeBounty(bounty, poster, validatedHunters, interaction.guild);
 	const rankUpdates = await getRankUpdates(interaction.guild, database);
 	const [company] = await findOrCreateCompany(interaction.guildId);

--- a/source/commands/bounty/edit.js
+++ b/source/commands/bounty/edit.js
@@ -4,6 +4,7 @@ const { timeConversion, textsHaveAutoModInfraction, trimForModalTitle, commandMe
 const { SKIP_INTERACTION_HANDLING, YEAR_IN_MS } = require("../../constants");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -186,7 +187,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			bounty.save();
 
 			// update bounty board
-			const poster = await database.models.Hunter.findOne({ where: { userId: modalSubmission.user.id, companyId: modalSubmission.guildId } });
+			const poster = await findOneHunter(modalSubmission.user.id, modalSubmission.guild.id);
 			const [company] = await findOrCreateCompany(modalSubmission.guildId);
 			const bountyEmbed = await bounty.embed(modalSubmission.guild, poster.level, false, company, await database.models.Completion.findAll({ where: { bountyId: bounty.id } }));
 			if (company.bountyBoardId) {

--- a/source/commands/bounty/index.js
+++ b/source/commands/bounty/index.js
@@ -2,6 +2,7 @@ const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('d
 const { CommandWrapper } = require('../../classes');
 const { createSubcommandMappings } = require('../../util/fileUtil.js');
 const { findOrCreateBountyHunter } = require('../../logic/hunters.js');
+const { findOrCreateCompany } = require('../../logic/companies.js');
 
 const mainId = "bounty";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
@@ -18,7 +19,7 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 module.exports = new CommandWrapper(mainId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
 	async (interaction, database, runMode) => {
 		const userId = interaction.user.id;
-		await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		await findOrCreateCompany(interaction.guild.id);
 		const [hunter] = await findOrCreateBountyHunter(userId, interaction.guild.id);
 		if (hunter.isBanned) {
 			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });

--- a/source/commands/bounty/index.js
+++ b/source/commands/bounty/index.js
@@ -1,6 +1,7 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../../classes');
 const { createSubcommandMappings } = require('../../util/fileUtil.js');
+const { findOrCreateBountyHunter } = require('../../logic/hunters.js');
 
 const mainId = "bounty";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
@@ -17,9 +18,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 module.exports = new CommandWrapper(mainId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
 	async (interaction, database, runMode) => {
 		const userId = interaction.user.id;
-		await database.models.User.findOrCreate({ where: { id: userId } });
 		await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
-		const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId, companyId: interaction.guildId } });
+		const [hunter] = await findOrCreateBountyHunter(userId, interaction.guild.id);
 		if (hunter.isBanned) {
 			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
 			return;

--- a/source/commands/bounty/list.js
+++ b/source/commands/bounty/list.js
@@ -1,5 +1,6 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -14,7 +15,7 @@ async function executeSubcommand(interaction, database, runMode, ...[userId]) {
 			interaction.reply({ content: `<@${listUserId}> doesn't have any open bounties posted.`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
-		const hunter = await database.models.Hunter.findOne({ where: { userId: listUserId, companyId: interaction.guildId } });
+		const hunter = await findOneHunter(listUserId, interaction.guild.id);
 		const company = await database.models.Company.findByPk(interaction.guildId);
 		interaction.reply({ embeds: await Promise.all(existingBounties.map(async bounty => bounty.embed(interaction.guild, hunter?.level ?? company.level, false, company, await database.models.Completion.findAll({ where: { bountyId: bounty.id } })))), flags: [MessageFlags.Ephemeral] });
 	});

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -6,6 +6,7 @@ const { getNumberEmoji, timeConversion, textsHaveAutoModInfraction, commandMenti
 const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS, SAFE_DELIMITER } = require("../../constants");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
+const { findOrCreateCompany } = require("../../logic/companies");
 
 /**
  * @param {CommandInteraction} interaction
@@ -14,7 +15,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
  * @param {[string, Hunter]} args
  */
 async function executeSubcommand(interaction, database, runMode, ...[posterId, hunter]) {
-	const [{ maxSimBounties }] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+	const [{ maxSimBounties }] = await findOrCreateCompany(interaction.guild.id);
 	const existingBounties = await database.models.Bounty.findAll({ where: { userId: posterId, companyId: interaction.guildId, state: "open" } });
 	const occupiedSlots = existingBounties.map(bounty => bounty.slotNumber);
 	const bountySlots = hunter.maxSlots(maxSimBounties);

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -7,6 +7,7 @@ const { SKIP_INTERACTION_HANDLING, MAX_EMBED_TITLE_LENGTH, YEAR_IN_MS, SAFE_DELI
 const { updateScoreboard } = require("../../util/embedUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -52,7 +53,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 		const [slotNumber] = collectedInteraction.values;
 		// Check user actually has slot
 		const company = await database.models.Company.findByPk(interaction.guildId);
-		const hunter = await database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } });
+		const hunter = await findOneHunter(interaction.user.id, interaction.guild.id);
 		if (parseInt(slotNumber) > hunter.maxSlots(company.maxSimBounties)) {
 			interaction.update({ content: `You haven't unlocked bounty slot ${slotNumber} yet.`, components: [] });
 			return;
@@ -183,7 +184,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId, h
 				participation.increment({ xp: 1 });
 			}
 			const company = await database.models.Company.findByPk(modalSubmission.guildId);
-			const poster = await database.models.Hunter.findOne({ where: { userId: modalSubmission.user.id, companyId: modalSubmission.guildId } });
+			const poster = await findOneHunter(modalSubmission.user.id, modalSubmission.guild.id);
 			poster.addXP(modalSubmission.guild.name, 1, true, database).then(() => {
 				getRankUpdates(modalSubmission.guild, database);
 				updateScoreboard(company, interaction.guild, database);

--- a/source/commands/bounty/showcase.js
+++ b/source/commands/bounty/showcase.js
@@ -4,6 +4,7 @@ const { timeConversion } = require("../../util/textUtil");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
 const { showcaseBounty } = require("../../util/bountyUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -12,7 +13,7 @@ const { showcaseBounty } = require("../../util/bountyUtil");
  * @param {[string]} args
  */
 async function executeSubcommand(interaction, database, runMode, ...[posterId]) {
-	database.models.Hunter.findOne({ where: { userId: posterId, companyId: interaction.guildId } }).then(async hunter => {
+	findOneHunter(posterId, interaction.guild.id).then(async hunter => {
 		const nextShowcaseInMS = new Date(hunter.lastShowcaseTimestamp).valueOf() + timeConversion(1, "w", "ms");
 		if (runMode === "prod" && Date.now() < nextShowcaseInMS) {
 			interaction.reply({ content: `You can showcase another bounty in <t:${Math.floor(nextShowcaseInMS / 1000)}:R>.`, flags: [MessageFlags.Ephemeral] });

--- a/source/commands/bounty/swap.js
+++ b/source/commands/bounty/swap.js
@@ -4,6 +4,7 @@ const { getNumberEmoji } = require("../../util/textUtil");
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../constants");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -34,7 +35,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			const collector = response.resource.message.createMessageComponentCollector({ max: 2 });
 			collector.on("collect", async (collectedInteraction) => {
 				if (collectedInteraction.customId.endsWith("bounty")) {
-					database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+					findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 						const company = await database.models.Company.findByPk(interaction.guildId);
 						if (hunter.maxSlots(company.maxSimBounties) < 2) {
 							collectedInteraction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: [MessageFlags.Ephemeral] });
@@ -97,7 +98,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 						destinationBounty.updatePosting(interaction.guild, company, database);
 					}
 
-					const hunter = await database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } });
+					const hunter = await findOneHunter(interaction.user.id, interaction.guild.id);
 					interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member}'s bounty, **${sourceBounty.title}** is now worth ${Bounty.calculateCompleterReward(hunter.level, destinationSlot, sourceBounty.showcaseCount)} XP.` }));
 				}
 			})

--- a/source/commands/bounty/takedown.js
+++ b/source/commands/bounty/takedown.js
@@ -5,6 +5,7 @@ const { SKIP_INTERACTION_HANDLING } = require("../../constants");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -40,7 +41,7 @@ async function executeSubcommand(interaction, database, runMode, ...[posterId]) 
 			}
 			bounty.destroy();
 
-			database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
+			findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 				hunter.decrement("xp");
 				const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 				const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });

--- a/source/commands/config-premium.js
+++ b/source/commands/config-premium.js
@@ -1,11 +1,12 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { GLOBAL_MAX_BOUNTY_SLOTS } = require('../constants');
+const { findOrCreateCompany } = require('../logic/companies');
 
 const mainId = "config-premium";
 module.exports = new CommandWrapper(mainId, "Configure premium BountyBot settings for this server", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	(interaction, database, runMode) => {
-		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
+		findOrCreateCompany(interaction.guild.id).then(([company]) => {
 			const updatePayload = {};
 			let content = "The following server settings have been configured:";
 			const errors = [];

--- a/source/commands/config-server.js
+++ b/source/commands/config-server.js
@@ -1,10 +1,11 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
+const { findOrCreateCompany } = require('../logic/companies');
 
 const mainId = "config-server";
 module.exports = new CommandWrapper(mainId, "Configure BountyBot settings for this server", PermissionFlagsBits.ManageGuild, false, [InteractionContextType.Guild], 3000,
 	(interaction, database, runMode) => {
-		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
+		findOrCreateCompany(interaction.guild.id).then(([company]) => {
 			const updatePayload = {};
 			let content = "The following server settings have been configured:";
 

--- a/source/commands/create-default/bountyboardforum.js
+++ b/source/commands/create-default/bountyboardforum.js
@@ -4,6 +4,7 @@ const { generateBountyBoardThread } = require("../../util/scoreUtil");
 const { Company } = require("../../models/companies/Company");
 const { SAFE_DELIMITER } = require("../../constants");
 const { timeConversion } = require("../../util/textUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -47,7 +48,7 @@ async function executeSubcommand(interaction, database, runMode, ...[company]) {
 				evergreenBounties.unshift(bounty);
 				continue;
 			}
-			database.models.Hunter.findOne({ where: { companyId: bounty.companyId, userId: bounty.userId } }).then(async poster => {
+			findOneHunter(bounty.userId, bounty.companyId).then(async poster => {
 				return bounty.embed(interaction.guild, bounty.userId == interaction.client.user.id ? company.level : poster.level, false, company, await database.models.Completion.findAll({ where: { bountyId: bounty.id } }));
 			}).then(bountyEmbed => {
 				return bountyBoard.threads.create({

--- a/source/commands/create-default/index.js
+++ b/source/commands/create-default/index.js
@@ -1,6 +1,7 @@
 const { PermissionFlagsBits, InteractionContextType } = require('discord.js');
 const { CommandWrapper } = require('../../classes');
 const { createSubcommandMappings } = require('../../util/fileUtil.js');
+const { findOrCreateCompany } = require('../../logic/companies.js');
 
 const mainId = "create-default";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
@@ -10,7 +11,7 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 ]);
 module.exports = new CommandWrapper(mainId, "Create a Discord resource for use by BountyBot", PermissionFlagsBits.ManageChannels, false, [InteractionContextType.Guild], 30000,
 	(interaction, database, runMode) => {
-		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
+		findOrCreateCompany(interaction.guild.id).then(([company]) => {
 			subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, database, runMode, company);
 		});
 	}

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -5,6 +5,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions, congratulationBuilder, listifyEN, generateTextBar } = require("../../util/textUtil");
 const { progressGoal, findLatestGoalProgress } = require("../../logic/goals");
+const { findOrCreateBountyHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -40,8 +41,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	for (const member of (await interaction.guild.members.fetch({ user: dedupedCompleterIds })).values()) {
 		if (runMode !== "prod" || !member.user.bot) {
 			const memberId = member.id;
-			await database.models.User.findOrCreate({ where: { id: memberId } });
-			const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: memberId, companyId: interaction.guildId } });
+			const [hunter] = await findOrCreateBountyHunter(memberId, interaction.guild.id);
 			if (!hunter.isBanned) {
 				validatedCompleterIds.push(memberId);
 			}

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -5,7 +5,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
 const { updateScoreboard } = require("../../util/embedUtil");
 const { extractUserIdsFromMentions, congratulationBuilder, listifyEN, generateTextBar } = require("../../util/textUtil");
 const { progressGoal, findLatestGoalProgress } = require("../../logic/goals");
-const { findOrCreateBountyHunter } = require("../../logic/hunters");
+const { findOrCreateBountyHunter, findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -74,7 +74,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	let wasGoalCompleted = false;
 	const finalContributorIds = new Set(validatedCompleterIds);
 	for (const userId of validatedCompleterIds) {
-		const hunter = await database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId } });
+		const hunter = await findOneHunter(userId, interaction.guild.id);
 		levelTexts.push(...await hunter.addXP(interaction.guild.name, bountyValue, true, database));
 		hunter.increment("othersFinished");
 		const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId, seasonId: season.id }, defaults: { xp: bountyValue } });

--- a/source/commands/evergreen/post.js
+++ b/source/commands/evergreen/post.js
@@ -3,6 +3,7 @@ const { Sequelize } = require("sequelize");
 const { MAX_EMBEDS_PER_MESSAGE, MAX_EMBED_TITLE_LENGTH, SKIP_INTERACTION_HANDLING } = require("../../constants");
 const { textsHaveAutoModInfraction, timeConversion, commandMention } = require("../../util/textUtil");
 const { generateBountyBoardThread } = require("../../util/scoreUtil");
+const { findOrCreateCompany } = require("../../logic/companies");
 
 /**
  * @param {CommandInteraction} interaction
@@ -83,7 +84,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 			}
 		}
 
-		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		const [company] = await findOrCreateCompany(interaction.guild.id);
 		const bounty = await database.models.Bounty.create(rawBounty);
 
 		// post in bounty board forum

--- a/source/commands/evergreen/swap.js
+++ b/source/commands/evergreen/swap.js
@@ -4,6 +4,7 @@ const { getNumberEmoji } = require("../../util/textUtil");
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../constants");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -34,7 +35,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 		const collector = response.resource.message.createMessageComponentCollector({ max: 2 });
 		collector.on("collect", async (collectedInteraction) => {
 			if (collectedInteraction.customId.endsWith("evergreen")) {
-				database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+				findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 					const existingBounties = await database.models.Bounty.findAll({ where: { isEvergreen: true, companyId: interaction.guildId, state: "open" } });
 					const previousBounty = existingBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
 					const previousBountySlot = previousBounty.slotNumber;

--- a/source/commands/festival/index.js
+++ b/source/commands/festival/index.js
@@ -1,6 +1,7 @@
 const { PermissionFlagsBits, InteractionContextType } = require('discord.js');
 const { CommandWrapper } = require('../../classes');
 const { createSubcommandMappings } = require('../../util/fileUtil.js');
+const { findOrCreateCompany } = require('../../logic/companies.js');
 
 const mainId = "festival";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
@@ -10,7 +11,7 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 module.exports = new CommandWrapper(mainId, "Manage a server-wide festival to multiply XP of bounty completions, toast reciepts, and crit toasts", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	/** Allow users to manage an XP multiplier festival */
 	(interaction, database, runMode) => {
-		database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(([company]) => {
+		findOrCreateCompany(interaction.guild.id).then(([company]) => {
 			subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, database, runMode, company);
 		});
 	}

--- a/source/commands/moderation/bountybotban.js
+++ b/source/commands/moderation/bountybotban.js
@@ -1,6 +1,7 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { findOrCreateBountyHunter } = require("../../logic/hunters");
+const { findOrCreateCompany } = require("../../logic/companies");
 
 /**
  * @param {CommandInteraction} interaction
@@ -10,7 +11,7 @@ const { findOrCreateBountyHunter } = require("../../logic/hunters");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const member = interaction.options.getUser("user");
-	await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+	await findOrCreateCompany(interaction.guild.id);
 	const [hunter] = await findOrCreateBountyHunter(member.id, interaction.guild.id);
 	hunter.isBanned = !hunter.isBanned;
 	if (hunter.isBanned) {

--- a/source/commands/moderation/bountybotban.js
+++ b/source/commands/moderation/bountybotban.js
@@ -1,5 +1,6 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
+const { findOrCreateBountyHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -9,9 +10,8 @@ const { Sequelize } = require("sequelize");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const member = interaction.options.getUser("user");
-	await database.models.User.findOrCreate({ where: { id: member.id } });
 	await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
-	const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId } });
+	const [hunter] = await findOrCreateBountyHunter(member.id, interaction.guild.id);
 	hunter.isBanned = !hunter.isBanned;
 	if (hunter.isBanned) {
 		hunter.hasBeenBanned = true;

--- a/source/commands/moderation/revokegoalbonus.js
+++ b/source/commands/moderation/revokegoalbonus.js
@@ -1,5 +1,6 @@
 const { CommandInteraction, MessageFlags, userMention } = require("discord.js");
 const { Sequelize } = require("sequelize");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -9,7 +10,7 @@ const { Sequelize } = require("sequelize");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const revokeOption = interaction.options.get("revokee", true);
-	const hunter = await database.models.Hunter.findOne({ where: { userId: revokeOption.value, companyId: interaction.guildId } });
+	const hunter = await findOneHunter(revokeOption.value, interaction.guild.id);
 	if (!hunter) {
 		interaction.reply({ content: `${userMention(revokeOption.value)} hasn't interacted with BountyBot yet.`, flags: [MessageFlags.Ephemeral] });
 		return;

--- a/source/commands/moderation/seasondisqualify.js
+++ b/source/commands/moderation/seasondisqualify.js
@@ -1,6 +1,7 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { getRankUpdates } = require("../../util/scoreUtil");
+const { findOrCreateCompany } = require("../../logic/companies");
 
 /**
  * @param {CommandInteraction} interaction
@@ -10,7 +11,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const member = interaction.options.getMember("bounty-hunter");
-	await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+	await findOrCreateCompany(interaction.guild.id);
 	const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 	await database.models.User.findOrCreate({ where: { id: member.id } });
 	const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { isRankDisqualified: true } });

--- a/source/commands/moderation/takedown.js
+++ b/source/commands/moderation/takedown.js
@@ -4,6 +4,7 @@ const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../constants")
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { bountiesToSelectOptions } = require("../../util/messageComponentUtil");
 const { findOrCreateCompany } = require("../../logic/companies");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -46,7 +47,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 			}
 			bounty.destroy();
 
-			database.models.Hunter.findOne({ where: { userId: posterId, companyId: interaction.guildId } }).then(async poster => {
+			findOneHunter(posterId, interaction.guild.id).then(async poster => {
 				poster.decrement("xp");
 				const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 				const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: posterId, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });

--- a/source/commands/moderation/userreport.js
+++ b/source/commands/moderation/userreport.js
@@ -1,6 +1,7 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { buildModStatsEmbed } = require("../../util/embedUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -10,7 +11,7 @@ const { buildModStatsEmbed } = require("../../util/embedUtil");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const member = interaction.options.getMember("user");
-	const hunter = await database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: member.id } });
+	const hunter = await findOneHunter(member.id, interaction.guild.id);
 	if (!hunter) {
 		interaction.reply({ content: `${member} has not interacted with BountyBot on this server.`, flags: [MessageFlags.Ephemeral] });
 		return;

--- a/source/commands/moderation/xppenalty.js
+++ b/source/commands/moderation/xppenalty.js
@@ -1,6 +1,7 @@
 const { CommandInteraction, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { getRankUpdates } = require("../../util/scoreUtil");
+const { findOneHunter } = require("../../logic/hunters");
 
 /**
  * @param {CommandInteraction} interaction
@@ -10,7 +11,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
  */
 async function executeSubcommand(interaction, database, runMode, ...args) {
 	const member = interaction.options.getMember("bounty-hunter");
-	const hunter = await database.models.Hunter.findOne({ where: { userId: member.id, companyId: interaction.guildId } });
+	const hunter = await findOneHunter(member.id, interaction.guild.id);
 	if (!hunter) {
 		interaction.reply({ content: `${member} hasn't interacted with BountyBot yet.`, flags: [MessageFlags.Ephemeral] });
 		return;

--- a/source/commands/rank/add.js
+++ b/source/commands/rank/add.js
@@ -3,6 +3,7 @@ const { Sequelize } = require("sequelize");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { MAX_EMBED_FIELD_COUNT } = require("../../constants");
 const { commandMention } = require("../../util/textUtil");
+const { findOrCreateCompany } = require("../../logic/companies");
 
 /**
  * @param {CommandInteraction} interaction
@@ -38,7 +39,7 @@ async function executeSubcommand(interaction, database, runMode, ...args) {
 	if (newRankmoji) {
 		rawRank.rankmoji = newRankmoji;
 	}
-	database.models.Company.findOrCreate({ where: { id: interaction.guildId } }).then(() => {
+	findOrCreateCompany(interaction.guild.id).then(() => {
 		database.models.Rank.create(rawRank);
 	})
 	getRankUpdates(interaction.guild, database);

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -4,6 +4,7 @@ const { Hunter } = require('../models/users/Hunter');
 const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../util/embedUtil');
 const { generateTextBar } = require('../util/textUtil');
 const { Op } = require('sequelize');
+const { findOneHunter } = require('../logic/hunters');
 
 const mainId = "stats";
 module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yourself or someone else", null, false, [InteractionContextType.Guild], 3000,
@@ -21,7 +22,7 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 				})
 			} else {
 				// Other Hunter
-				database.models.Hunter.findOne({ where: { userId: target.id, companyId: interaction.guildId } }).then(async hunter => {
+				findOneHunter(target.id, interaction.guild.id).then(async hunter => {
 					if (!hunter) {
 						interaction.reply({ content: "The specified user doesn't seem to have a profile with this server's BountyBot yet. It'll be created when they gain XP.", flags: [MessageFlags.Ephemeral] });
 						return;
@@ -61,7 +62,7 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 			}
 		} else {
 			// Self
-			database.models.Hunter.findOne({ where: { userId: interaction.user.id, companyId: interaction.guildId } }).then(async hunter => {
+			findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 				if (!hunter) {
 					interaction.reply({ content: "You don't seem to have a profile with this server's BountyBot yet. It'll be created when you gain XP.", flags: [MessageFlags.Ephemeral] });
 					return;

--- a/source/context_menus/BountyBot_Stats.js
+++ b/source/context_menus/BountyBot_Stats.js
@@ -4,6 +4,7 @@ const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('.
 const { generateTextBar } = require('../util/textUtil');
 const { UserContextMenuWrapper } = require('../classes');
 const { Op } = require('sequelize');
+const { findOneHunter } = require('../logic/hunters');
 
 const mainId = "BountyBot Stats";
 module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionContextType.Guild], 3000,
@@ -20,7 +21,7 @@ module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionCon
 			})
 		} else {
 			// Other Hunter
-			database.models.Hunter.findOne({ where: { userId: target.id, companyId: interaction.guildId } }).then(async hunter => {
+			findOneHunter(target.id, interaction.guild.id).then(async hunter => {
 				if (!hunter) {
 					interaction.reply({ content: "The specified user doesn't seem to have a profile with this server's BountyBot yet. It'll be created when they gain XP.", flags: [MessageFlags.Ephemeral] });
 					return;

--- a/source/context_menus/Give_Bounty_Credit.js
+++ b/source/context_menus/Give_Bounty_Credit.js
@@ -4,6 +4,7 @@ const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { addCompleters } = require('../logic/bounties.js');
 const { commandMention, listifyEN, congratulationBuilder } = require('../util/textUtil');
 const { Completion } = require('../models/bounties/Completion.js');
+const { findOrCreateBountyHunter } = require('../logic/hunters.js');
 
 /**
  * Updates the board posting for the bounty after adding the completers
@@ -47,8 +48,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			return;
 		}
 
-		await database.models.User.findOrCreate({ where: { id: interaction.targetId } });
-		const [hunter] = await database.models.Hunter.findOrCreate({ where: { userId: interaction.targetId, companyId: interaction.guildId } });
+		const [hunter] = await findOrCreateBountyHunter(interaction.targetId, interaction.guild.id);
 		if (hunter.isBanned) {
 			interaction.reply({ content: `${userMention(interaction.targetId)} cannot be credited with bounty completion because they are banned from interacting with BountyBot on this server.`, flags: [MessageFlags.Ephemeral] });
 			return;

--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -1,10 +1,11 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOrCreateCompany } = require("../logic/companies");
 
 const itemName = "Goal Initializer";
 module.exports = new Item(itemName, "Begin a Server Goal if there isn't already one running", 3000,
 	async (interaction, database) => {
-		const [company] = await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		const [company] = await findOrCreateCompany(interaction.guild.id);
 		const existingGoals = await database.models.Goal.findAll({ where: { companyId: interaction.guildId, state: "ongoing" } });
 		if (existingGoals.length > 0) {
 			interaction.reply({ content: "This server already has a Server Goal running.", flags: [MessageFlags.Ephemeral] });
@@ -16,7 +17,7 @@ module.exports = new Item(itemName, "Begin a Server Goal if there isn't already 
 		const previousSeason = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isPreviousSeason: true } });
 		const activeHunters = previousSeason ? (await database.models.Participation.findOne({ where: { seasonId: season.id }, order: [["placement", "DESC"]] })).placement : 3;
 		const requiredGP = activeHunters * 20;
-		await database.models.Company.findOrCreate({ where: { id: interaction.guildId } });
+		await findOrCreateCompany(interaction.guild.id);
 		await database.models.Goal.create({ companyId: interaction.guildId, type: goalType, requiredGP });
 		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));
 	}

--- a/source/items/profile-colorizer-aqua.js
+++ b/source/items/profile-colorizer-aqua.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Aqua";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Aqua in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-blue.js
+++ b/source/items/profile-colorizer-blue.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Blue";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blue in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-blurple.js
+++ b/source/items/profile-colorizer-blurple.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Blurple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blurple in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkaqua.js
+++ b/source/items/profile-colorizer-darkaqua.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Aqua";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkAqua in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkblue.js
+++ b/source/items/profile-colorizer-darkblue.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Blue";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkBlue in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkbutnotblack.js
+++ b/source/items/profile-colorizer-darkbutnotblack.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark But Not Black";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkButNotBlack in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkergrey.js
+++ b/source/items/profile-colorizer-darkergrey.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Darker Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkerGrey in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkgold.js
+++ b/source/items/profile-colorizer-darkgold.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Gold";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGold in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkgreen.js
+++ b/source/items/profile-colorizer-darkgreen.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Green";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGreen in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkgrey.js
+++ b/source/items/profile-colorizer-darkgrey.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGrey in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darknavy.js
+++ b/source/items/profile-colorizer-darknavy.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Navy";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkNavy in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkorange.js
+++ b/source/items/profile-colorizer-darkorange.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Orange";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkOrange in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkpurple.js
+++ b/source/items/profile-colorizer-darkpurple.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Blue";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blue in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkred.js
+++ b/source/items/profile-colorizer-darkred.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Red";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkRed in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-darkvividpink.js
+++ b/source/items/profile-colorizer-darkvividpink.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Dark Vivid Pink";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkVividPink in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-default.js
+++ b/source/items/profile-colorizer-default.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Default";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, "Changes the color of your stats profile embed to black", 3000,
 	/** Sets the user's Hunter profile to Colors.Default in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-fuchsia.js
+++ b/source/items/profile-colorizer-fuchsia.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Fuchsia";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Fuchsia in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-gold.js
+++ b/source/items/profile-colorizer-gold.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Gold";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Gold in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-green.js
+++ b/source/items/profile-colorizer-green.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Green";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Green in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-grey.js
+++ b/source/items/profile-colorizer-grey.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Grey in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-greyple.js
+++ b/source/items/profile-colorizer-greyple.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Greyple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Greyple in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-lightgrey.js
+++ b/source/items/profile-colorizer-lightgrey.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Light Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.LightGrey in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-luminousvividpink.js
+++ b/source/items/profile-colorizer-luminousvividpink.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Luminous Vivid Pink";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.LuminousVividPink in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-navy.js
+++ b/source/items/profile-colorizer-navy.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Navy";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Navy in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-notquiteblack.js
+++ b/source/items/profile-colorizer-notquiteblack.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Not Quite Black";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.NotQuiteBlack in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color.replace(/ /g, "");
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-orange.js
+++ b/source/items/profile-colorizer-orange.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Orange";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Orange in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-purple.js
+++ b/source/items/profile-colorizer-purple.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Purple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Purple in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-red.js
+++ b/source/items/profile-colorizer-red.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Red";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Red in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-white.js
+++ b/source/items/profile-colorizer-white.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "White";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.White in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/profile-colorizer-yellow.js
+++ b/source/items/profile-colorizer-yellow.js
@@ -1,12 +1,13 @@
 const { MessageFlags } = require("discord.js");
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 
 const color = "Yellow";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new Item(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Yellow in the used guild */
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(hunter => {
 			hunter.profileColor = color;
 			hunter.save();
 		})

--- a/source/items/xp-boost-epic.js
+++ b/source/items/xp-boost-epic.js
@@ -1,11 +1,12 @@
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 const { getRankUpdates } = require("../util/scoreUtil");
 
 const itemName = "Epic XP Boost";
 const xpValue = 25;
 module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
 			if (!participationCreated) {

--- a/source/items/xp-boost-legendary.js
+++ b/source/items/xp-boost-legendary.js
@@ -1,11 +1,12 @@
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 const { getRankUpdates } = require("../util/scoreUtil");
 
 const itemName = "Legendary XP Boost";
 const xpValue = 75;
 module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
 			if (!participationCreated) {

--- a/source/items/xp-boost.js
+++ b/source/items/xp-boost.js
@@ -1,11 +1,12 @@
 const { Item } = require("../classes");
+const { findOneHunter } = require("../logic/hunters");
 const { getRankUpdates } = require("../util/scoreUtil");
 
 const itemName = "XP Boost";
 const xpValue = 5;
 module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
 	async (interaction, database) => {
-		database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } }).then(async hunter => {
+		findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await database.models.Season.findOrCreate({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
 			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
 			if (!participationCreated) {

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -1,4 +1,5 @@
 const { Sequelize, Op } = require("sequelize");
+const { findOrCreateBountyHunter } = require("./hunters");
 
 /** @type {Sequelize} */
 let db;
@@ -45,9 +46,8 @@ async function progressGoal(companyId, progressType, userId) {
 		if (goal.type === progressType) {
 			returnData.gpContributed *= 2;
 		}
-		await db.models.User.findOrCreate({ where: { id: userId } });
 		await db.models.Contribution.create({ goalId: goal.id, userId, value: returnData.gpContributed });
-		const [hunter] = await db.models.Hunter.findOrCreate({ where: { companyId, userId } });
+		const [hunter] = await findOrCreateBountyHunter(userId, companyId);
 		hunter.increment("goalContributions");
 		const [season] = await db.models.Season.findOrCreate({ where: { companyId, isCurrentSeason: true } });
 		const [participation] = await db.models.Participation.findOrCreate({ where: { companyId, userId, seasonId: season.id } });

--- a/source/util/bountyUtil.js
+++ b/source/util/bountyUtil.js
@@ -1,5 +1,6 @@
 const { Interaction, TextChannel, PermissionFlagsBits, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
+const { findOneHunter } = require("../logic/hunters");
 
 /**
  * @param {Interaction} interaction
@@ -28,7 +29,7 @@ async function showcaseBounty(interaction, bountyId, showcaseChannel, isItemShow
 	bounty.increment("showcaseCount");
 	await bounty.save().then(bounty => bounty.reload());
 	const company = await database.models.Company.findByPk(interaction.guildId);
-	const poster = await database.models.Hunter.findOne({ where: { companyId: interaction.guildId, userId: interaction.user.id } });
+	const poster = await findOneHunter(interaction.user.id, interaction.guild.id);
 	if (!isItemShowcase) {
 		poster.lastShowcaseTimestamp = new Date();
 		poster.save();


### PR DESCRIPTION
Summary
-------
- apply `findOrCreateBountyHunter()` to reduce frontend dependence on database references
- apply `findOrCreateCompany()` to reduce frontend dependence on database references
- apply `findOneHunter()` to reduce frontend dependence on database references
   - skipped use in `bounties.addCompleters()`: already noted in #322
   - skipped use in `Bounty.updatePosting()`: out of scope
   - skipped use in `Participation.hunter`: out of scope

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)