### PR TITLE
#310: move `buildModStatsEmbed()` to `Hunter.modStatsEmbed()`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Server Goals are BountyBot objectives everyone on the server contributes to. A g
 - Fixed crashes when toasting, completing bounties, or seconding toasts in threads
 - Added an optional text input for `/evergreen showcase` to allow moderators to add text to the showcase message
 - Fixed `/bounty edit` and `/evergreen edit` not saving modifications
+- Fixed `/moderation user-report` listing XP awarded for recent bounties as "undefined"
 ## BountyBot Version 2.8.0:
 ### Context Menu Options
 - Added the following BountyBot functionality to the Apps dropdown when right-clicking on a User or Message:

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -93,7 +93,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						console.error(error);
 					}
 				});
-				updateScoreboard(company, collectedInteraction.guild, database);
+				updateScoreboard(collectedInteraction.guild, database);
 			}).catch(error => {
 				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
 					console.error(error);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -138,7 +138,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					thread.send({ content, flags: MessageFlags.SuppressNotifications });
 				})
 			}
-			updateScoreboard(await database.models.Company.findByPk(interaction.guildId), interaction.guild, database);
+			updateScoreboard(interaction.guild, database);
 		})
 
 		if (progressData.goalCompleted) {

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -107,7 +107,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			})
 		}
 
-		updateScoreboard(company, interaction.guild, database);
+		updateScoreboard(interaction.guild, database);
 	});
 };
 

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -185,7 +185,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			const poster = await logicLayer.hunters.findOneHunter(modalSubmission.user.id, modalSubmission.guild.id);
 			poster.addXP(modalSubmission.guild.name, 1, true, database).then(() => {
 				getRankUpdates(modalSubmission.guild, database);
-				updateScoreboard(company, interaction.guild, database);
+				updateScoreboard(interaction.guild, database);
 			});
 
 			if (shouldMakeEvent) {

--- a/source/commands/create-default/scoreboardreference.js
+++ b/source/commands/create-default/scoreboardreference.js
@@ -29,7 +29,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 	});
 	const isSeasonal = interaction.options.getString("scoreboard-type") == "season";
 	scoreboard.send({
-		embeds: [isSeasonal ? await buildSeasonalScoreboardEmbed(interaction.guild, database) : await buildOverallScoreboardEmbed(interaction.guild, database)]
+		embeds: [isSeasonal ? await buildSeasonalScoreboardEmbed(interaction.guild, database, logicLayer) : await buildOverallScoreboardEmbed(interaction.guild, database, logicLayer)]
 	}).then(message => {
 		company.scoreboardChannelId = scoreboard.id;
 		company.scoreboardMessageId = message.id;

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -106,7 +106,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 			response.resource.message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
 				thread.send({ content: Bounty.generateRewardString(validatedCompleterIds, bountyBaseValue, null, null, company.festivalMultiplierString(), rankUpdates, levelTexts), flags: MessageFlags.SuppressNotifications });
 			})
-			updateScoreboard(company, interaction.guild, database);
+			updateScoreboard(interaction.guild, database);
 		});
 	})
 };

--- a/source/commands/reset/allhunterstats.js
+++ b/source/commands/reset/allhunterstats.js
@@ -11,12 +11,12 @@ const { updateScoreboard } = require("../../util/embedUtil");
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
 	database.models.Hunter.destroy({ where: { companyId: interaction.guildId } });
 	interaction.reply({ content: "Resetting bounty hunter stats has begun.", flags: [MessageFlags.Ephemeral] });
-	const company = await database.models.Company.findByPk(interaction.guildId);
-	const season = await database.models.Season.findOne({ where: { companyId: interaction.guildId, isCurrentSeason: true } });
+	await database.models.Company.findByPk(interaction.guildId);
+	const season = await logicLayer.seasons.findOneSeason(interaction.guild.id, "current");
 	if (season) {
 		await database.models.Participation.destroy({ where: { seasonId: season.id } });
 	}
