### PR TITLE
add endpoint `changeSeasonXP()`

### DIFF
--- a/source/buttons/bbtakedown.js
+++ b/source/buttons/bbtakedown.js
@@ -36,10 +36,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 					hunter.decrement("xp");
 					const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-					const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });
-					if (!participationCreated) {
-						participation.decrement("xp");
-					}
+					logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
 					getRankUpdates(interaction.guild, database, logicLayer);
 				})
 

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -48,13 +48,10 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		for (const userId of recipientIds) {
 			const hunter = await logicLayer.hunters.findOneHunter(userId, interaction.guild.id);
 			const recipientLevelTexts = await hunter.addXP(interaction.guild.name, 1, true, company);
-			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId, seasonId: season.id }, defaults: { xp: 1 } });
-			if (!participationCreated) {
-				participation.increment({ xp: 1 });
-			}
 			if (recipientLevelTexts.length > 0) {
 				rewardTexts.push(...recipientLevelTexts);
 			}
+			logicLayer.seasons.changeSeasonXP(userId, interaction.guildId, season.id, 1);
 			hunter.increment("toastsReceived");
 		}
 
@@ -102,10 +99,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				if (seconderLevelTexts.length > 0) {
 					rewardTexts = rewardTexts.concat(seconderLevelTexts);
 				}
-				const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: 1 } });
-				if (!participationCreated) {
-					participation.increment({ xp: 1 });
-				}
+				logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, 1);
 			}
 		}
 

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -177,10 +177,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			}
 
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(modalSubmission.guild.id);
-			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: modalSubmission.guildId, userId: modalSubmission.user.id, seasonId: season.id }, defaults: { xp: 1 } });
-			if (!participationCreated) {
-				participation.increment({ xp: 1 });
-			}
+			logicLayer.seasons.changeSeasonXP(modalSubmission.user.id, modalSubmission.guildId, season.id, 1);
 			const company = await logicLayer.companies.findCompanyByPK(modalSubmission.guild.id);
 			const poster = await logicLayer.hunters.findOneHunter(modalSubmission.user.id, modalSubmission.guildId);
 			poster.addXP(modalSubmission.guild.name, 1, true, company).then(() => {

--- a/source/commands/bounty/takedown.js
+++ b/source/commands/bounty/takedown.js
@@ -42,10 +42,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 				hunter.decrement("xp");
 				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-				const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: interaction.user.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });
-				if (!participationCreated) {
-					participation.decrement("xp");
-				}
+				logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
 				getRankUpdates(interaction.guild, database, logicLayer);
 			})
 

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -76,10 +76,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 		const hunter = await logicLayer.hunters.findOneHunter(userId, interaction.guild.id);
 		levelTexts.push(...await hunter.addXP(interaction.guild.name, bountyValue, true, company));
 		hunter.increment("othersFinished");
-		const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId, seasonId: season.id }, defaults: { xp: bountyValue } });
-		if (!participationCreated) {
-			participation.increment({ xp: bountyValue });
-		}
+		logicLayer.seasons.changeSeasonXP(userId, interaction.guildId, season.id, bountyValue);
 		const { gpContributed, goalCompleted, contributorIds } = await logicLayer.goals.progressGoal(interaction.guildId, "bounties", userId);
 		totalGP += gpContributed;
 		wasGoalCompleted ||= goalCompleted;

--- a/source/commands/moderation/bountybotban.js
+++ b/source/commands/moderation/bountybotban.js
@@ -17,7 +17,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	}
 	hunter.save();
 	interaction.reply({ content: `${member} has been ${hunter.isBanned ? "" : "un"}banned from interacting with BountyBot.`, flags: [MessageFlags.Ephemeral] });
-	if (!member.bot) {
+	if (!member.user.bot) {
 		member.send(`You have been ${hunter.isBanned ? "" : "un"}banned from interacting with BountyBot on ${interaction.guild.name}. The reason provided was: ${interaction.options.getString("reason")}`);
 	}
 };

--- a/source/commands/moderation/seasondisqualify.js
+++ b/source/commands/moderation/seasondisqualify.js
@@ -23,7 +23,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	}
 	getRankUpdates(interaction.guild, database, logicLayer);
 	interaction.reply({ content: `<@${member.id}> has been ${participation.isRankDisqualified ? "dis" : "re"}qualified for achieving ranks this season.`, flags: [MessageFlags.Ephemeral] });
-	if (!member.bot) {
+	if (!member.user.bot) {
 		member.send(`You have been ${participation.isRankDisqualified ? "dis" : "re"}qualified for season ranks this season by ${interaction.member}. The reason provided was: ${interaction.options.getString("reason")}`);
 	}
 };

--- a/source/commands/moderation/takedown.js
+++ b/source/commands/moderation/takedown.js
@@ -48,10 +48,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 			logicLayer.hunters.findOneHunter(posterId, interaction.guild.id).then(async poster => {
 				poster.decrement("xp");
 				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-				const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: posterId, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 } });
