### PR TITLE
#426: fix false positive on existing Server Goal check in Goal Initializer

### DIFF
--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -82,7 +82,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						if (goalUpdate.gpContributed > 0) {
 							const { goalId, requiredGP, currentGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);
 							if (goalId !== null) {
-								embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+								embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 							} else {
 								embed.addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
 							}

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -112,7 +112,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		if (goalProgressFieldIndex !== -1) {
 			const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);
 			if (goalId !== null) {
-				embed.spliceFields(goalProgressFieldIndex, 1, { name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+				embed.spliceFields(goalProgressFieldIndex, 1, { name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 			} else {
 				embed.spliceFields(goalProgressFieldIndex, 1, { name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Complete!` });
 			}

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -68,7 +68,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 			if (goalUpdate.gpContributed > 0) {
 				const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);
 				if (goalId !== null) {
-					embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+					embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 				} else {
 					embed.addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
 				}

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -82,7 +82,7 @@ module.exports = new SubcommandWrapper("complete", "Awarding XP to a hunter for 
 				levelTexts.push(`This bounty contributed ${totalGP} GP to the Server Goal!`);
 				const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);
 				if (goalId !== null) {
-					embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+					embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 				} else {
 					embed.addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
 				}

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -79,7 +79,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 				}
 				const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
 				if (goalId !== null) {
-					embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+					embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 				} else {
 					embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
 				}

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -68,7 +68,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 					}
 					const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
 					if (goalId !== null) {
-						embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${Math.min(currentGP, requiredGP)}/${requiredGP} GP` });
+						embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 					} else {
 						embeds[0].addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
 					}

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -16,7 +16,7 @@ function setDB(database) {
  * @param {string} companyId
  */
 function findCurrentServerGoal(companyId) {
-	return db.models.Goal.findOne({ where: { companyId }, state: "ongoing", order: [["createdAt", "DESC"]] });
+	return db.models.Goal.findOne({ where: { companyId, state: "ongoing" }, order: [["createdAt", "DESC"]] });
 }
 
 /** *Create a Goal for the specified Company*

--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -119,8 +119,8 @@ class Company extends Model {
 		}
 
 		const fields = [];
-		const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
-		if (goalId !== null) {
+		const { currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
+		if (currentGP < requiredGP) {
 			fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 		}
 		if (this.festivalMultiplier !== 1) {
@@ -176,8 +176,8 @@ class Company extends Model {
 		}
 
 		const fields = [];
-		const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
-		if (goalId !== null) {
+		const { currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(guild.id);
+		if (currentGP < requiredGP) {
 			fields.push({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
 		}
 		if (this.festivalMultiplier !== 1) {


### PR DESCRIPTION
Summary
-------
- fix false positive on existing Server Goal check in Goal Initializer
- fix completed goals being shown on scoreboards
- remove clamping to requiredGP on GP gain updates
   - clamping was previously added because having the existing GP be above the required GP "looked buggy", but a realistic case where the GP could be above the threshold was found during testing: if type doubling or another feature increased the GP gain above the remaining quota. in this case, it recognizes hunter contributions better if it shows the over-contribution

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Goal Initializer works when a server has a completed goal
- [x] scoreboards don't show completed goals
- [x] over-contribution shown on toast embed

Issue
-----
Closes #426