### PR TITLE
remove `database` from `updateScoreboard()` and `buildOverallScoreboardEmbed()`

### DIFF
--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -102,7 +102,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						console.error(error);
 					}
 				});
-				updateScoreboard(collectedInteraction.guild, database, logicLayer);
+				updateScoreboard(collectedInteraction.guild, logicLayer);
 			}).catch(error => {
 				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
 					console.error(error);

--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -102,7 +102,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						console.error(error);
 					}
 				});
-				updateScoreboard(collectedInteraction.guild, logicLayer);
+				company.updateScoreboard(collectedInteraction.guild, logicLayer);
 			}).catch(error => {
 				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
 					console.error(error);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -127,7 +127,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					thread.send({ content, flags: MessageFlags.SuppressNotifications });
 				})
 			}
-			updateScoreboard(interaction.guild, database, logicLayer);
+			updateScoreboard(interaction.guild, logicLayer);
 		})
 
 		if (progressData.goalCompleted) {

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -127,7 +127,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					thread.send({ content, flags: MessageFlags.SuppressNotifications });
 				})
 			}
-			updateScoreboard(interaction.guild, logicLayer);
+			company.updateScoreboard(interaction.guild, logicLayer);
 		})
 
 		if (progressData.goalCompleted) {

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -114,7 +114,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			})
 		}
 
-		updateScoreboard(interaction.guild, logicLayer);
+		company.updateScoreboard(interaction.guild, logicLayer);
 	});
 };
 

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -114,7 +114,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			})
 		}
 
