### PR TITLE
Workaround create table failure

### DIFF
--- a/migrations/20250402165105-addTimestampsToGoals.js
+++ b/migrations/20250402165105-addTimestampsToGoals.js
@@ -12,7 +12,9 @@ module.exports = {
 				await queryInterface.addColumn(table, "updatedAt", { type: Sequelize.Sequelize.DataTypes.DATE, allowNull: false });
 				updatedColumnEntries.push(["updatedAt", new Date()]);
 			}
-			await queryInterface.bulkUpdate(table, Object.fromEntries(updatedColumnEntries));
+			if (updatedColumnEntries.length > 0) {
+				await queryInterface.bulkUpdate(table, Object.fromEntries(updatedColumnEntries));
+			}
 		}
 	},
 	async down(queryInterface, Sequelize) {

--- a/migrations/20250402165105-addTimestampsToGoals.js
+++ b/migrations/20250402165105-addTimestampsToGoals.js
@@ -1,0 +1,24 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		for (const table of ["Goal", "Contribution"]) {
+			const tableDescription = await queryInterface.describeTable(table);
+			const updatedColumnEntries = [];
+			if (!("createdAt" in tableDescription)) {
+				await queryInterface.addColumn(table, "createdAt", { type: Sequelize.Sequelize.DataTypes.DATE, allowNull: false });
+				updatedColumnEntries.push(["createdAt", new Date()]);
+			}
+			if (!("updatedAt" in tableDescription)) {
+				await queryInterface.addColumn(table, "updatedAt", { type: Sequelize.Sequelize.DataTypes.DATE, allowNull: false });
+				updatedColumnEntries.push(["updatedAt", new Date()]);
+			}
+			await queryInterface.bulkUpdate(table, Object.fromEntries(updatedColumnEntries));
+		}
+	},
+	async down(queryInterface, Sequelize) {
+		await queryInterface.removeColumn("Goal", "createdAt");
+		await queryInterface.removeColumn("Goal", "updatedAt");
+		await queryInterface.removeColumn("Contribution", "createdAt");
+		await queryInterface.removeColumn("Contribution", "updatedAt");
+	}
+};

--- a/source/bot.js
+++ b/source/bot.js
@@ -72,8 +72,8 @@ const dbReady = dbConnection.authenticate().then(async () => {
 		}
 	});
 
-	return dbConnection.sync();
-}).then(() => {
+	if (runMode !== 'production') dbConnection.sync();
+
 	for (const interface in logicBlob) { // Set the database for the logic files that store it
 		logicBlob[interface].setDB?.(dbConnection);
 	}

--- a/source/bot.js
+++ b/source/bot.js
@@ -72,8 +72,8 @@ const dbReady = dbConnection.authenticate().then(async () => {
 		}
 	});
 
-	if (runMode !== 'production') dbConnection.sync();
-
+	return dbConnection.sync();
+}).then(() => {
 	for (const interface in logicBlob) { // Set the database for the logic files that store it
 		logicBlob[interface].setDB?.(dbConnection);
 	}

--- a/wiki/Developers.md
+++ b/wiki/Developers.md
@@ -34,3 +34,12 @@ Please use `camelCase` unless one of the following exceptions apply:
    - Context menu commands have their customIds visible to the end user as the menu option name, and we use `Proper Noun Case` as a result
       - File names should match the customIds, but use underscores instead of spaces (like `Proper_Noun_Case.js`)
    - Others are `alllowercase`
+
+## Migrations and Database Management
+We us `sequelize-cli` for migration management (see `npx seqeulize help` for a list of its commands)
+
+### Migration Writing Tips
+- Migration SQL logging can be turned on by adding `logging: true` to the env in `./config/config.json`
+   - This logging is off by default because it throws a deprecation error on regular startup
+- Creating tables in migrations is considered best practice (so that shards aren't trying to race to finish that work), but the schemas for `queryInterface.createTable()` need to include even the properties Sequelize automatically manages (like auto-incrementing `id`s, `createdAt`, or `updatedAt`)
+- `queryInterface.bulkUpdate()` will create an empty SET query if provided an empty `values` object (like if dynamic calculation finds no properties to update), causing a `SQLITE_ERROR: incomplete input`


### PR DESCRIPTION
Summary
-------
- add migration for adding `createdAt` and `updatedAt` columns to `Goal` and `Contribution`
- ~~create new tables by synching database models on startup~~
   - ~~this solution is considered non-ideal because it opens the problem of "bot shards racing to update the tables"~~

Later research discovered the following (thanks @doubledh!):
- SQL logging can be turned on for migrations by adding `logging: true` to the env the migration is being run in (in `config/config.json`). The default for this was left off because it throws a deprecation error into the console on normal startup.
- The `SQLITE_ERROR: incomplete input` was coming from the `bulkUpdate` in the `addTimestampsToGoals` migration being run with an empty `values` parameter. That migration was being run before experimental table creation migrations, so the error was mistakenly attributed to the `createTable` call.
- `createTable()` requires differently shaped schemas than `dbConnection.sync()`. `createTable()` needs all columns defined, even the ones Sequelize usually manages (eg ``createdAt`, `updatedAt`, and `id`), whereas the Sequelized-managed properties can be omitted from `dbConnection.sync()`.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] migration up creates new columns
- [x] migration down removes columns