### PR TITLE
only nudge members who can manage the bot to create a bounty board

### DIFF
--- a/source/commands/bounty/post.js
+++ b/source/commands/bounty/post.js
@@ -234,7 +234,9 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 							bounty.save()
 						});
 					} else {
-						interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: [MessageFlags.Ephemeral] });
+						if (!interaction.member.manageable) {
+							interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: [MessageFlags.Ephemeral] });
+						}
 					}
 				});
 			});

--- a/source/commands/evergreen/post.js
+++ b/source/commands/evergreen/post.js
@@ -102,7 +102,9 @@ module.exports = new SubcommandWrapper("post", "Post an evergreen bounty, limit 
 						bounty.save()
 					});
 				} else {
-					interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: [MessageFlags.Ephemeral] });
+					if (!interaction.member.manageable) {
+						interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: [MessageFlags.Ephemeral] });
+					}
 				}
 			});
 		}).catch(console.error)


### PR DESCRIPTION
Summary
-------
- only nudge members who can manage the bot to create a bounty board

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /create-default bounty-board-forum shows up when a bot managers posts a bounty, but only for bot managers