-	updateScoreboard(company, interaction.guild, database);
+	updateScoreboard(interaction.guild, database);
 	interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
 };
 

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -10,7 +10,7 @@ module.exports = new CommandWrapper(mainId, "View the XP scoreboard", null, fals
 	/** View the XP scoreboard */
 	(interaction, database, runMode) => {
 		if (interaction.options.getString("scoreboard-type") === "season") {
-			buildSeasonalScoreboardEmbed(interaction.guild, database).then(embed => {
+			buildSeasonalScoreboardEmbed(interaction.guild, database, logicLayer).then(embed => {
 				interaction.reply({
 					embeds: [embed],
 					flags: [MessageFlags.Ephemeral]

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -1,6 +1,8 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { buildCompanyStatsEmbed, updateScoreboard } = require('../util/embedUtil');
+const { updateScoreboard } = require('../util/embedUtil');
+const { Hunter } = require('../models/users/Hunter');
+const { COMPANY_XP_COEFFICIENT } = require('../constants');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;
@@ -15,7 +17,11 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 			return;
 		}
 
-		buildCompanyStatsEmbed(interaction.guild, database).then(async embed => {
+		const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
+		const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
+		const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
+		const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
+		company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(async embed => {
 			const seasonBeforeEndingSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
 			if (seasonBeforeEndingSeason) {
 				seasonBeforeEndingSeason.isPreviousSeason = false;
@@ -58,7 +64,7 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				})
 			}
 			await database.models.Hunter.update({ rank: null, nextRankXP: null }, { where: { companyId: company.id } });
-			updateScoreboard(company, interaction.guild, database);
+			updateScoreboard(interaction.guild, database);
 			let announcementText = "A new season has started, ranks and placements have been reset!";
 			if (shoutouts.length > 0) {
 				announcementText += `\n## Shoutouts\n- ${shoutouts.join("\n- ")}`;

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -1,9 +1,10 @@
 const { EmbedBuilder, Colors, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { Hunter } = require('../models/users/Hunter');
-const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../util/embedUtil');
+const { randomFooterTip, ihpAuthorPayload } = require('../util/embedUtil');
 const { generateTextBar } = require('../util/textUtil');
 const { Op } = require('sequelize');
+const { COMPANY_XP_COEFFICIENT } = require('../constants');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;
@@ -11,12 +12,17 @@ let logicLayer;
 const mainId = "stats";
 module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yourself or someone else", null, false, [InteractionContextType.Guild], 3000,
 	/** Get the BountyBot stats for yourself or someone else */
-	(interaction, database, runMode) => {
+	async (interaction, database, runMode) => {
 		const target = interaction.options.getMember("bounty-hunter");
 		if (target) {
 			if (target.id === interaction.client.user.id) {
 				// BountyBot
-				buildCompanyStatsEmbed(interaction.guild, database).then(embed => {
+				const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
+				const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
+				const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
+				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
+				const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
+				company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 					interaction.reply({
 						embeds: [embed],
 						flags: [MessageFlags.Ephemeral]

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -104,7 +104,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 						thread.send({ content, flags: MessageFlags.SuppressNotifications });
 					})
 				}
-				updateScoreboard(company, interaction.guild, database);
+				updateScoreboard(interaction.guild, database);
 			}
 		});
 	}

--- a/source/context_menus/BountyBot_Stats.js
+++ b/source/context_menus/BountyBot_Stats.js
@@ -1,9 +1,10 @@
 const { EmbedBuilder, Colors, InteractionContextType, MessageFlags } = require('discord.js');
 const { Hunter } = require('../models/users/Hunter');
-const { buildCompanyStatsEmbed, randomFooterTip, ihpAuthorPayload } = require('../util/embedUtil');
+const { randomFooterTip, ihpAuthorPayload } = require('../util/embedUtil');
 const { generateTextBar } = require('../util/textUtil');
 const { UserContextMenuWrapper } = require('../classes');
 const { Op } = require('sequelize');
+const { COMPANY_XP_COEFFICIENT } = require('../constants');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;
@@ -11,11 +12,16 @@ let logicLayer;
 const mainId = "BountyBot Stats";
 module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionContextType.Guild], 3000,
 	/** Specs */
-	(interaction, database, runMode) => {
+	async (interaction, database, runMode) => {
 		const target = interaction.targetMember;
 		if (target.id == interaction.client.user.id) {
 			// BountyBot
-			buildCompanyStatsEmbed(interaction.guild, database).then(embed => {
+			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
+			const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
+			const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
+			const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
+			const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
+			company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 				interaction.reply({
 					embeds: [embed],
 					flags: [MessageFlags.Ephemeral]

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -93,7 +93,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 							thread.send({ content, flags: MessageFlags.SuppressNotifications });
 						})
 					}
-					updateScoreboard(company, modalSubmission.guild, database);
+					updateScoreboard(modalSubmission.guild, database);
 				}
 			});
 		})

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -1,5 +1,8 @@
-const { MessageFlags } = require('discord.js');
+const { MessageFlags, EmbedBuilder, Colors } = require('discord.js');
 const { Model, Sequelize, DataTypes } = require('sequelize');
+const { ihpAuthorPayload, randomFooterTip } = require('../../util/embedUtil');
+const { generateTextBar } = require('../../util/textUtil');
+const { Season } = require('../seasons/Season');
 
 /** A Company of bounty hunters contains a Discord Guild's information and settings */
 class Company extends Model {
@@ -52,6 +55,38 @@ class Company extends Model {
 			messageOptions.content = `${this.announcementPrefix} ${messageOptions.content}`;
 		}
 		return messageOptions;
+	}
+
+	/**
+	 * @param {Guild} guild
+	 * @param {Sequelize} database
+	 * @param {number} currentLevelThreshold
+	 * @param {number} nextLevelThreshold
+	 * @param {Season} currentSeason
+	 * @param {Season} lastSeason
+	 */
+	async statsEmbed(guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason) {
+		const participantCount = await database.models.Participation.count({ where: { seasonId: currentSeason.id } });
+		const companyXP = await this.xp;
+		const currentSeasonXP = await currentSeason.totalXP;
+		const lastSeasonXP = await lastSeason?.totalXP ?? 0;
+
+		const particpantPercentage = participantCount / guild.memberCount * 100;
+		const seasonXPDifference = currentSeasonXP - lastSeasonXP;
+		const seasonBountyDifference = currentSeason.bountiesCompleted - (lastSeason?.bountiesCompleted ?? 0);
+		const seasonToastDifference = currentSeason.toastsRaised - (lastSeason?.toastsRaised ?? 0);
+		return new EmbedBuilder().setColor(Colors.Blurple)
+			.setAuthor(ihpAuthorPayload)
+			.setTitle(`${guild.name} is __Level ${this.level}__`)
+			.setThumbnail(guild.iconURL())
+			.setDescription(`${generateTextBar(companyXP - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - companyXP} Bounty Hunter Levels`)
+			.addFields(
+				{ name: "Total Bounty Hunter Level", value: `${companyXP} level${companyXP == 1 ? "" : "s"}`, inline: true },
+				{ name: "Participation", value: `${participantCount} server members have interacted with BountyBot this season (${particpantPercentage.toPrecision(3)}% of server members)` },
+				{ name: `${currentSeasonXP} XP Earned Total (${seasonXPDifference === 0 ? "same as last season" : `${seasonXPDifference > 0 ? `+${seasonXPDifference} more XP` : `${seasonXPDifference * -1} fewer XP`} than last season`})`, value: `${currentSeason.bountiesCompleted} bounties (${seasonBountyDifference === 0 ? "same as last season" : `${seasonBountyDifference > 0 ? `**+${seasonBountyDifference} more bounties**` : `**${seasonBountyDifference * -1} fewer bounties**`} than last season`})\n${currentSeason.toastsRaised} toasts (${seasonToastDifference === 0 ? "same as last season" : `${seasonToastDifference > 0 ? `**+${seasonToastDifference} more toasts**` : `**${seasonToastDifference * -1} fewer toasts**`} than last season`})` }
+			)
+			.setFooter(randomFooterTip())
+			.setTimestamp()
 	}
 }
 

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -1,5 +1,9 @@
 const { Model, Sequelize, DataTypes } = require('sequelize');
-const { congratulationBuilder } = require('../../util/textUtil');
+const { congratulationBuilder, listifyEN } = require('../../util/textUtil');
+const { Bounty } = require('../bounties/Bounty');
+const { EmbedBuilder, userMention } = require('discord.js');
+const { randomFooterTip } = require('../../util/embedUtil');
+const { Completion } = require('../bounties/Completion');
 
 /** This class stores a user's information related to a specific company */
 class Hunter extends Model {
@@ -9,11 +13,16 @@ class Hunter extends Model {
 		});
 	}
 
+	/**
+	 * @param {number} level
+	 * @param {number} xpCoefficient
+	 */
 	static xpThreshold(level, xpCoefficient) {
 		// xp = xpCoefficient*(level - 1)^2
 		return xpCoefficient * (level - 1) ** 2;
 	}
 
+	/** @param {number} maxSimBounties */
 	maxSlots(maxSimBounties) {
 		let slots = 1 + Math.floor(this.level / 12) * 2;
 		let remainder = this.level % 12;
@@ -64,6 +73,11 @@ class Hunter extends Model {
 		return levelTexts;
 	}
 
+	/**
+	 * @param {number} level
+	 * @param {number} maxSlots
+	 * @param {boolean} futureReward
+	 */
 	levelUpReward(level, maxSlots, futureReward = true) {
 		const texts = [];
 		if (level % 2) {
@@ -78,6 +92,38 @@ class Hunter extends Model {
 			};
 		}
 		return texts;
+	}
+
+	/**
+	* @param {Guild} guild
+	* @param {GuildMember} member
+	* @param {number} dqCount
+	* @param {(Bounty & {Completions: Completion[]})[]} lastFiveBounties
+	*/
+	modStatsEmbed(guild, member, dqCount, lastFiveBounties) {
+		const embed = new EmbedBuilder().setColor(member.displayColor)
+			.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
+			.setTitle(`Moderation Stats: ${member.user.tag}`)
+			.setThumbnail(member.user.avatarURL())
+			.setDescription(`Display Name: **${member.displayName}** (id: *${member.id}*)\nAccount created on: ${member.user.createdAt.toDateString()}\nJoined server on: ${member.joinedAt.toDateString()}`)
+			.addFields(
+				{ name: "Bans", value: `Currently Banned: ${this.isBanned ? "Yes" : "No"}\nHas Been Banned: ${this.hasBeenBanned ? "Yes" : "No"}`, inline: true },
+				{ name: "Disqualifications", value: `${dqCount} season DQs`, inline: true },
+				{ name: "Penalties", value: `${this.penaltyCount} penalties (${this.penaltyPointTotal} points total)`, inline: true }
+			)
+			.setFooter(randomFooterTip())
+			.setTimestamp();
+
+		let bountyHistory = "";
+		for (let i = 0; i < lastFiveBounties.length; i++) {
+			const bounty = lastFiveBounties[i];
+			bountyHistory += `__${bounty.title}__${bounty.description !== null ? ` ${bounty.description}` : ""}${listifyEN(bounty.Completions.map(completion => `\n${userMention(completion.userId)} +${completion.xpAwarded} XP`))}\n\n`;
+		}
+
+		if (bountyHistory === "") {
+			bountyHistory = "No recent bounties";
+		}
+		return embed.addFields({ name: "Last 5 Completed Bounties Created by this User", value: bountyHistory });
 	}
 }
 

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -1,13 +1,8 @@
 const fs = require("fs");
 const { EmbedBuilder, Guild, Colors } = require("discord.js");
 const { Sequelize } = require("sequelize");
-const { Hunter } = require("../models/users/Hunter");
-const { Company } = require("../models/companies/Company");
-const { COMPANY_XP_COEFFICIENT, MAX_EMBED_DESCRIPTION_LENGTH } = require("../constants");
+const { MAX_EMBED_DESCRIPTION_LENGTH } = require("../constants");
 const { generateTextBar } = require("./textUtil");
-const { findLatestGoalProgress } = require("../logic/goals");
-const { findOrCreateCompany } = require("../logic/companies");
-const { findOrCreateCurrentSeason, findOneSeason } = require("../logic/seasons");
 
 const discordIconURL = "https://cdn.discordapp.com/attachments/618523876187570187/1110265047516721333/discord-mark-blue.png";
 const bountyBotIcon = "https://cdn.discordapp.com/attachments/618523876187570187/1138968614364528791/BountyBotIcon.jpg";
@@ -47,46 +42,13 @@ function randomFooterTip() {
 	return tipPool[Math.floor(Math.random() * tipPool.length)];
 }
 
-/**
- * @param {Guild} guild
- * @param {Sequelize} database
- */
-async function buildCompanyStatsEmbed(guild, database) {
-	const [company] = await findOrCreateCompany(guild.id);
-	const [currentSeason] = await findOrCreateCurrentSeason(guild.id);
-	const lastSeason = await findOneSeason(guild.id, "previous");
-	const participantCount = await database.models.Participation.count({ where: { seasonId: currentSeason.id } });
-	const companyXP = await company.xp;
-	const currentSeasonXP = await currentSeason.totalXP;
-	const lastSeasonXP = await lastSeason?.totalXP ?? 0;
-
-	const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
-	const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
-	const particpantPercentage = participantCount / guild.memberCount * 100;
-	const seasonXPDifference = currentSeasonXP - lastSeasonXP;
-	const seasonBountyDifference = currentSeason.bountiesCompleted - (lastSeason?.bountiesCompleted ?? 0);
-	const seasonToastDifference = currentSeason.toastsRaised - (lastSeason?.toastsRaised ?? 0);
-	return new EmbedBuilder().setColor(Colors.Blurple)
-		.setAuthor(module.exports.ihpAuthorPayload)
-		.setTitle(`${guild.name} is __Level ${company.level}__`)
-		.setThumbnail(guild.iconURL())
-		.setDescription(`${generateTextBar(companyXP - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)}*Next Level:* ${nextLevelThreshold - companyXP} Bounty Hunter Levels`)
-		.addFields(
-			{ name: "Total Bounty Hunter Level", value: `${companyXP} level${companyXP == 1 ? "" : "s"}`, inline: true },
-			{ name: "Participation", value: `${participantCount} server members have interacted with BountyBot this season (${particpantPercentage.toPrecision(3)}% of server members)` },
-			{ name: `${currentSeasonXP} XP Earned Total (${seasonXPDifference === 0 ? "same as last season" : `${seasonXPDifference > 0 ? `+${seasonXPDifference} more XP` : `${seasonXPDifference * -1} fewer XP`} than last season`})`, value: `${currentSeason.bountiesCompleted} bounties (${seasonBountyDifference === 0 ? "same as last season" : `${seasonBountyDifference > 0 ? `**+${seasonBountyDifference} more bounties**` : `**${seasonBountyDifference * -1} fewer bounties**`} than last season`})\n${currentSeason.toastsRaised} toasts (${seasonToastDifference === 0 ? "same as last season" : `${seasonToastDifference > 0 ? `**+${seasonToastDifference} more toasts**` : `**${seasonToastDifference * -1} fewer toasts**`} than last season`})` }
-		)
-		.setFooter(randomFooterTip())
-		.setTimestamp()
-}
-
 /** A seasonal scoreboard orders a company's hunters by their seasonal xp
  * @param {Guild} guild
  * @param {Sequelize} database
  */
-async function buildSeasonalScoreboardEmbed(guild, database) {
-	const [company] = await findOrCreateCompany(guild.id);
-	const [season] = await findOrCreateCurrentSeason(company.id);
+async function buildSeasonalScoreboardEmbed(guild, database, logicLayer) {
+	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
+	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(company.id);
 	const participations = await database.models.Participation.findAll({ where: { seasonId: season.id }, order: [["xp", "DESC"]] });
 
 	const hunterMembers = await guild.members.fetch({ user: participations.map(participation => participation.userId) });
@@ -124,7 +86,7 @@ async function buildSeasonalScoreboardEmbed(guild, database) {
 	}
 
 	const fields = [];
-	const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(guild.id);
+	const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
 	if (goalId !== null) {
 		fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 	}
@@ -145,9 +107,9 @@ async function buildSeasonalScoreboardEmbed(guild, database) {
  * @param {Guild} guild
  * @param {Sequelize} database
  */
-async function buildOverallScoreboardEmbed(guild, database) {
+async function buildOverallScoreboardEmbed(guild, database, logicLayer) {
 	const hunters = await database.models.Hunter.findAll({ where: { companyId: guild.id }, order: [["xp", "DESC"]] });
-	const [company] = await findOrCreateCompany(guild.id);
+	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
 
 	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
 	const rankmojiArray = (await database.models.Rank.findAll({ where: { companyId: guild.id }, order: [["varianceThreshold", "DESC"]] })).map(rank => rank.rankmoji);
@@ -183,7 +145,7 @@ async function buildOverallScoreboardEmbed(guild, database) {
 	}
 
 	const fields = [];
-	const { goalId, currentGP, requiredGP } = await findLatestGoalProgress(guild.id);
+	const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
 	if (goalId !== null) {
 		fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 	}
@@ -199,40 +161,6 @@ async function buildOverallScoreboardEmbed(guild, database) {
 	}
 
 	return embed;
-}
-
-/**
- * @param {Guild} guild
- * @param {GuildMember} member
- * @param {Hunter} hunter
- * @param {Sequelize} database
- */
-async function buildModStatsEmbed(guild, member, hunter, database) {
-	const embed = new EmbedBuilder().setColor(member.displayColor)
-		.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
-		.setTitle(`Moderation Stats: ${member.user.tag}`)
-		.setThumbnail(member.user.avatarURL())
-		.setDescription(`Display Name: **${member.displayName}** (id: *${member.id}*)\nAccount created on: ${member.user.createdAt.toDateString()}\nJoined server on: ${member.joinedAt.toDateString()}`)
-		.addFields(
-			{ name: "Bans", value: `Currently Banned: ${hunter.isBanned ? "Yes" : "No"}\nHas Been Banned: ${hunter.hasBeenBanned ? "Yes" : "No"}`, inline: true },
-			{ name: "Disqualifications", value: `${await database.models.Participation.sum("dqCount", { where: { companyId: guild.id, userId: member.id } }) ?? 0} season DQs`, inline: true },
-			{ name: "Penalties", value: `${hunter.penaltyCount} penalties (${hunter.penaltyPointTotal} points total)`, inline: true }
-		)
-		.setFooter(randomFooterTip())
-		.setTimestamp();
-
-	let bountyHistory = "";
-	const lastFiveBounties = await database.models.Bounty.findAll({ where: { userId: member.id, companyId: guild.id, state: "completed" }, order: [["completedAt", "DESC"]], limit: 5 });
-	lastFiveBounties.forEach(async bounty => {
-		const completions = await database.models.Completion.findAll({ where: { bountyId: bounty.id } });
-		bountyHistory += `__${bounty.title}__${bounty.description !== null ? ` ${bounty.description}` : ""}\n${bounty.xpAwarded} XP per completer\nCompleters: <@${completions.map(completion => completion.userId).join('>, <@')
-			}>\n\n`;
-	})
-
-	if (bountyHistory === "") {
-		bountyHistory = "No recent bounties";
-	}
-	return embed.addFields({ name: "Last 5 Completed Bounties Created by this User", value: bountyHistory });
 }
 
 /** The version embed lists the following: changes in the most recent update, known issues in the most recent update, and links to support the project
@@ -260,16 +188,16 @@ async function buildVersionEmbed() {
 }
 
 /** If the guild has a scoreboard reference channel, update the embed in it
- * @param {Company} company
  * @param {Guild} guild
  * @param {Sequelize} database
  */
-function updateScoreboard(company, guild, database) {
+async function updateScoreboard(guild, database, logicLayer) {
+	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
 	if (company.scoreboardChannelId && company.scoreboardMessageId) {
 		guild.channels.fetch(company.scoreboardChannelId).then(scoreboard => {
 			return scoreboard.messages.fetch(company.scoreboardMessageId);
 		}).then(async scoreboardMessage => {
-			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await buildSeasonalScoreboardEmbed(guild, database) : await buildOverallScoreboardEmbed(guild, database)] });
+			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await buildSeasonalScoreboardEmbed(guild, database, logicLayer) : await buildOverallScoreboardEmbed(guild, database, logicLayer)] });
 		});
 	}
 }
@@ -277,10 +205,8 @@ function updateScoreboard(company, guild, database) {
 module.exports = {
 	ihpAuthorPayload: { name: "Click here to check out the Imaginary Horizons GitHub", iconURL: "https://images-ext-2.discordapp.net/external/8DllSg9z_nF3zpNliVC3_Q8nQNu9J6Gs0xDHP_YthRE/https/cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png", url: "https://github.com/Imaginary-Horizons-Productions" },
 	randomFooterTip,
-	buildCompanyStatsEmbed,
 	buildSeasonalScoreboardEmbed,
 	buildOverallScoreboardEmbed,
-	buildModStatsEmbed,
 	buildVersionEmbed,
 	updateScoreboard
 };


### PR DESCRIPTION
Summary
-------
- move `buildModStatsEmbed()` to `Hunter.modStatsEmbed()`
- move `buildCompanyStatsEmbed()` to `Company.statsEmbed()`

This is Ugly but is Scheduled to Be Refactored Later
------------
- `company` removed from `updateScoreboard()` parameters to avoid circular dependency with Company (which needs `ihpAuthorPayload` among others)
- added `logicLayer` as parameter for `buildSeasonalScoreboardEmbed()` and `buildOverallScoreboardEmbed()`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used context menu flow to check user stats
- [x] used context menu flow to check company stats

Issue
-----
Closes #310