### PR TITLE
update sequelize to v6.37.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"dependencies": {
 				"discord.js": "^14.18.0",
-				"sequelize": "^6.37.5",
+				"sequelize": "^6.37.7",
 				"sequelize-cli": "^6.6.2",
 				"sqlite3": "^5.1.7"
 			}
@@ -1985,9 +1985,9 @@
 			}
 		},
 		"node_modules/sequelize": {
-			"version": "6.37.5",
-			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.5.tgz",
-			"integrity": "sha512-10WA4poUb3XWnUROThqL2Apq9C2NhyV1xHPMZuybNMCucDsbbFuKg51jhmyvvAUyUqCiimwTZamc3AHhMoBr2Q==",
+			"version": "6.37.7",
+			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.7.tgz",
+			"integrity": "sha512-mCnh83zuz7kQxxJirtFD7q6Huy6liPanI67BSlbzSYgVNl5eXVdE2CN1FuAeZwG1SNpGsNRCV+bJAVVnykZAFA==",
 			"funding": [
 				{
 					"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"discord.js": "^14.18.0",
-		"sequelize": "^6.37.5",
+		"sequelize": "^6.37.7",
 		"sequelize-cli": "^6.6.2",
 		"sqlite3": "^5.1.7"
 	}


### PR DESCRIPTION
Summary
-------
- update sequelize to v6.37.7

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] according to Sequelize's release notes, the two patches were a documentation update and an update to handling BLOB type (which we don't use any of)