### PR TITLE
implement `getParticipantCount()` in Goal Initializer

### DIFF
--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -17,7 +17,7 @@ module.exports = new ItemTemplate(itemName, "Begin a Server Goal if there isn't 
 		const eligibleTypes = ["bounties", "toasts", "secondings"];
 		const goalType = eligibleTypes[Math.floor(Math.random() * eligibleTypes.length)];
 		const previousSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
-		const activeHunters = previousSeason ? (await database.models.Participation.findOne({ where: { seasonId: season.id }, order: [["placement", "DESC"]] })).placement : 3;
+		const activeHunters = previousSeason ? await logicLayer.seasons.getParticipantCount(previousSeason.id) : 3;
 		const requiredGP = activeHunters * 20;
 		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		await logicLayer.goals.createGoal(interaction.guildId, goalType, requiredGP);

--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -17,8 +17,8 @@ module.exports = new ItemTemplate(itemName, "Begin a Server Goal if there isn't 
 		const eligibleTypes = ["bounties", "toasts", "secondings"];
 		const goalType = eligibleTypes[Math.floor(Math.random() * eligibleTypes.length)];
 		const previousSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
-		const activeHunters = previousSeason ? await logicLayer.seasons.getParticipantCount(previousSeason.id) : 3;
-		const requiredGP = activeHunters * 20;
+		const activeHunters = previousSeason ? await logicLayer.seasons.getParticipantCount(previousSeason.id) : 0;
+		const requiredGP = Math.max(activeHunters * 20, 60);
 		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		await logicLayer.goals.createGoal(interaction.guildId, goalType, requiredGP);
 		interaction.channel.send(company.sendAnnouncement({ content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));


### PR DESCRIPTION
Summary
-------
- implement `getParticipantCount()` in Goal Initializer

The existing code was originally incorrectly read, making it look like ties in placements would reduce the Participant count returned. In reality, ties are placed at the lowest placement they tie at (instead of "1, 2, 2", it would be "I, 3, 3"), which would give a correct count, but is still a more confusion way to achieve the count than the direct Participant count endpoint.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)