### PR TITLE
#425: fix crash on uncaught modal expiry error

### DIFF
--- a/source/commands/bounty/edit.js
+++ b/source/commands/bounty/edit.js
@@ -84,7 +84,7 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 						)
 					)
 			);
-			interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
+			return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
 				const title = modalSubmission.fields.getTextInputValue("title");
 				const description = modalSubmission.fields.getTextInputValue("description");
 

--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -98,7 +98,7 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 					)
 			);
 
-			collectedInteraction.awaitModalSubmit({ filter: (incoming) => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
+			return collectedInteraction.awaitModalSubmit({ filter: (incoming) => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
 				const title = modalSubmission.fields.getTextInputValue("title");
 				const description = modalSubmission.fields.getTextInputValue("description");
 

--- a/source/commands/evergreen/edit.js
+++ b/source/commands/evergreen/edit.js
@@ -62,7 +62,7 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 						)
 					)
 			);
-			interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
+			return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${collectedInteraction.id}`, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
 				interaction.deleteReply();
 				const title = modalSubmission.fields.getTextInputValue("title");
 				const description = modalSubmission.fields.getTextInputValue("description");

--- a/source/commands/evergreen/post.js
+++ b/source/commands/evergreen/post.js
@@ -1,4 +1,4 @@
-const { ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags } = require("discord.js");
+const { ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, DiscordjsErrorCodes } = require("discord.js");
 const { MAX_EMBEDS_PER_MESSAGE, MAX_EMBED_TITLE_LENGTH, SKIP_INTERACTION_HANDLING } = require("../../constants");
 const { textsHaveAutoModInfraction, timeConversion, commandMention } = require("../../util/textUtil");
 const { generateBountyBoardThread } = require("../../util/scoreUtil");
@@ -46,7 +46,7 @@ module.exports = new SubcommandWrapper("post", "Post an evergreen bounty, limit 
 				)
 		);
 
-		interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${interaction.id}`, time: timeConversion(5, "m", "ms") }).then(async interaction => {
+		return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === `${SKIP_INTERACTION_HANDLING}${interaction.id}`, time: timeConversion(5, "m", "ms") }).then(async interaction => {
 			const title = interaction.fields.getTextInputValue("title");
 			const description = interaction.fields.getTextInputValue("description");
 
@@ -105,6 +105,10 @@ module.exports = new SubcommandWrapper("post", "Post an evergreen bounty, limit 
 					interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: [MessageFlags.Ephemeral] });
 				}
 			});
-		}).catch(console.error)
+		}).catch(error => {
+			if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+				console.error(error);
+			}
+		})
 	}
 );

--- a/source/commands/feedback.js
+++ b/source/commands/feedback.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, TextInputBuilder, ModalBuilder, TextInputStyle, PermissionFlagsBits, EmbedBuilder, InteractionContextType, MessageFlags } = require('discord.js');
+const { ActionRowBuilder, TextInputBuilder, ModalBuilder, TextInputStyle, PermissionFlagsBits, EmbedBuilder, InteractionContextType, MessageFlags, DiscordjsErrorCodes } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 const { MAX_EMBED_TITLE_LENGTH, testGuildId, feedbackChannelId, SKIP_INTERACTION_HANDLING } = require('../constants');
 
@@ -78,7 +78,11 @@ module.exports = new CommandWrapper(mainId, "Provide BountyBot feedback and get 
 							modalSubmission.reply({ content: `Your bug report has been recorded${errors.length > 0 ? `, but the following errors were encountered: ${errors.join(", ")}` : ""}.You can join the Imaginary Horizons Productions test server to provide additional information here: ${invite.url}`, flags: [MessageFlags.Ephemeral] })
 						})
 					})
-				}).catch(console.error);
+				}).catch(error => {
+					if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+						console.error(error);
+					}
+				});
 				break;
 			case "feature":
 				interaction.showModal(new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
@@ -149,7 +153,11 @@ module.exports = new CommandWrapper(mainId, "Provide BountyBot feedback and get 
 							modalSubmission.reply({ content: `Your feature request has been recorded${errors.length > 0 ? `, but the following errors were encountered: ${errors.join(", ")}` : ""}. You can join the Imaginary Horizons Productions test server to provide additional information here: ${invite.url}`, flags: [MessageFlags.Ephemeral] })
 						})
 					})
