### PR TITLE
create endpoint `findParticipationWithTopParticipationStat()`

### DIFF
--- a/source/commands/season-end.js
+++ b/source/commands/season-end.js
@@ -34,16 +34,16 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 				if (firstPlace) {
 					shoutouts.push(`<@${firstPlace.userId}> earned the most XP this season!`);
 				}
-				const mostPostingsCompleted = await database.models.Participation.findOne({ where: { companyId: interaction.guildId, seasonId: endingSeason.id }, order: [["postingsCompleted", "DESC"]] });
-				if (mostPostingsCompleted?.postingsCompleted > 0) {
+				const mostPostingsCompleted = await logicLayer.seasons.findParticipationWithTopParticipationStat(interaction.guildId, endingSeason.id, "postingsCompleted");
+				if (mostPostingsCompleted) {
 					shoutouts.push(`<@${mostPostingsCompleted.userId}> posted the most completed bounties this season!`);
 				}
-				const mostToastsRaised = await database.models.Participation.findOne({ where: { companyId: interaction.guildId, seasonId: endingSeason.id }, order: [["toastsRaised", "DESC"]] });
-				if (mostToastsRaised?.toastsRaised > 0) {
+				const mostToastsRaised = await logicLayer.seasons.findParticipationWithTopParticipationStat(interaction.guildId, endingSeason.id, "toastsRaised");
+				if (mostToastsRaised) {
 					shoutouts.push(`<@${mostToastsRaised.userId}> raised the most toasts this season!`);
 				}
-				const mostGoalContributions = await database.models.Participation.findOne({ where: { companyId: interaction.guildId, seasonId: endingSeason.id }, order: [["goalContributions", "DESC"]] });
-				if (mostGoalContributions?.goalContributions > 0) {
+				const mostGoalContributions = await logicLayer.seasons.findParticipationWithTopParticipationStat(interaction.guildId, endingSeason.id, "goalContributions");
+				if (mostGoalContributions) {
 					shoutouts.push(`<@${mostGoalContributions.userId}> made the most goal contributions this season!`);
 				}
 				endingSeason.isCurrentSeason = false;

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -79,6 +79,19 @@ function findFirstPlaceParticipation(companyId, seasonId) {
 	return db.models.Participation.findOne({ where: { companyId, seasonId, placement: 1 } });
 }
 
+/** *Finds the Participation of the specified Season's Hunter with the most of the specified Participation property*
+ * @param {string} companyId
+ * @param {string} seasonId
+ * @param {string} particiaptionProperty
+ */
+async function findParticipationWithTopParticipationStat(companyId, seasonId, particiaptionProperty) {
+	const participation = await db.models.Participation.findOne({ where: { companyId, seasonId }, order: [[particiaptionProperty, "DESC"]] });
+	if (participation === null || participation[particiaptionProperty] === 0) {
+		return null;
+	}
+	return participation;
+}
+
 /** *Change the specified Hunter's Seasonal XP*
  * @param {string} userId
  * @param {string} companyId
@@ -149,6 +162,7 @@ module.exports = {
 	bulkFindParticipations,
 	findHunterParticipations,
 	findFirstPlaceParticipation,
+	findParticipationWithTopParticipationStat,
 	changeSeasonXP,
 	incrementSeasonStat,
 	disqualifyHunter,


### PR DESCRIPTION
Summary
-------
- create endpoint `findParticipationWithTopParticipationStat()`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)