### PR TITLE
remove `database` from item effect functions

### DIFF
--- a/source/classes/ItemTemplate.js
+++ b/source/classes/ItemTemplate.js
@@ -1,12 +1,11 @@
 const { CommandInteraction } = require("discord.js");
-const { Sequelize } = require("sequelize");
 
 class ItemTemplate {
 	/**
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: CommandInteraction, database: Sequelize) => Promise<boolean>} effectFunction
+	 * @param {(interaction: CommandInteraction) => Promise<boolean>} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, cooldownInMS, effectFunction) {
 		this.name = nameInput;

--- a/source/commands/item.js
+++ b/source/commands/item.js
@@ -44,7 +44,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 				return;
 			}
 
-			await itemRow.reload();
+			await itemRow?.reload();
 			if (runMode === "production" && itemRow.count < 1) {
 				collectedInteration.reply({ content: `You don't have any ${itemName}.`, flags: [MessageFlags.Ephemeral] });
 				return;
@@ -71,7 +71,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 				setTimeout(() => timestamps.delete(collectedInteration.user.id), getItemCooldown(itemName));
 			}
 
-			return useItem(itemName, collectedInteration, database).then(shouldSkipDecrement => {
+			return useItem(itemName, collectedInteration).then(shouldSkipDecrement => {
 				if (!shouldSkipDecrement && runMode === "production") {
 					itemRow.decrement("count");
 				}

--- a/source/items/_itemDictionary.js
+++ b/source/items/_itemDictionary.js
@@ -1,6 +1,5 @@
 const { CommandInteraction } = require("discord.js");
 const { ItemTemplate } = require("../classes");
-const { Sequelize } = require("sequelize");
 
 /** @type {Record<string, ItemTemplate>} */
 const ITEMS = {};
@@ -71,11 +70,10 @@ exports.getItemCooldown = function (itemName) {
 /**
  * @param {string} itemName
  * @param {CommandInteraction} interaction
- * @param {Sequelize} database
  * @returns {Promise<boolean>} whether to skip decrementing the item count
  */
-exports.useItem = function (itemName, interaction, database) {
-	return ITEMS[itemName].effect(interaction, database);
+exports.useItem = function (itemName, interaction) {
+	return ITEMS[itemName].effect(interaction);
 }
 
 exports.setLogic = function (logicBlob) {

--- a/source/items/_item_template.js
+++ b/source/items/_item_template.js
@@ -6,7 +6,7 @@ let logicLayer;
 const itemName = "";
 module.exports = new ItemTemplate(itemName, "description", 3000,
 	/** specs */
-	async (interaction, database) => {
+	async (interaction) => {
 
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/items/bonus-bounty-showcase.js
+++ b/source/items/bonus-bounty-showcase.js
@@ -10,7 +10,7 @@ let logicLayer;
 
 const itemName = "Bonus Bounty Showcase";
 module.exports = new ItemTemplate(itemName, "Showcase one of your bounties and increase its reward on a separate cooldown", timeConversion(1, "d", "ms"),
-	async (interaction, database) => {
+	async (interaction) => {
 		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: "You don't have any open bounties on this server to showcase.", flags: [MessageFlags.Ephemeral] });

--- a/source/items/bounty-thumbnail.js
+++ b/source/items/bounty-thumbnail.js
@@ -9,7 +9,7 @@ let logicLayer;
 
 const itemName = "Bounty Thumbnail";
 module.exports = new ItemTemplate(itemName, "Adds an image (via URL) to one of your open bounties!", 3000,
-	async (interaction, database) => {
+	async (interaction) => {
 		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: "You don't have any open bounties on this server to add a thumbnail to.", flags: [MessageFlags.Ephemeral] });

--- a/source/items/goal-initializer.js
+++ b/source/items/goal-initializer.js
@@ -6,7 +6,7 @@ let logicLayer;
 
 const itemName = "Goal Initializer";
 module.exports = new ItemTemplate(itemName, "Begin a Server Goal if there isn't already one running", 3000,
-	async (interaction, database) => {
+	async (interaction) => {
 		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guildId);
 		if (!!goal) {

--- a/source/items/loot-box.js
+++ b/source/items/loot-box.js
@@ -8,7 +8,7 @@ let logicLayer;
 
 const itemName = "Loot Box";
 module.exports = new ItemTemplate(itemName, "Unboxes into 2 random items!", 3000,
-	async (interaction, database) => {
+	async (interaction) => {
 		const rolledItems = [rollItemDrop(1), rollItemDrop(1)];
 		for (const droppedItem of rolledItems) {
 			await logicLayer.items.grantItem(interaction.user.id, droppedItem);

--- a/source/items/profile-colorizer-aqua.js
+++ b/source/items/profile-colorizer-aqua.js
@@ -8,7 +8,7 @@ const color = "Aqua";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Aqua in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-blue.js
+++ b/source/items/profile-colorizer-blue.js
@@ -8,7 +8,7 @@ const color = "Blue";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blue in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-blurple.js
+++ b/source/items/profile-colorizer-blurple.js
@@ -8,7 +8,7 @@ const color = "Blurple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blurple in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkaqua.js
+++ b/source/items/profile-colorizer-darkaqua.js
@@ -8,7 +8,7 @@ const color = "Dark Aqua";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkAqua in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkblue.js
+++ b/source/items/profile-colorizer-darkblue.js
@@ -8,7 +8,7 @@ const color = "Dark Blue";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkBlue in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkbutnotblack.js
+++ b/source/items/profile-colorizer-darkbutnotblack.js
@@ -8,7 +8,7 @@ const color = "Dark But Not Black";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkButNotBlack in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkergrey.js
+++ b/source/items/profile-colorizer-darkergrey.js
@@ -8,7 +8,7 @@ const color = "Darker Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkerGrey in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkgold.js
+++ b/source/items/profile-colorizer-darkgold.js
@@ -8,7 +8,7 @@ const color = "Dark Gold";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGold in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkgreen.js
+++ b/source/items/profile-colorizer-darkgreen.js
@@ -8,7 +8,7 @@ const color = "Dark Green";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGreen in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkgrey.js
+++ b/source/items/profile-colorizer-darkgrey.js
@@ -8,7 +8,7 @@ const color = "Dark Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkGrey in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darknavy.js
+++ b/source/items/profile-colorizer-darknavy.js
@@ -8,7 +8,7 @@ const color = "Dark Navy";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkNavy in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkorange.js
+++ b/source/items/profile-colorizer-darkorange.js
@@ -8,7 +8,7 @@ const color = "Dark Orange";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkOrange in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkpurple.js
+++ b/source/items/profile-colorizer-darkpurple.js
@@ -8,7 +8,7 @@ const color = "Dark Purple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Blue in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkred.js
+++ b/source/items/profile-colorizer-darkred.js
@@ -8,7 +8,7 @@ const color = "Dark Red";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkRed in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-darkvividpink.js
+++ b/source/items/profile-colorizer-darkvividpink.js
@@ -8,7 +8,7 @@ const color = "Dark Vivid Pink";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.DarkVividPink in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-default.js
+++ b/source/items/profile-colorizer-default.js
@@ -8,7 +8,7 @@ const color = "Default";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, "Changes the color of your stats profile embed to black", 3000,
 	/** Sets the user's Hunter profile to Colors.Default in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to black in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-fuchsia.js
+++ b/source/items/profile-colorizer-fuchsia.js
@@ -8,7 +8,7 @@ const color = "Fuchsia";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Fuchsia in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-gold.js
+++ b/source/items/profile-colorizer-gold.js
@@ -8,7 +8,7 @@ const color = "Gold";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Gold in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-green.js
+++ b/source/items/profile-colorizer-green.js
@@ -8,7 +8,7 @@ const color = "Green";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Green in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-grey.js
+++ b/source/items/profile-colorizer-grey.js
@@ -8,7 +8,7 @@ const color = "Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Grey in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-greyple.js
+++ b/source/items/profile-colorizer-greyple.js
@@ -8,7 +8,7 @@ const color = "Greyple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Greyple in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-lightgrey.js
+++ b/source/items/profile-colorizer-lightgrey.js
@@ -8,7 +8,7 @@ const color = "Light Grey";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.LightGrey in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-luminousvividpink.js
+++ b/source/items/profile-colorizer-luminousvividpink.js
@@ -8,7 +8,7 @@ const color = "Luminous Vivid Pink";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.LuminousVividPink in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-navy.js
+++ b/source/items/profile-colorizer-navy.js
@@ -8,7 +8,7 @@ const color = "Navy";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Navy in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-notquiteblack.js
+++ b/source/items/profile-colorizer-notquiteblack.js
@@ -8,7 +8,7 @@ const color = "Not Quite Black";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.NotQuiteBlack in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-orange.js
+++ b/source/items/profile-colorizer-orange.js
@@ -8,7 +8,7 @@ const color = "Orange";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Orange in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-purple.js
+++ b/source/items/profile-colorizer-purple.js
@@ -8,7 +8,7 @@ const color = "Purple";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Purple in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-red.js
+++ b/source/items/profile-colorizer-red.js
@@ -8,7 +8,7 @@ const color = "Red";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Red in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-white.js
+++ b/source/items/profile-colorizer-white.js
@@ -8,7 +8,7 @@ const color = "White";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.White in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/profile-colorizer-yellow.js
+++ b/source/items/profile-colorizer-yellow.js
@@ -8,7 +8,7 @@ const color = "Yellow";
 const itemName = `${color} Profile Colorizer`;
 module.exports = new ItemTemplate(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 	/** Sets the user's Hunter profile to Colors.Yellow in the used guild */
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color);
 		interaction.reply({ content: `Your profile color has been set to ${color} in this server.`, flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/items/progress-in-a-can.js
+++ b/source/items/progress-in-a-can.js
@@ -7,7 +7,7 @@ let logicLayer;
 
 const itemName = "Progress-in-a-Can";
 module.exports = new ItemTemplate(itemName, "Add a contribution to the currently running Server Goal", 3000,
-	async (interaction, database) => {
+	async (interaction) => {
 		const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guild.id);
 		if (!goal) {
 			interaction.reply({ content: "There isn't currently a Server Goal running.", flags: [MessageFlags.Ephemeral] });

--- a/source/items/unidentified-item.js
+++ b/source/items/unidentified-item.js
@@ -8,7 +8,7 @@ let logicLayer;
 
 const itemName = "Unidentified Item";
 module.exports = new ItemTemplate(itemName, "Rolls as a random item!", 3000,
-	async (interaction, database) => {
+	async (interaction) => {
 		const rolledItem = rollItemDrop(1);
 		await logicLayer.items.grantItem(interaction.user.id, rolledItem);
 		interaction.reply({ content: `The unidentified item was a **${rolledItem}**! Use it with ${commandMention("item")}?`, flags: [MessageFlags.Ephemeral] });

--- a/source/items/xp-boost-epic.js
+++ b/source/items/xp-boost-epic.js
@@ -7,7 +7,7 @@ let logicLayer;
 const itemName = "Epic XP Boost";
 const xpValue = 25;
 module.exports = new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);

--- a/source/items/xp-boost-legendary.js
+++ b/source/items/xp-boost-legendary.js
@@ -7,7 +7,7 @@ let logicLayer;
 const itemName = "Legendary XP Boost";
 const xpValue = 75;
 module.exports = new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);

--- a/source/items/xp-boost.js
+++ b/source/items/xp-boost.js
@@ -7,7 +7,7 @@ let logicLayer;
 const itemName = "XP Boost";
 const xpValue = 5;
 module.exports = new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-	async (interaction, database) => {
+	async (interaction) => {
 		logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);


### PR DESCRIPTION
Summary
-------
- remove `database` from item effect functions
- fix crash when using debug mode on item user has no stock of

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] using Loot Box in debug mode works without regression