-				}).catch(console.error);
+				}).catch(error => {
+					if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+						console.error(error);
+					}
+				});
 				break;
 		}
 	}

--- a/source/context_menus/Give_Bounty_Credit.js
+++ b/source/context_menus/Give_Bounty_Credit.js
@@ -1,4 +1,4 @@
-const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, userMention, bold, MessageFlags, Guild } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, userMention, bold, MessageFlags, Guild, DiscordjsErrorCodes } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { commandMention, listifyEN, congratulationBuilder } = require('../util/textUtil');
@@ -69,7 +69,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				)
 			)
 		);
-		interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
+		return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
 			const slotNumber = modalSubmission.fields.getTextInputValue("slot-number");
 			const bounty = await logicLayer.bounties.findBounty({ slotNumber, userId: interaction.user.id, companyId: modalSubmission.guild.id });
 			if (!bounty) {
@@ -87,6 +87,10 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 					modalSubmission.reply({ content: e, flags: [MessageFlags.Ephemeral] });
 				}
 				return;
+			}
+		}).catch(error => {
+			if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+				console.error(error);
 			}
 		})
 	}

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -1,4 +1,4 @@
-const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, userMention } = require('discord.js');
+const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, userMention, DiscordjsErrorCodes } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../constants');
 const { textsHaveAutoModInfraction, generateTextBar } = require('../util/textUtil');
@@ -47,7 +47,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				)
 			)
 		);
-		interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
+		return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
 			const toastText = modalSubmission.fields.getTextInputValue("message");
 			if (await textsHaveAutoModInfraction(modalSubmission.channel, modalSubmission.member, [toastText], "toast")) {
 				modalSubmission.reply({ content: "Your toast was blocked by AutoMod.", flags: [MessageFlags.Ephemeral] });
@@ -97,6 +97,10 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 					company.updateScoreboard(modalSubmission.guild, logicLayer);
 				}
 			});
+		}).catch(error => {
+			if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+				console.error(error);
+			}
 		})
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/items/bounty-thumbnail.js
+++ b/source/items/bounty-thumbnail.js
@@ -39,7 +39,7 @@ module.exports = new ItemTemplateSet(
 					}
 				}
 
-				modalSubmission.reply({
+				return modalSubmission.reply({
 					content: `A bounty's thumbnail will be shown on the bounty board and in the bounty's embed. It will also increase the XP you receive when the bounty's completed by 1.\n${imageURL}`,
 					components: [
 						new ActionRowBuilder().addComponents(
@@ -62,13 +62,13 @@ module.exports = new ItemTemplateSet(
 						bounty.updatePosting(interaction.guild, company, (await logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id)).level, bounty.id);
 					});
 					return collectedInteraction.reply({ content: `The thumbnail on ${bounty.title} has been updated.${bounty.postingId !== null ? ` <#${bounty.postingId}>` : ""}`, flags: [MessageFlags.Ephemeral] });
-				}).catch(error => {
-					if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
-						console.error(error);
-					}
-				}).finally(() => {
-					modalSubmission.deleteReply();
 				})
+			}).catch(error => {
+				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+					console.error(error);
+				}
+			}).finally(() => {
+				modalSubmission.deleteReply();
 			})
 		}
 	)


### PR DESCRIPTION
Summary
-------
- fix crashes on modal expiry in the following places:
   - `/bounty edit`
   - `/bounty post`
   - `/evergreen edit`
   - `/evergreen post`
   - Give Bounty Credit context menu
   - Raise a Toast context menu
   - Bounty Thumbnail item (catch/finally blocks were on the wrong layer)
- ignore thrown `InteractionCollectorError`s in the following places:
   - `/evergreen post`
   - `/feedback` bug report
   - `/feedback` feature request
   - Give Bounty Credit context menu
   - Raise a Toast context menu

We, unfortunately, don't have a way to close expired modals, so users who try to submit those afterward will see a "the application didn't respond" on the modal (but no error on our side).

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty post` doesn't crash when modal expires (set time to 1ms)
- [x] `/bounty post` continues through flow

Issue
-----
Closes #425