### PR TITLE
#332: avoid crash if Bounty's embed's Completers field overflows

### DIFF
--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -1,7 +1,7 @@
 ﻿const { EmbedBuilder, Guild, ActionRowBuilder, ButtonBuilder, ButtonStyle, heading, userMention } = require('discord.js');
 const { Model, Sequelize, DataTypes } = require('sequelize');
 const { Company } = require('../companies/Company');
-const { SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH } = require('../../constants');
+const { SAFE_DELIMITER, MAX_MESSAGE_CONTENT_LENGTH, MAX_EMBED_FIELD_VALUE_LENGTH } = require('../../constants');
 const { timeConversion, commandMention, listifyEN } = require('../../util/textUtil');
 const { Completion } = require('./Completion');
 
@@ -53,7 +53,12 @@ class Bounty extends Model {
 		}
 		if (completions.length > 0) {
 			const uniqueCompleters = new Set(completions.map(reciept => reciept.userId));
-			fields.push({ name: "Completers", value: listifyEN([...uniqueCompleters].map(id => userMention(id))) });
+			const completersFieldText = listifyEN([...uniqueCompleters].map(id => userMention(id)));
+			if (completersFieldText.length <= MAX_EMBED_FIELD_VALUE_LENGTH) {
+				fields.push({ name: "Completers", value: completersFieldText });
+			} else {
+				fields.push({ name: "Completers", value: "Too many to display!" });
+			}
 		}
 
 		if (fields.length > 0) {


### PR DESCRIPTION
Summary
-------
-  avoid crash if Bounty's embed's Completers field overflows

Pivots
-------
Decided to pivot away from user validation: on bounty render is a fairly difficult place to predict for database updates to be happening and checking if a user is in a guild requires fetching the entire guild member (a dAPI "are these members in this guild?" endpoint would be ideal for that).

Also decided to do a full replacement of text to avoid the string modification problem that only really adds "completer order politics".

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/evergreen list` with too many completers doesn't crash due to completers field overflowing

Issue
-----
Closes #332 