### PR TITLE
SillySalamndr/issue448

### DIFF
--- a/source/commands/create-default/rankroles.js
+++ b/source/commands/create-default/rankroles.js
@@ -16,7 +16,7 @@ module.exports = new SubcommandWrapper("rank-roles", "Create the default ranks f
 				console.error(error);
 			}
 		});
-		const deletedCount = await logicLayer.ranks.deleteRanks(interaction.guild.id);
+		const deletedCount = await logicLayer.ranks.deleteCompanyRanks(interaction.guild.id);
 		const roles = await interaction.guild.roles.fetch().then(existingGuildRoles => {
 			return Promise.all(
 				[

--- a/source/commands/rank/info.js
+++ b/source/commands/rank/info.js
@@ -9,15 +9,15 @@ module.exports = new SubcommandWrapper("info", "Get the information about an exi
 			interaction.reply({ content: `Could not find aany seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
-		const rankStrings = ranks.map((rank, index) => {
+		const allRanksMsg = ranks.map((rank, index) => {
 			return `${rank.rankmoji ?? ""}${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}`;
 		}).join('\n');
 
 		const msgJson = { flags: [MessageFlags.Ephemeral] };
-		if (rankStrings.length < MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
-			msgJson.content = rankStrings;
+		if (allRanksMsg.length < MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
+			msgJson.content = allRanksMsg;
 		} else {
-			msgJson.files = [new AttachmentBuilder(Buffer.from(rankStrings, 'utf16le'), { name: 'ranks.txt' })];
+			msgJson.files = [new AttachmentBuilder(Buffer.from(allRanksMsg, 'utf16le'), { name: 'ranks.txt' })];
 		}
 
 		interaction.reply(msgJson);

--- a/source/commands/rank/info.js
+++ b/source/commands/rank/info.js
@@ -1,5 +1,4 @@
 const { MessageFlags } = require("discord.js");
-const { Buffer } = require('node:buffer');
 const { SubcommandWrapper } = require("../../classes");
 const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
 
@@ -15,10 +14,10 @@ module.exports = new SubcommandWrapper("info", "Get the information about an exi
 		}).join('\n');
 
 		const msgJson = { flags: [MessageFlags.Ephemeral] };
-		if (rankStrings.length > MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
-			msgJson.files = [ Buffer.from(rankStrings, 'utf16le') ];
-		} else {
+		if (rankStrings.length < MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
 			msgJson.content = rankStrings;
+		} else {
+			msgJson.files = [new AttachmentBuilder(Buffer.from(rankStrings, 'utf16le'), { name: 'ranks.txt' })];
 		}
 
 		interaction.reply(msgJson);

--- a/source/commands/rank/info.js
+++ b/source/commands/rank/info.js
@@ -1,28 +1,26 @@
 const { MessageFlags } = require("discord.js");
+const { Buffer } = require('node:buffer');
 const { SubcommandWrapper } = require("../../classes");
+const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
 
 module.exports = new SubcommandWrapper("info", "Get the information about an existing seasonal rank",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
-		const varianceThreshold = interaction.options.getNumber("variance-threshold");
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-		let index = 0;
-		const rank = ranks.find(rank => {
-			index++;
-			return rank.varianceThreshold == varianceThreshold
-		});
-
-		if (!rank) {
-			interaction.reply({ content: `Could not find a seasonal rank with variance threshold of ${varianceThreshold}.`, flags: [MessageFlags.Ephemeral] });
+		if (!ranks || !ranks.length) {
+			interaction.reply({ content: `Could not find aany seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
+		const rankStrings = ranks.map((rank, index) => {
+			return `${rank.rankmoji ?? ""}${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}`;
+		}).join('\n');
 
-		interaction.reply({ content: `${rank.rankmoji ?? ""}${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}`, flags: [MessageFlags.Ephemeral] });
-	}
-).setOptions(
-	{
-		type: "Number",
-		name: "variance-threshold",
-		description: "The variance threshold of the rank to view",
-		required: true
+		const msgJson = { flags: [MessageFlags.Ephemeral] };
+		if (rankStrings.length > MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
+			msgJson.files = [ Buffer.from(rankStrings, 'utf16le') ];
+		} else {
+			msgJson.content = rankStrings;
+		}
+
+		interaction.reply(msgJson);
 	}
 );


### PR DESCRIPTION
Implemented `/rank info` listing all ranks instead of needing to specify a rank by variance. This implementation includes a means to send the ranks as a text file, even through hitting character limits to trigger this seems unlikely due to a (default) rank limit of 25.

Fixed a bug found along the way where creating the default ranks would fail due to referencing a renamed function that removes all old ranks.

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] `/rank info` displays all ranks available from the default set when the bot is configured with that initial set
- [X] `/rank info` displays all 25 ranks after creating 25 ranks to be displayed

Issue
-----
Closes #448
