### PR TITLE
implement `findBounty()` in more places

### DIFF
--- a/source/commands/bounty/addcompleters.js
+++ b/source/commands/bounty/addcompleters.js
@@ -43,7 +43,7 @@ async function updateBoardPosting(bounty, company, poster, newCompleterIds, comp
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer, posterId]) {
 	const slotNumber = interaction.options.getInteger("bounty-slot");
 
-	const bounty = await logicLayer.bounties.findBounty({slotNumber, posterId, guildId: interaction.guild.id});
+	const bounty = await logicLayer.bounties.findBounty({ slotNumber, userId: posterId, companyId: interaction.guild.id });
 	if (!bounty) {
 		interaction.reply({ content: "You don't have a bounty in the `bounty-slot` provided.", flags: [MessageFlags.Ephemeral] });
 		return;
@@ -54,7 +54,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 		interaction.reply({ content: "Could not find any user mentions in `hunters` (you can't add yourself).", flags: [MessageFlags.Ephemeral] });
 		return;
 	}
-	
+
 	const completerMembers = Array.from((await interaction.guild.members.fetch({ user: completerIds })).values());
 	try {
 		let { bounty: returnedBounty, allCompleters, poster, company, validatedCompleterIds, bannedIds } = await logicLayer.bounties.addCompleters(bounty, interaction.guild, completerMembers, runMode);
@@ -67,10 +67,10 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 		if (typeof e !== 'string') {
 			console.error(e);
 		} else {
-			interaction.reply({ content: e, flags: [MessageFlags.Ephemeral]});
-    }
-    return;
-  }
+			interaction.reply({ content: e, flags: [MessageFlags.Ephemeral] });
+		}
+		return;
+	}
 
 };
 

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -14,8 +14,7 @@ const { Goal } = require("../../models/companies/Goal");
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer, posterId]) {
 	const slotNumber = interaction.options.getInteger("bounty-slot");
-	/** @type {Bounty | null} */
-	const bounty = await database.models.Bounty.findOne({ where: { userId: posterId, companyId: interaction.guildId, slotNumber, state: "open" } });
+	const bounty = await logicLayer.bounties.findBounty({ userId: posterId, slotNumber, companyId: interaction.guild.id });
 	if (!bounty) {
 		interaction.reply({ content: "You don't have a bounty in the `bounty-slot` provided.", flags: [MessageFlags.Ephemeral] });
 		return;

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -58,7 +58,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer,
 		}
 
 		// Check slot is not occupied
-		const existingBounty = await database.models.Bounty.findOne({ where: { state: "open", userId: interaction.user.id, companyId: interaction.guildId, slotNumber: parseInt(slotNumber) } });
+		const existingBounty = await logicLayer.bounties.findBounty({ userId: interaction.user.id, companyId: interaction.guild.id, slotNumber: parseInt(slotNumber) });
 		if (existingBounty) {
 			interaction.update({ content: `You already have a bounty in slot ${slotNumber}.`, components: [] });
 			return;

--- a/source/commands/bounty/removecompleters.js
+++ b/source/commands/bounty/removecompleters.js
@@ -10,7 +10,7 @@ const { extractUserIdsFromMentions, listifyEN } = require("../../util/textUtil")
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer, posterId]) {
 	const slotNumber = interaction.options.getInteger("bounty-slot");
-	database.models.Bounty.findOne({ where: { userId: posterId, companyId: interaction.guildId, slotNumber, state: "open" } }).then(async bounty => {
+	logicLayer.bounties.findBounty({ userId: posterId, companyId: interaction.guild.id, slotNumber }).then(async bounty => {
 		if (!bounty) {
 			interaction.reply({ content: "You don't have a bounty in the `bounty-slot` provided.", flags: [MessageFlags.Ephemeral] });
 			return;

--- a/source/context_menus/Give_Bounty_Credit.js
+++ b/source/context_menus/Give_Bounty_Credit.js
@@ -71,7 +71,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 		);
 		interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
 			const slotNumber = modalSubmission.fields.getTextInputValue("slot-number");
-			const bounty = await logicLayer.bounties.findBounty({ slotNumber, posterId: interaction.user.id, guildId: modalSubmission.guild.id });
+			const bounty = await logicLayer.bounties.findBounty({ slotNumber, userId: interaction.user.id, companyId: modalSubmission.guild.id });
 			if (!bounty) {
 				modalSubmission.reply({ content: `You don't appear to have an open bounty in slot ${slotNumber}.`, flags: [MessageFlags.Ephemeral] });
 				return;

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -16,14 +16,13 @@ function setDB(database) {
 }
 
 /**
- * @param {{slotNumber: number, posterId: string, guildId: string} | string} bountyInfo
+ * @param {{slotNumber: number, userId: string, companyId: string} | string} bountyInfo
  */
 function findBounty(bountyInfo) {
 	if (typeof bountyInfo === 'string') {
 		return db.models.Bounty.findByPk(bountyInfo);
 	} else {
-		const { posterId: userId, guildId: companyId, slotNumber } = bountyInfo;
-		return db.models.Bounty.findOne({ where: { userId, companyId, slotNumber, state: "open" } });
+		return db.models.Bounty.findOne({ where: { ...bountyInfo, state: "open" } });
 	}
 }
 


### PR DESCRIPTION
Summary
-------
- implement `findBounty()` in more places
- rename properties in object bountyInfo to `userId` and `companyId` to match entity name

Future Work
--------
- Discovered `findBounty()` is being called for two different use-cases, which unnecessarily increases implementation complexity, wrote up #388 to record

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)