### PR TITLE
create endpoint `findHunterIdsAtOrAboveRank()`

### DIFF
--- a/source/commands/create-default/rankroles.js
+++ b/source/commands/create-default/rankroles.js
@@ -9,7 +9,7 @@ const { Sequelize } = require("sequelize");
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
 	await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
-	const previousRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id, "descending");
+	const previousRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 	const previousRoleIds = [];
 	for (const rank of previousRanks) {
 		if (rank.roleId) {

--- a/source/commands/moderation/seasondisqualify.js
+++ b/source/commands/moderation/seasondisqualify.js
@@ -12,7 +12,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	const member = interaction.options.getMember("bounty-hunter");
 	await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-	const participation = await logicLayer.seasons.disqualifyHunter(member.id, interaction.guildId, season.id);
+	const participation = await logicLayer.seasons.toggleHunterSeasonDisqualification(member.id, interaction.guildId, season.id);
 	getRankUpdates(interaction.guild, logicLayer);
 	interaction.reply({ content: `<@${member.id}> has been ${participation.isRankDisqualified ? "dis" : "re"}qualified for achieving ranks this season.`, flags: [MessageFlags.Ephemeral] });
 	if (!member.user.bot) {

--- a/source/commands/moderation/seasondisqualify.js
+++ b/source/commands/moderation/seasondisqualify.js
@@ -12,7 +12,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 	const member = interaction.options.getMember("bounty-hunter");
 	await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-	await logicLayer.seasons.disqualifyHunter(member.id, interaction.guildId, season.id);
+	const participation = await logicLayer.seasons.disqualifyHunter(member.id, interaction.guildId, season.id);
 	getRankUpdates(interaction.guild, logicLayer);
 	interaction.reply({ content: `<@${member.id}> has been ${participation.isRankDisqualified ? "dis" : "re"}qualified for achieving ranks this season.`, flags: [MessageFlags.Ephemeral] });
 	if (!member.user.bot) {

--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -9,7 +9,7 @@ const { SKIP_INTERACTION_HANDLING } = require("../../constants");
  * @param {[typeof import("../../logic")]} args
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
-	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id, "ascending");
+	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 	if (ranks.length < 1) {
 		interaction.reply({ content: "This server doesn't have any ranks configured.", flags: [MessageFlags.Ephemeral] });
 		return;
@@ -43,7 +43,7 @@ async function executeSubcommand(interaction, database, runMode, ...[logicLayer]
 		}).then((unvalidatedMembers) => {
 			const eligibleMembers = unvalidatedMembers.filter(member => member.manageable);
 			if (eligibleMembers.size < 1) {
-				logicLayer.ranks.findAllRanks(interaction.guildId, "ascending").then(ranks => {
+				logicLayer.ranks.findAllRanks(interaction.guildId).then(ranks => {
 					const rank = ranks[rankIndex];
 					collectedInteraction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above the rank ${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${rankIndex + 1}`}).`, flags: [MessageFlags.Ephemeral] });
 				});

--- a/source/commands/rank/add.js
+++ b/source/commands/rank/add.js
@@ -11,7 +11,7 @@ const { commandMention } = require("../../util/textUtil");
  * @param {[typeof import("../../logic")]} args
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
-	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id, "descending");
+	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 	const newThreshold = interaction.options.getNumber("variance-threshold");
 	const existingThresholds = ranks.map(rank => rank.varianceThreshold);
 	if (existingThresholds.includes(newThreshold)) {

--- a/source/commands/rank/info.js
+++ b/source/commands/rank/info.js
@@ -9,7 +9,7 @@ const { Sequelize } = require("sequelize");
  */
 async function executeSubcommand(interaction, database, runMode, ...[logicLayer]) {
 	const varianceThreshold = interaction.options.getNumber("variance-threshold");
-	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id, "descending");
+	const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 	let index = 0;
 	const rank = ranks.find(rank => {
 		index++;

--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -52,7 +52,7 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				endingSeason.save();
 			}
 			await logicLayer.seasons.createSeason(interaction.guildId);
-			const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId, "descending");
+			const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
 			const roleIds = ranks.filter(rank => rank.roleId != "").map(rank => rank.roleId);
 			if (roleIds.length > 0) {
 				const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);

--- a/source/commands/stats.js
+++ b/source/commands/stats.js
@@ -44,7 +44,7 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 					const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
 					const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
 					const previousParticipations = currentParticipation === null ? participations : participations.slice(1);
-					const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId, "descending");
+					const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
 					const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 					const mostSecondedToast = await logicLayer.toasts.findMostSecondedToast(target.id, interaction.guild.id);
 
@@ -85,7 +85,7 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
 				const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
 				const previousParticipations = currentParticipation === null ? participations : participations.slice(1);
-				const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId, "descending");
+				const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
 				const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 				const mostSecondedToast = await logicLayer.toasts.findMostSecondedToast(interaction.user.id, interaction.guild.id);
 

--- a/source/context_menus/BountyBot_Stats.js
+++ b/source/context_menus/BountyBot_Stats.js
@@ -43,7 +43,7 @@ module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionCon
 				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 				const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
 				const previousParticipations = currentParticipation === null ? participations : participations.slice(1);
-				const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId, "descending");
+				const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
 				const rankName = ranks[hunter.rank]?.roleId ? `<@&${ranks[hunter.rank].roleId}>` : `Rank ${hunter.rank + 1}`;
 				const mostSecondedToast = await logicLayer.toasts.findMostSecondedToast(target.id, interaction.guild.id);
 

--- a/source/logic/hunters.js
+++ b/source/logic/hunters.js
@@ -46,7 +46,7 @@ function findCompanyHunters(companyId) {
  * @param {number} rankIndex
  */
 async function findHunterIdsAtOrAboveRank(companyId, rankIndex) {
-	const hunters = await db.models.Hunter.findAll({ where: { companyId, rank: { [Op.gte]: rankIndex } } });
+	const hunters = await db.models.Hunter.findAll({ where: { companyId, rank: { [Op.lte]: rankIndex } } });
 	const season = await db.models.Season.findOne({ where: { companyId, isCurrentSeason: true } });
 	if (!season) {
 		return hunters.map(hunter => hunter.userId);

--- a/source/logic/ranks.js
+++ b/source/logic/ranks.js
@@ -43,15 +43,9 @@ function findOneRank(companyId, varianceThreshold) {
 
 /** *Finds all of a company's ranks and returns them in the specified order*
  * @param {string} companyId
- * @param {"ascending" | "descending"} sortOrder the order to sort the ranks by variance threshold
  */
-function findAllRanks(companyId, sortOrder) {
-	switch (sortOrder) {
-		case "ascending":
-			return db.models.Rank.findAll({ where: { companyId }, order: [["varianceThreshold", "ASC"]] });
-		case "descending":
-			return db.models.Rank.findAll({ where: { companyId }, order: [["varianceThreshold", "DESC"]] });
-	}
+function findAllRanks(companyId) {
+	return db.models.Rank.findAll({ where: { companyId }, order: [["varianceThreshold", "DESC"]] });
 }
 
 /** *Deletes all of a company's ranks*

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -107,16 +107,16 @@ async function incrementSeasonStat(guildId, stat) {
  * @param {string} companyId
  * @param {string} seasonId
  */
-async function disqualifyHunter(userId, companyId, seasonId) {
+async function toggleHunterSeasonDisqualification(userId, companyId, seasonId) {
 	await db.models.User.findOrCreate({ where: { id: userId } });
 	const [participation, participationCreated] = await db.models.Participation.findOrCreate({ where: { userId, companyId, seasonId }, defaults: { isRankDisqualified: true } });
 	if (!participationCreated) {
-		await participation.update("isRankDisqualified", !participation.isRankDisqualified);
+		await participation.update({ isRankDisqualified: !participation.isRankDisqualified });
 	}
 	if (participationCreated || participation.isRankDisqualified) {
 		await participation.increment("dqCount");
 	}
-	return;
+	return participation;
 }
 
 /** @param {string} companyId */
@@ -151,7 +151,7 @@ module.exports = {
 	findFirstPlaceParticipation,
 	changeSeasonXP,
 	incrementSeasonStat,
-	disqualifyHunter,
+	disqualifyHunter: toggleHunterSeasonDisqualification,
 	deleteCompanySeasons,
 	deleteSeasonParticipations,
 	deleteCompanyParticipations

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -151,7 +151,7 @@ module.exports = {
 	findFirstPlaceParticipation,
 	changeSeasonXP,
 	incrementSeasonStat,
-	disqualifyHunter: toggleHunterSeasonDisqualification,
+	toggleHunterSeasonDisqualification,
 	deleteCompanySeasons,
 	deleteSeasonParticipations,
 	deleteCompanyParticipations

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -85,7 +85,7 @@ class Company extends Model {
 		const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(this.id);
 		const participations = await logicLayer.seasons.findSeasonParticipations(season.id);
 		const hunterMembers = await guild.members.fetch({ user: participations.map(participation => participation.userId) });
-		const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id, "descending")).map(rank => rank.rankmoji);
+		const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id)).map(rank => rank.rankmoji);
 
 		const scorelines = [];
 		for (const participation of participations) {
@@ -143,7 +143,7 @@ class Company extends Model {
 	async overallScoreboardEmbed(guild, logicLayer) {
 		const hunters = await logicLayer.hunters.findCompanyHuntersByDescendingXP(guild.id);
 		const hunterMembers = await guild.members.fetch({ user: hunters.map(hunter => hunter.userId) });
-		const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id, "descending")).map(rank => rank.rankmoji);
+		const rankmojiArray = (await logicLayer.ranks.findAllRanks(guild.id)).map(rank => rank.rankmoji);
 
 		const scorelines = [];
 		for (const hunter of hunters) {

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -91,7 +91,7 @@ class Company extends Model {
 		for (const participation of participations) {
 			if (participation.xp > 0) {
 				const hunter = await participation.hunter;
-				scorelines.push(`${hunter.rank !== null ? `${rankmojiArray[hunter.rank]} ` : ""}#${participation.placement} **${hunterMembers.get(participation.userId).displayName}** __Level ${hunter.level}__ *${participation.xp} season XP*`);
+				scorelines.push(`${!(hunter.rank === null || participation.isRankDisqualified) ? `${rankmojiArray[hunter.rank]} ` : ""}#${participation.placement} **${hunterMembers.get(participation.userId).displayName}** __Level ${hunter.level}__ *${participation.xp} season XP*`);
 			}
 		}
 		const embed = new EmbedBuilder().setColor(Colors.Blurple)

--- a/source/util/scoreUtil.js
+++ b/source/util/scoreUtil.js
@@ -90,7 +90,7 @@ async function calculateRanks(season, allHunters, ranks, participations) {
  */
 async function getRankUpdates(guild, logicLayer) {
 	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
-	const ranks = await logicLayer.ranks.findAllRanks(guild.id, "descending");
+	const ranks = await logicLayer.ranks.findAllRanks(guild.id);
 	const allHunters = await logicLayer.hunters.findCompanyHunters(guild.id);
 	const participations = await logicLayer.seasons.findSeasonParticipations(season.id);
 


### PR DESCRIPTION
Summary
-------
- create endpoint `findHunterIdsAtOrAboveRank()`
- fix hunter rank disqualification validation (`isRankDisqualified` had been moved from `Hunter` to `Participation`)
- fixed query directionality of `findHunterIdsAtOrAboveRank()`
   - `/raffle by-rank` was incorrectly using low rank indices as the easy to achieve ranks (contrary to convention in database)
- removed extra query case in `findAllRanks()` by reversing the order in which ranks are presented in `/raffle by-rank`
   - ranks were originally presented in ascending difficulty to obtain to nudge bot managers to run more accessible raffles, but the maintainability streamlining is more valuable considering the low effect of the nudge due to bot managers being nudged to announce raffles ahead of time
-  fixed scoreboard showing rank emoji for rank disqualified hunters
- fixed crashes in `/moderation season-disqualify`
- renamed `disqualifyHunter()` to `toggleHunterSeasonDisqualification()` for more accurate function description

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/raffle by-rank` skips hunters who are rank disqualified (but would otherwise qualify)