-		updateScoreboard(interaction.guild, database, logicLayer);
+		updateScoreboard(interaction.guild, logicLayer);
 	});
 };
 

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -182,7 +182,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			const poster = await logicLayer.hunters.findOneHunter(modalSubmission.user.id, modalSubmission.guildId);
 			poster.addXP(modalSubmission.guild.name, 1, true, company).then(() => {
 				getRankUpdates(modalSubmission.guild, logicLayer);
-				updateScoreboard(interaction.guild, logicLayer);
+				company.updateScoreboard(interaction.guild, logicLayer);
 			});
 
 			if (shouldMakeEvent) {

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -182,7 +182,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 			const poster = await logicLayer.hunters.findOneHunter(modalSubmission.user.id, modalSubmission.guildId);
 			poster.addXP(modalSubmission.guild.name, 1, true, company).then(() => {
 				getRankUpdates(modalSubmission.guild, logicLayer);
-				updateScoreboard(interaction.guild, database, logicLayer);
+				updateScoreboard(interaction.guild, logicLayer);
 			});
 
 			if (shouldMakeEvent) {

--- a/source/commands/create-default/scoreboardreference.js
+++ b/source/commands/create-default/scoreboardreference.js
@@ -29,7 +29,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 	});
 	const isSeasonal = interaction.options.getString("scoreboard-type") == "season";
 	scoreboard.send({
-		embeds: [isSeasonal ? await buildSeasonalScoreboardEmbed(interaction.guild, logicLayer) : await buildOverallScoreboardEmbed(interaction.guild, database, logicLayer)]
+		embeds: [isSeasonal ? await buildSeasonalScoreboardEmbed(interaction.guild, logicLayer) : await buildOverallScoreboardEmbed(interaction.guild, logicLayer)]
 	}).then(message => {
 		company.scoreboardChannelId = scoreboard.id;
 		company.scoreboardMessageId = message.id;

--- a/source/commands/create-default/scoreboardreference.js
+++ b/source/commands/create-default/scoreboardreference.js
@@ -1,6 +1,5 @@
 const { CommandInteraction, ChannelType, PermissionFlagsBits, OverwriteType, MessageFlags } = require("discord.js");
 const { Sequelize } = require("sequelize");
-const { buildSeasonalScoreboardEmbed, buildOverallScoreboardEmbed } = require("../../util/embedUtil");
 
 /**
  * @param {CommandInteraction} interaction
@@ -29,7 +28,11 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 	});
 	const isSeasonal = interaction.options.getString("scoreboard-type") == "season";
 	scoreboard.send({
-		embeds: [isSeasonal ? await buildSeasonalScoreboardEmbed(interaction.guild, logicLayer) : await buildOverallScoreboardEmbed(interaction.guild, logicLayer)]
+		embeds: [
+			isSeasonal ?
+				await company.seasonalScoreboardEmbed(interaction.guild, logicLayer) :
+				await company.overallScoreboardEmbed(interaction.guild, logicLayer)
+		]
 	}).then(message => {
 		company.scoreboardChannelId = scoreboard.id;
 		company.scoreboardMessageId = message.id;

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -102,7 +102,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 			response.resource.message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
 				thread.send({ content: Bounty.generateRewardString(validatedCompleterIds, bountyBaseValue, null, null, company.festivalMultiplierString(), rankUpdates, levelTexts), flags: MessageFlags.SuppressNotifications });
 			})
-			updateScoreboard(interaction.guild, logicLayer);
+			company.updateScoreboard(interaction.guild, logicLayer);
 		});
 	})
 };

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -102,7 +102,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 			response.resource.message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
 				thread.send({ content: Bounty.generateRewardString(validatedCompleterIds, bountyBaseValue, null, null, company.festivalMultiplierString(), rankUpdates, levelTexts), flags: MessageFlags.SuppressNotifications });
 			})
-			updateScoreboard(interaction.guild, database, logicLayer);
+			updateScoreboard(interaction.guild, logicLayer);
 		});
 	})
 };

--- a/source/commands/reset/allhunterstats.js
+++ b/source/commands/reset/allhunterstats.js
@@ -16,7 +16,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	if (season) {
 		await logicLayer.seasons.deleteSeasonParticipations(season.id);
 	}
-	updateScoreboard(interaction.guild, database, logicLayer);
+	updateScoreboard(interaction.guild, logicLayer);
 	interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
 };
 

--- a/source/commands/reset/allhunterstats.js
+++ b/source/commands/reset/allhunterstats.js
@@ -11,12 +11,12 @@ const { updateScoreboard } = require("../../util/embedUtil");
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
 	logicLayer.hunters.deleteCompanyHunters(interaction.guild.id);
 	interaction.reply({ content: "Resetting bounty hunter stats has begun.", flags: [MessageFlags.Ephemeral] });
-	await logicLayer.companies.findCompanyByPK(interaction.guild.id);
+	const company = await logicLayer.companies.findCompanyByPK(interaction.guild.id);
 	const season = await logicLayer.seasons.findOneSeason(interaction.guild.id, "current");
 	if (season) {
 		await logicLayer.seasons.deleteSeasonParticipations(season.id);
 	}
-	updateScoreboard(interaction.guild, logicLayer);
+	company.updateScoreboard(interaction.guild, logicLayer);
 	interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
 };
 

--- a/source/commands/scoreboard.js
+++ b/source/commands/scoreboard.js
@@ -1,6 +1,5 @@
 const { InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { buildSeasonalScoreboardEmbed, buildOverallScoreboardEmbed } = require('../util/embedUtil');
 
 /** @type {typeof import("../logic")} */
 let logicLayer;
@@ -8,22 +7,16 @@ let logicLayer;
 const mainId = "scoreboard";
 module.exports = new CommandWrapper(mainId, "View the XP scoreboard", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** View the XP scoreboard */
-	(interaction, database, runMode) => {
-		if (interaction.options.getString("scoreboard-type") === "season") {
-			buildSeasonalScoreboardEmbed(interaction.guild, logicLayer).then(embed => {
-				interaction.reply({
-					embeds: [embed],
-					flags: [MessageFlags.Ephemeral]
-				});
-			})
-		} else {
-			buildOverallScoreboardEmbed(interaction.guild, database, logicLayer).then(embed => {
-				interaction.reply({
-					embeds: [embed],
-					flags: [MessageFlags.Ephemeral]
-				});
-			})
-		}
+	async (interaction, database, runMode) => {
+		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
+		interaction.reply({
+			embeds: [
+				interaction.options.getString("scoreboard-type") === "season" ?
+					await company.seasonalScoreboardEmbed(interaction.guild, logicLayer) :
+					await company.overallScoreboardEmbed(interaction.guild, logicLayer)
+			],
+			flags: [MessageFlags.Ephemeral]
+		});
 	}
 ).setOptions(
 	{

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -65,7 +65,7 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				})
 			}
 			await logicLayer.hunters.resetCompanyRanks(company.id);
-			updateScoreboard(interaction.guild, database, logicLayer);
+			updateScoreboard(interaction.guild, logicLayer);
 			let announcementText = "A new season has started, ranks and placements have been reset!";
 			if (shoutouts.length > 0) {
 				announcementText += `\n## Shoutouts\n- ${shoutouts.join("\n- ")}`;

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -65,7 +65,7 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				})
 			}
 			await logicLayer.hunters.resetCompanyRanks(company.id);
