### PR TITLE
#423: `/festival close` and `/festival open` now update the scoreboard appropriately

### DIFF
--- a/source/commands/festival/close.js
+++ b/source/commands/festival/close.js
@@ -7,5 +7,6 @@ module.exports = new SubcommandWrapper("close", "End the festival, returning to 
 			bountyBot.setNickname(null);
 		})
 		interaction.reply(company.sendAnnouncement({ content: "The XP multiplier festival has ended. Hope you participate next time!" }));
+		company.updateScoreboard(interaction.guild, logicLayer);
 	}
 );

--- a/source/commands/festival/start.js
+++ b/source/commands/festival/start.js
@@ -17,6 +17,7 @@ module.exports = new SubcommandWrapper("start", "Start an XP multiplier festival
 			}
 		})
 		interaction.reply(company.sendAnnouncement({ content: `An XP multiplier festival has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
+		company.updateScoreboard(interaction.guild, logicLayer);
 	}
 ).setOptions(
 	{


### PR DESCRIPTION
Summary
-------
- `/festival close` and `/festival open` now update the scoreboard appropriately

Local Tests Performed
---------------------
- [ ] bot still turns on (no build errors, circular dependencies, or start-up errors)

Issue
-----
Closes #423