### PR TITLE
fix crash on add completers button in archived thread

### DIFF
--- a/source/buttons/bbaddcompleters.js
+++ b/source/buttons/bbaddcompleters.js
@@ -1,8 +1,11 @@
-const { ActionRowBuilder, UserSelectMenuBuilder, userMention, DiscordjsErrorCodes, ComponentType, MessageFlags } = require('discord.js');
+const { ActionRowBuilder, UserSelectMenuBuilder, userMention, DiscordjsErrorCodes, ComponentType, MessageFlags, Guild, ThreadChannel } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { listifyEN, congratulationBuilder, timeConversion } = require('../util/textUtil');
 const { Completion } = require('../models/bounties/Completion.js');
+const { Bounty } = require('../models/bounties/Bounty.js');
+const { Company } = require('../models/companies/Company.js');
+const { Hunter } = require('../models/users/Hunter.js');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;
@@ -15,11 +18,12 @@ let logicLayer;
  * @param {string[]} newCompleterIds
  * @param {Completion[]} completers
  * @param {Guild} guild
+ * @param {ThreadChannel} btnPost
  */
 async function updateBoardPosting(bounty, company, poster, newCompleterIds, completers, guild, btnPost) {
 	if (!btnPost) return;
 	if (btnPost.archived) {
-		await thread.setArchived(false, "Unarchived to update posting");
+		await btnPost.setArchived(false, "Unarchived to update posting");
 	}
 	btnPost.edit({ name: bounty.title });
 	let numCompleters = newCompleterIds.length;

--- a/source/commands/bounty/addcompleters.js
+++ b/source/commands/bounty/addcompleters.js
@@ -1,7 +1,10 @@
-const { CommandInteraction, userMention, bold, MessageFlags } = require("discord.js");
+const { CommandInteraction, userMention, bold, MessageFlags, Guild } = require("discord.js");
 const { Sequelize } = require("sequelize");
 const { extractUserIdsFromMentions, listifyEN, commandMention, congratulationBuilder } = require("../../util/textUtil");
 const { Completion } = require("../../models/bounties/Completion.js");
+const { Bounty } = require("../../models/bounties/Bounty.js");
+const { Company } = require("../../models/companies/Company.js");
+const { Hunter } = require("../../models/users/Hunter.js");
 
 /**
  * Updates the board posting for the bounty after adding the completers

--- a/source/context_menus/Give_Bounty_Credit.js
+++ b/source/context_menus/Give_Bounty_Credit.js
@@ -1,8 +1,11 @@
-const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, userMention, bold, MessageFlags } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, userMention, bold, MessageFlags, Guild } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { commandMention, listifyEN, congratulationBuilder } = require('../util/textUtil');
 const { Completion } = require('../models/bounties/Completion.js');
+const { Bounty } = require('../models/bounties/Bounty.js');
+const { Company } = require('../models/companies/Company.js');
+const { Hunter } = require('../models/users/Hunter.js');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;


### PR DESCRIPTION
Summary
-------
- fix crash on add completers button in archived thread
- add missing type annotation imports

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] bot doesn't crash if adding completers to an archived bounty thread via the thread button