-			updateScoreboard(interaction.guild, logicLayer);
+			company.updateScoreboard(interaction.guild, logicLayer);
 			let announcementText = "A new season has started, ranks and placements have been reset!";
 			if (shoutouts.length > 0) {
 				announcementText += `\n## Shoutouts\n- ${shoutouts.join("\n- ")}`;

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -106,7 +106,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 						thread.send({ content, flags: MessageFlags.SuppressNotifications });
 					})
 				}
-				updateScoreboard(interaction.guild, logicLayer);
+				company.updateScoreboard(interaction.guild, logicLayer);
 			}
 		});
 	}

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -106,7 +106,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 						thread.send({ content, flags: MessageFlags.SuppressNotifications });
 					})
 				}
-				updateScoreboard(interaction.guild, database, logicLayer);
+				updateScoreboard(interaction.guild, logicLayer);
 			}
 		});
 	}

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -95,7 +95,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 							thread.send({ content, flags: MessageFlags.SuppressNotifications });
 						})
 					}
-					updateScoreboard(modalSubmission.guild, database, logicLayer);
+					updateScoreboard(modalSubmission.guild, logicLayer);
 				}
 			});
 		})

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -95,7 +95,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 							thread.send({ content, flags: MessageFlags.SuppressNotifications });
 						})
 					}
-					updateScoreboard(modalSubmission.guild, logicLayer);
+					company.updateScoreboard(modalSubmission.guild, logicLayer);
 				}
 			});
 		})

--- a/source/logic/hunters.js
+++ b/source/logic/hunters.js
@@ -41,6 +41,13 @@ function findCompanyHunters(companyId) {
 	return db.models.Hunter.findAll({ where: { companyId } });
 }
 
+/** *Find all Hunters in the specified Company, ordered by descending XP*
+ * @param {string} companyId
+ */
+function findCompanyHuntersByDescendingXP(companyId) {
+	return db.models.Hunter.findAll({ where: { companyId }, order: [["xp", "DESC"]] });
+}
+
 /** *Sets a Hunter's Profile Color*
  * @param {string} userId
  * @param {string} companyId
@@ -69,6 +76,7 @@ module.exports = {
 	findOrCreateBountyHunter,
 	findOneHunter,
 	findCompanyHunters,
+	findCompanyHuntersByDescendingXP,
 	setHunterProfileColor,
 	resetCompanyRanks,
 	deleteCompanyHunters

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -186,26 +186,10 @@ async function buildVersionEmbed() {
 		.setTimestamp(stats.mtime);
 }
 
-/** If the guild has a scoreboard reference channel, update the embed in it
- * @param {Guild} guild
- * @param {typeof import("../logic")} logicLayer
- */
-async function updateScoreboard(guild, logicLayer) {
-	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
-	if (company.scoreboardChannelId && company.scoreboardMessageId) {
-		guild.channels.fetch(company.scoreboardChannelId).then(scoreboard => {
-			return scoreboard.messages.fetch(company.scoreboardMessageId);
-		}).then(async scoreboardMessage => {
-			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await buildSeasonalScoreboardEmbed(guild, logicLayer) : await buildOverallScoreboardEmbed(guild, logicLayer)] });
-		});
-	}
-}
-
 module.exports = {
 	ihpAuthorPayload: { name: "Click here to check out the Imaginary Horizons GitHub", iconURL: "https://images-ext-2.discordapp.net/external/8DllSg9z_nF3zpNliVC3_Q8nQNu9J6Gs0xDHP_YthRE/https/cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png", url: "https://github.com/Imaginary-Horizons-Productions" },
 	randomFooterTip,
 	buildSeasonalScoreboardEmbed,
 	buildOverallScoreboardEmbed,
-	buildVersionEmbed,
-	updateScoreboard
+	buildVersionEmbed
 };

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const { EmbedBuilder, Guild, Colors } = require("discord.js");
-const { Sequelize } = require("sequelize");
 const { MAX_EMBED_DESCRIPTION_LENGTH } = require("../constants");
 const { generateTextBar } = require("./textUtil");
 