-				if (!participationCreated) {
-					participation.decrement("xp");
-				}
+				logicLayer.seasons.changeSeasonXP(posterId, interaction.guildId, season.id, 1);
 				getRankUpdates(interaction.guild, database, logicLayer);
 			})
 			collectedInteraction.reply({ content: `<@${posterId}>'s bounty **${bounty.title}** has been taken down by ${interaction.member}.` });

--- a/source/commands/moderation/xppenalty.js
+++ b/source/commands/moderation/xppenalty.js
@@ -19,13 +19,10 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	hunter.decrement({ xp: penaltyValue });
 	hunter.increment({ penaltyCount: 1, penaltyPointTotal: penaltyValue });
 	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-	const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { userId: member.id, companyId: interaction.guildId, seasonId: season.id }, defaults: { xp: -1 * penaltyValue } });
-	if (!participationCreated) {
-		participation.decrement("xp", { by: penaltyValue });
-	}
+	logicLayer.seasons.changeSeasonXP(member.id, interaction.guildId, season.id, penaltyValue * -1);
 	getRankUpdates(interaction.guild, database, logicLayer);
 	interaction.reply({ content: `<@${member.id}> has been penalized ${penaltyValue} XP.`, flags: [MessageFlags.Ephemeral] });
-	if (!member.bot) {
+	if (!member.user.bot) {
 		member.send(`You have been penalized ${penaltyValue} XP by ${interaction.member}. The reason provided was: ${interaction.options.getString("reason")}`);
 	}
 };

--- a/source/items/xp-boost-epic.js
+++ b/source/items/xp-boost-epic.js
@@ -10,10 +10,7 @@ module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaf
 	async (interaction, database) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
-			if (!participationCreated) {
-				participation.increment({ xp: xpValue });
-			}
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
 			hunter.addXP(interaction.guild.name, xpValue, true, await logicLayer.companies.findCompanyByPK(interaction.guildId)).then(levelTexts => {
 				getRankUpdates(interaction.guild, database, logicLayer).then(rankUpdates => {
 					hunter.save();

--- a/source/items/xp-boost-legendary.js
+++ b/source/items/xp-boost-legendary.js
@@ -10,10 +10,7 @@ module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaf
 	async (interaction, database) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
-			if (!participationCreated) {
-				participation.increment({ xp: xpValue });
-			}
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
 			hunter.addXP(interaction.guild.name, xpValue, true, await logicLayer.companies.findCompanyByPK(interaction.guildId)).then(levelTexts => {
 				getRankUpdates(interaction.guild, database, logicLayer).then(rankUpdates => {
 					hunter.save();

--- a/source/items/xp-boost.js
+++ b/source/items/xp-boost.js
@@ -10,10 +10,7 @@ module.exports = new Item(itemName, `Gain ${xpValue} XP in the used server (unaf
 	async (interaction, database) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-			const [participation, participationCreated] = await database.models.Participation.findOrCreate({ where: { companyId: interaction.guildId, userId: interaction.user.id, seasonId: season.id }, defaults: { xp: xpValue } });
-			if (!participationCreated) {
-				participation.increment({ xp: xpValue });
-			}
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
 			hunter.addXP(interaction.guild.name, xpValue, true, await logicLayer.companies.findCompanyByPK(interaction.guildId)).then(levelTexts => {
 				getRankUpdates(interaction.guild, database, logicLayer).then(rankUpdates => {
 					hunter.save();

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -33,6 +33,20 @@ function findOneSeason(companyId, type) {
 	}
 }
 
+/** *Change the specified Hunter's Seasonal XP*
+ * @param {string} userId
+ * @param {string} companyId
+ * @param {string} seasonId
+ * @param {number} xp negative numbers allowed
+ */
+function changeSeasonXP(userId, companyId, seasonId, xp) {
+	db.models.Participation.findOrCreate({ where: { userId, companyId, seasonId }, defaults: { xp } }).then(([participation, participationCreated]) => {
+		if (!participationCreated) {
+			participation.increment({ xp });
+		}
+	});
+}
+
 /** @param {string} companyId */
 function deleteCompanySeasons(companyId) {
 	return db.models.Season.destroy({ where: { companyId } });
@@ -43,5 +57,6 @@ module.exports = {
 	createSeason,
 	findOrCreateCurrentSeason,
 	findOneSeason,
+	changeSeasonXP,
 	deleteCompanySeasons
 }


### PR DESCRIPTION
Summary
-------
- add endpoint `changeSeasonXP()`
- fix skip DMing bot check always returning true

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used `/moderation xp-penalty` to verify `model.increment()` works with negative values
- [x] bot no longer attempts to DM other bots when using `/moderation xp-penalty`