### PR TITLE
#424: `/config premium` improvements

### DIFF
--- a/source/models/companies/Company.js
+++ b/source/models/companies/Company.js
@@ -224,6 +224,14 @@ class Company extends Model {
 			.setFooter(randomFooterTip())
 			.setTimestamp()
 	}
+
+	/** Updates the level on this Company instance (DOES NOT SAVE TO DB) */
+	async updateLevel() {
+		const calculatedLevel = Math.floor(Math.sqrt(await this.xp / 3) + 1);
+		const levelChanged = this.level !== calculatedLevel;
+		this.level = calculatedLevel;
+		return levelChanged;
+	}
 }
 
 /** @param {Sequelize} sequelize */

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -37,6 +37,16 @@ class Hunter extends Model {
 		return Math.min(slots, maxSimBounties);
 	}
 
+	/** Updates the level on this Hunter instance (DOES NOT SAVE TO DB)
+	 * @param {number} xpCoefficient
+	 */
+	updateLevel(xpCoefficient) {
+		const calculatedLevel = Math.floor(Math.sqrt(this.xp / xpCoefficient) + 1);
+		const levelChanged = this.level !== calculatedLevel;
+		this.level = calculatedLevel;
+		return levelChanged;
+	}
+
 	/**
 	 * @param {string} guildName
 	 * @param {number} points
@@ -50,12 +60,13 @@ class Hunter extends Model {
 		const previousCompanyLevel = company.level;
 
 		this.xp += totalPoints;
-
-		this.level = Math.floor(Math.sqrt(this.xp / company.xpCoefficient) + 1);
+		this.updateLevel(company.xpCoefficient);
 		this.save();
 
-		company.level = Math.floor(Math.sqrt(await company.xp / 3) + 1);
-		company.save();
+		const levelChanged = await company.updateLevel();
+		if (levelChanged) {
+			company.save();
+		}
 
 		const levelTexts = [];
 		if (this.level > previousLevel) {

--- a/source/models/users/Hunter.js
+++ b/source/models/users/Hunter.js
@@ -63,8 +63,8 @@ class Hunter extends Model {
 		this.updateLevel(company.xpCoefficient);
 		this.save();
 
-		const levelChanged = await company.updateLevel();
-		if (levelChanged) {
+		const companyLevelChanged = await company.updateLevel();
+		if (companyLevelChanged) {
 			company.save();
 		}
 


### PR DESCRIPTION
Summary
-------
- recalculate hunter levels after setting level threshold multiplier
- add validation to reject 0 and negative numbers in level threshold multiplier
- allow rest of command to resolve if given invalid bounty slots input

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] a Hunter with 5 XP is demoted from level 2 to level 1 when level threshold multiplier is set to 6
- [x] level threshold multiplier rejects values of 0 and negative numbers
- [x] providing invalid bounty slots allows rest of command to resolve

Issue
-----
Closes #424