### PR TITLE
#334: remove `database` from `Company.statsEmbed()` parameters

### DIFF
--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -21,7 +21,8 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 		const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
 		const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
 		const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
-		company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(async embed => {
+		const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
+		company.statsEmbed(interaction.guild, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(async embed => {
 			const seasonBeforeEndingSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
 			if (seasonBeforeEndingSeason) {
 				seasonBeforeEndingSeason.isPreviousSeason = false;

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -22,7 +22,8 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 				const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
 				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
 				const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
-				company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
+				const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
+				company.statsEmbed(interaction.guild, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 					interaction.reply({
 						embeds: [embed],
 						flags: [MessageFlags.Ephemeral]

--- a/source/context_menus/BountyBot_Stats.js
+++ b/source/context_menus/BountyBot_Stats.js
@@ -19,9 +19,10 @@ module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionCon
 			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 			const currentLevelThreshold = Hunter.xpThreshold(company.level, COMPANY_XP_COEFFICIENT);
 			const nextLevelThreshold = Hunter.xpThreshold(company.level + 1, COMPANY_XP_COEFFICIENT);
-			const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
-			const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
-			company.statsEmbed(interaction.guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
+			const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
+			const lastSeason = await logicLayer.seasons.findOneSeason(interaction.guild.id, "previous");
+			const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
+			company.statsEmbed(interaction.guild, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 				interaction.reply({
 					embeds: [embed],
 					flags: [MessageFlags.Ephemeral]

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -33,6 +33,13 @@ function findOneSeason(companyId, type) {
 	}
 }
 
+/** *Get the number of participating bounty hunters in the specified Season*
+ * @param {string} seasonId
+ */
+function getParticipantCount(seasonId) {
+	return db.models.Participation.count({ where: { seasonId } });
+}
+
 /** @param {string} companyId */
 function deleteCompanySeasons(companyId) {
 	return db.models.Season.destroy({ where: { companyId } });
@@ -43,5 +50,6 @@ module.exports = {
 	createSeason,
 	findOrCreateCurrentSeason,
 	findOneSeason,
+	getParticipantCount,
 	deleteCompanySeasons
 }

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -59,14 +59,13 @@ class Company extends Model {
 
 	/**
 	 * @param {Guild} guild
-	 * @param {Sequelize} database
+	 * @param {number} participantCount
 	 * @param {number} currentLevelThreshold
 	 * @param {number} nextLevelThreshold
 	 * @param {Season} currentSeason
 	 * @param {Season} lastSeason
 	 */
-	async statsEmbed(guild, database, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason) {
-		const participantCount = await database.models.Participation.count({ where: { seasonId: currentSeason.id } });
+	async statsEmbed(guild, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason) {
 		const companyXP = await this.xp;
 		const currentSeasonXP = await currentSeason.totalXP;
 		const lastSeasonXP = await lastSeason?.totalXP ?? 0;


### PR DESCRIPTION
## NO REVIEW CANDIDATE

Summary
-------
- remove `database` from `Company.statsEmbed()` parameters

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] company stats embed can still be gotten via context menu option

Issue
-----
Closes #334