### PR TITLE
#279 & #409: add time based item drop rate limiting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Server Goals are BountyBot objectives everyone on the server contributes to. A g
 - Fixed crash when using `/create-default rank-roles` twice in a row
 - Fixed `/moderation user-report` listing XP awarded for recent bounties as "undefined"
 - Fixed Dark Purple Profile Colorizer not dropping
+- Item drops are now limited to 2 items per day, or 4 items if you are a premium user
+
 ## BountyBot Version 2.8.0:
 ### Context Menu Options
 - Added the following BountyBot functionality to the Apps dropdown when right-clicking on a User or Message:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ Server Goals are BountyBot objectives everyone on the server contributes to. A g
 - Fixed crash when using `/create-default rank-roles` twice in a row
 - Fixed `/moderation user-report` listing XP awarded for recent bounties as "undefined"
 - Fixed Dark Purple Profile Colorizer not dropping
-- Item drops are now limited to 2 items per day, or 4 items if you are a premium user
+- Item drops are now limited to 2 items per day, or 4 items for Premium users
 
 ## BountyBot Version 2.8.0:
 ### Context Menu Options

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -1,5 +1,5 @@
 const { Sequelize, Op } = require("sequelize");
-const { Guild, GuildMember, time } = require("discord.js");
+const { Guild, GuildMember } = require("discord.js");
 const { Bounty } = require("../models/bounties/Bounty");
 const { Hunter } = require("../models/users/Hunter");
 const { rollItemDrop } = require("../util/itemUtil");

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -122,6 +122,42 @@ function timeConversion(value, startingUnit, resultUnit) {
 	}
 }
 
+/**
+ * A utility wrapper for @function timeConversion that goes back in time from the current timestamp
+ * @param {{'w': number?,
+ * 			'd': number?,
+ * 			'h': number?,
+ * 			'm': number?,
+ * 			's': number?,
+ * 			'ms': number?}} timeMap The amount of time to go back in the past
+ * @returns {Date} The Date in the past as adjusted by the timeMap
+ */
+function dateInPast(timeMap) {
+	let nowTimestamp = new Date();
+	for (key in timeMap) {
+		nowTimestamp -= timeConversion(timeMap[key], key, 'ms');
+	}
+	return new Date(nowTimestamp);
+}
+
+/**
+ * A utility wrapper for @function timeConversion that goes into the future from the current timestamp
+ * @param {{'w': number?,
+* 			'd': number?,
+* 			'h': number?,
+* 			'm': number?,
+* 			's': number?,
+* 			'ms': number?}} timeMap The amount of time to go into the future
+* @returns {Date} The Date in the future as adjusted by the timeMap
+*/
+function dateInFuture(timeMap) {
+	let nowTimestamp = new Date();
+	for (key in timeMap) {
+		nowTimestamp += timeConversion(timeMap[key], key, 'ms');
+	}
+	return new Date(nowTimestamp);
+}
+
 /** Extracting user ids from mentions in a string allows us to accept an arbitrary number of users from a single string input
  * @param {string} mentionsText
  * @param {string[]} excludedIds
@@ -240,6 +276,8 @@ module.exports = {
 	generateTextBar,
 	getNumberEmoji,
 	timeConversion,
+	dateInPast,
+	dateInFuture,
 	extractUserIdsFromMentions,
 	textsHaveAutoModInfraction,
 	listifyEN,

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -124,13 +124,12 @@ function timeConversion(value, startingUnit, resultUnit) {
 
 /**
  * A utility wrapper for @function timeConversion that goes back in time from the current timestamp
- * @param {{'w': number?,
- * 			'd': number?,
- * 			'h': number?,
- * 			'm': number?,
- * 			's': number?,
- * 			'ms': number?}} timeMap The amount of time to go back in the past
- * @returns {Date} The Date in the past as adjusted by the timeMap
+ * @param {{w?: number,
+ * 			d?: number,
+ * 			h?: number,
+ * 			m?: number,
+ * 			s?: number,
+ * 			ms?: number}} timeMap The amount of time to go back in the past
  */
 function dateInPast(timeMap) {
 	let nowTimestamp = new Date();
@@ -142,13 +141,12 @@ function dateInPast(timeMap) {
 
 /**
  * A utility wrapper for @function timeConversion that goes into the future from the current timestamp
- * @param {{'w': number?,
-* 			'd': number?,
-* 			'h': number?,
-* 			'm': number?,
-* 			's': number?,
-* 			'ms': number?}} timeMap The amount of time to go into the future
-* @returns {Date} The Date in the future as adjusted by the timeMap
+ * @param {{w?: number,
+* 			d?: number,
+* 			h?: number,
+* 			m?: number,
+* 			s?: number,
+* 			ms?: number}} timeMap The amount of time to go into the future
 */
 function dateInFuture(timeMap) {
 	let nowTimestamp = new Date();


### PR DESCRIPTION
Moved the roll code into a separate function to better manage item rolls in the logic layer, since this code (other than roll rate) should function the same regardless of the person being rolled for.

I've added some convenience functions for calculating dates which are not required to be done in this pull request, but were done here due to them being convenient.

Includes a fix for not pulling the `season` data.

Fixes #279

Summary
-------
(Include a summary of the work done or the reasoning for the pivot here)

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] item limit (silently) hit over repeated testing
- [X] item drop text still displays as relevant

Issue
-----
Closes #279
