### PR TITLE
#429: add early out if rank goes missing during `/raffle by-rank`

### DIFF
--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -49,11 +49,15 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 				company.update("nextRaffleString", null);
 			});
 		}).catch(error => {
+			if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {
+				return;
+			}
+
 			if (error.name === "SequelizeInstanceError") {
 				interaction.user.send({ content: "A raffle by ranks could not be started because there was an error with finding the rank you selected." });
 			} else if (Object.values(error.rawError.errors.data.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
 				interaction.user.send({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji." });
-			} else if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
+			} else {
 				console.error(error);
 			}
 		}).finally(() => {

--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -54,7 +54,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			}
 
 			if (error.name === "SequelizeInstanceError") {
-				interaction.user.send({ content: "A raffle by ranks could not be started because there was an error with finding the rank you selected." });
+				interaction.user.send({ content: "A raffle by ranks could not be started because there was an error with finding the rank you selected. Please try again." });
 			} else if (Object.values(error.rawError.errors.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
 				interaction.user.send({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji.", flags: [MessageFlags.Ephemeral] });
 			} else {

--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -35,7 +35,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			const varianceThreshold = Number(collectedInteraction.values[0]);
 			const reloadedRanks = await Promise.all(ranks.map(rank => rank.reload()));
 			const rankIndex = reloadedRanks.findIndex(rank => rank.varianceThreshold === varianceThreshold);
-			const rank = ranks[rankIndex];
+			const rank = reloadedRanks[rankIndex];
 			const qualifiedHunterIds = await logicLayer.hunters.findHunterIdsAtOrAboveRank(interaction.guildId, rankIndex);
 			const unvalidatedMembers = await interaction.guild.members.fetch({ user: qualifiedHunterIds });
 			const eligibleMembers = unvalidatedMembers.filter(member => member.manageable);

--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -31,7 +31,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 				)
 			],
 			withResponse: true
-		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
+		}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 			const varianceThreshold = Number(collectedInteraction.values[0]);
 			const reloadedRanks = await Promise.all(ranks.map(rank => rank.reload()));
 			const rankIndex = reloadedRanks.findIndex(rank => rank.varianceThreshold === varianceThreshold);

--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -10,7 +10,8 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			return;
 		}
 		const guildRoles = await interaction.guild.roles.fetch();
-		interaction.reply({
+		await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+		interaction.editReply({
 			content: "Select a rank to be the eligibility threshold for this raffle:",
 			components: [
 				new ActionRowBuilder().addComponents(
@@ -29,7 +30,6 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 						}))
 				)
 			],
-			flags: [MessageFlags.Ephemeral],
 			withResponse: true
 		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 			const varianceThreshold = Number(collectedInteraction.values[0]);
@@ -55,8 +55,8 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 
 			if (error.name === "SequelizeInstanceError") {
 				interaction.user.send({ content: "A raffle by ranks could not be started because there was an error with finding the rank you selected." });
-			} else if (Object.values(error.rawError.errors.data.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
-				interaction.user.send({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji." });
+			} else if (Object.values(error.rawError.errors.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
+				interaction.user.send({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji.", flags: [MessageFlags.Ephemeral] });
 			} else {
 				console.error(error);
 			}


### PR DESCRIPTION
Summary
-------
- catch Sequelize error on non-existent rank reload during `/raffle by-rank`
- move "nonemoji rank emoji" error handling to a DM, as the ephemeral message that would have held the error message gets cleaned up

This is a blocker for #427, which will be working in the same lines of code.

Had to change from `rankIndex` as select value to `varianceThreshold` to be able to detect missing ranks. This is likely pointing at changing a column on Hunter (in v2.10.0), given how volatile `rankIndex` is.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/raffle by-rank` early outs instead of crashing if selected rank was deleted
- [x] `/raffle by-rank` can proceed beyond rank existence check

~~I'll need help testing the racing on this one. Also, I looked, but couldn't find any documentation on what Sequelize does if we try to reload an instance who's been deleted.~~ Sequelize throws an error (unhelpfully only containing the vague name "SequelizeInstanceError") when reloading a non-existant entity.

Issue
-----
Closes #429