@@ -189,7 +188,7 @@ async function buildVersionEmbed() {
 
 /** If the guild has a scoreboard reference channel, update the embed in it
  * @param {Guild} guild
- * @param {Sequelize} database
+ * @param {typeof import("../logic")} logicLayer
  */
 async function updateScoreboard(guild, logicLayer) {
 	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -105,11 +105,10 @@ async function buildSeasonalScoreboardEmbed(guild, logicLayer) {
 
 /** An overall scoreboard orders a company's hunters by total xp
  * @param {Guild} guild
- * @param {Sequelize} database
  * @param {typeof import("../logic")} logicLayer
  */
-async function buildOverallScoreboardEmbed(guild, database, logicLayer) {
-	const hunters = await database.models.Hunter.findAll({ where: { companyId: guild.id }, order: [["xp", "DESC"]] });
+async function buildOverallScoreboardEmbed(guild, logicLayer) {
+	const hunters = await logicLayer.hunters.findCompanyHuntersByDescendingXP(guild.id);
 	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
 
 	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
@@ -192,13 +191,13 @@ async function buildVersionEmbed() {
  * @param {Guild} guild
  * @param {Sequelize} database
  */
-async function updateScoreboard(guild, database, logicLayer) {
+async function updateScoreboard(guild, logicLayer) {
 	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
 	if (company.scoreboardChannelId && company.scoreboardMessageId) {
 		guild.channels.fetch(company.scoreboardChannelId).then(scoreboard => {
 			return scoreboard.messages.fetch(company.scoreboardMessageId);
 		}).then(async scoreboardMessage => {
-			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await buildSeasonalScoreboardEmbed(guild, logicLayer) : await buildOverallScoreboardEmbed(guild, database, logicLayer)] });
+			scoreboardMessage.edit({ embeds: [company.scoreboardIsSeasonal ? await buildSeasonalScoreboardEmbed(guild, logicLayer) : await buildOverallScoreboardEmbed(guild, logicLayer)] });
 		});
 	}
 }

--- a/source/util/embedUtil.js
+++ b/source/util/embedUtil.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
-const { EmbedBuilder, Guild, Colors } = require("discord.js");
+const { EmbedBuilder, Colors } = require("discord.js");
 const { MAX_EMBED_DESCRIPTION_LENGTH } = require("../constants");
-const { generateTextBar } = require("./textUtil");
 
 const discordIconURL = "https://cdn.discordapp.com/attachments/618523876187570187/1110265047516721333/discord-mark-blue.png";
 const bountyBotIcon = "https://cdn.discordapp.com/attachments/618523876187570187/1138968614364528791/BountyBotIcon.jpg";
@@ -41,127 +40,6 @@ function randomFooterTip() {
 	return tipPool[Math.floor(Math.random() * tipPool.length)];
 }
 
-/** A seasonal scoreboard orders a company's hunters by their seasonal xp
- * @param {Guild} guild
- * @param {typeof import("../logic")} logicLayer
- */
-async function buildSeasonalScoreboardEmbed(guild, logicLayer) {
-	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
-	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(company.id);
-	const participations = await logicLayer.seasons.findSeasonParticipations(season.id);
-
-	const hunterMembers = await guild.members.fetch({ user: participations.map(participation => participation.userId) });
-	const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id, "descending")).map(rank => rank.rankmoji);
-
-	const scorelines = [];
-	for (const participation of participations) {
-		if (participation.xp > 0) {
-			const hunter = await participation.hunter;
-			scorelines.push(`${hunter.rank !== null ? `${rankmojiArray[hunter.rank]} ` : ""}#${participation.placement} **${hunterMembers.get(participation.userId).displayName}** __Level ${hunter.level}__ *${participation.xp} season XP*`);
-		}
-	}
-	const embed = new EmbedBuilder().setColor(Colors.Blurple)
-		.setAuthor(module.exports.ihpAuthorPayload)
-		.setThumbnail(company.scoreboardThumbnailURL ?? "https://cdn.discordapp.com/attachments/545684759276421120/734094693217992804/scoreboard.png")
-		.setTitle("The Season Scoreboard")
-		.setFooter(randomFooterTip())
-		.setTimestamp();
-	let description = "";
-	const andMore = "…and more";
-	const maxDescriptionLength = 2048 - andMore.length;
-	for (const scoreline of scorelines) {
-		if (description.length + scoreline.length <= maxDescriptionLength) {
-			description += `${scoreline}\n`;
-		} else {
-			description += andMore;
-			break;
-		}
-	}
-
-	if (description) {
-		embed.setDescription(description);
-	} else {
-		embed.setDescription("No Bounty Hunters yet…");
-	}
-
-	const fields = [];
-	const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
-	if (goalId !== null) {
-		fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
-	}
-	if (company.festivalMultiplier !== 1) {
-		fields.push({ name: "XP Festival", value: `An XP multiplier festival is currently active for ${company.festivalMultiplierString()}.` });
-	}
-	if (company.nextRaffleString) {
-		fields.push({ name: "Next Raffle", value: `The next raffle will be on ${company.nextRaffleString}!` });
-	}
-
-	if (fields.length > 0) {
-		embed.addFields(fields);
-	}
-	return embed;
-}
-
-/** An overall scoreboard orders a company's hunters by total xp
- * @param {Guild} guild
- * @param {typeof import("../logic")} logicLayer
- */
-async function buildOverallScoreboardEmbed(guild, logicLayer) {
-	const hunters = await logicLayer.hunters.findCompanyHuntersByDescendingXP(guild.id);
-	const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
-
-	const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
-	const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id, "descending")).map(rank => rank.rankmoji);
-
-	const scorelines = [];
-	for (const hunter of hunters) {
-		if (hunter.xp > 0) {
-			scorelines.push(`${hunter.rank !== null ? `${rankmojiArray[hunter.rank]} ` : ""} **${hunterMembers.get(hunter.userId).displayName}** __Level ${hunter.level}__ *${hunter.xp} XP*`);
-		}
-	}
-	const embed = new EmbedBuilder().setColor(Colors.Blurple)
-		.setAuthor(module.exports.ihpAuthorPayload)
-		.setThumbnail(company.scoreboardThumbnailURL ?? "https://cdn.discordapp.com/attachments/545684759276421120/734094693217992804/scoreboard.png")
-		.setTitle("The Scoreboard")
-		.setFooter(randomFooterTip())
-		.setTimestamp();
-	let description = "";
-	const andMore = "…and more";
-	const maxDescriptionLength = 2048 - andMore.length;
-	for (const scoreline of scorelines) {
-		if (description.length + scoreline.length <= maxDescriptionLength) {
-			description += `${scoreline}\n`;
-		} else {
-			description += andMore;
-			break;
-		}
-	}
-
-	if (description) {
-		embed.setDescription(description);
-	} else {
-		embed.setDescription("No Bounty Hunters yet…");
-	}
-
-	const fields = [];
-	const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
-	if (goalId !== null) {
-		fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
-	}
-	if (company.festivalMultiplier !== 1) {
-		fields.push({ name: "XP Festival", value: `An XP multiplier festival is currently active for ${company.festivalMultiplierString()}.` });
-	}
-	if (company.nextRaffleString) {
-		fields.push({ name: "Next Raffle", value: `The next raffle will be on ${company.nextRaffleString}!` });
-	}
-
-	if (fields.length > 0) {
-		embed.addFields(fields);
-	}
-
-	return embed;
-}
-
 /** The version embed lists the following: changes in the most recent update, known issues in the most recent update, and links to support the project
  * @returns {MessageEmbed}
  */
@@ -189,7 +67,5 @@ async function buildVersionEmbed() {
 module.exports = {
 	ihpAuthorPayload: { name: "Click here to check out the Imaginary Horizons GitHub", iconURL: "https://images-ext-2.discordapp.net/external/8DllSg9z_nF3zpNliVC3_Q8nQNu9J6Gs0xDHP_YthRE/https/cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png", url: "https://github.com/Imaginary-Horizons-Productions" },
 	randomFooterTip,
-	buildSeasonalScoreboardEmbed,
-	buildOverallScoreboardEmbed,
 	buildVersionEmbed
 };


### PR DESCRIPTION
Summary
-------
- create (temporary) `findCompanyHuntersByDescendingXP()` to remove `database` from `updateScoreboard()` and `buildOverallScoreboardEmbed()`
- made `updateScoreboard()`, `buildSeasonalScoreboardEmbed()` and `buildOverallScoreboardEmbed()` into `Company` methods

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/toast` still updates the scoreboard reference channel without regression
- [x] `/scoreboard (seasonal)` still works
- [x] `/scoreboard (overall)` still works