### PR TITLE
create endpoint `wasAlreadySeconded()`

### DIFF
--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -26,8 +26,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
-		const secondReciept = await database.models.Seconding.findOne({ where: { toastId, seconderId: interaction.user.id } });
-		if (secondReciept) {
+		if (await logicLayer.toasts.wasAlreadySeconded(toastId, interaction.user.id)) {
 			interaction.reply({ content: "You've already seconded this toast.", flags: [MessageFlags.Ephemeral] });
 			return;
 		}

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -11,6 +11,14 @@ function setDB(database) {
 	db = database;
 }
 
+/** *Checks if the specified seconder has already seconded the specified Toast*
+ * @param {string} toastId
+ * @param {string} seconderId
+ */
+async function wasAlreadySeconded(toastId, seconderId) {
+	return Boolean(await db.models.Seconding.findOne({ where: { toastId, seconderId } }));
+}
+
 /**
  * @param {Guild} guild
  * @param {Company} company
@@ -119,5 +127,6 @@ async function raiseToast(guild, company, sender, senderHunter, toasteeIds, seas
 
 module.exports = {
 	setDB,
+	wasAlreadySeconded,
 	raiseToast
 }


### PR DESCRIPTION
## NO REVIEW CANDIDATE

Summary
-------
- create endpoint `wasAlreadySeconded()`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)