### PR TITLE
SillySalamndr/issue447

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -252,6 +252,10 @@ dAPIClient.on(Events.GuildDelete, async guild => {
 	logicBlob.seasons.deleteCompanySeasons(guild.id);
 	logicBlob.goals.deleteCompanyGoals(guild.id);
 	logicBlob.hunters.deleteCompanyHunters(guild.id);
+	logicBlob.ranks.findCompanyRanks(guild.id)
+			.map(r => r.roleId)
+			.filter(id => !!id)
+			.forEach(id => guild.roles.delete(id, 'Cleaning up BountyBot roles during kick.'));
 	logicBlob.ranks.deleteCompanyRanks(guild.id);
 	logicBlob.companies.deleteCompany(guild.id);
 });

--- a/source/bot.js
+++ b/source/bot.js
@@ -252,7 +252,7 @@ dAPIClient.on(Events.GuildDelete, async guild => {
 	logicBlob.seasons.deleteCompanySeasons(guild.id);
 	logicBlob.goals.deleteCompanyGoals(guild.id);
 	logicBlob.hunters.deleteCompanyHunters(guild.id);
-	logicBlob.ranks.findCompanyRanks(guild.id)
+	(await logicBlob.ranks.findAllRanks(guild.id))
 			.map(r => r.roleId)
 			.filter(id => !!id)
 			.forEach(id => guild.roles.delete(id, 'Cleaning up BountyBot roles during kick.'));

--- a/source/commands/create-default/rankroles.js
+++ b/source/commands/create-default/rankroles.js
@@ -16,6 +16,10 @@ module.exports = new SubcommandWrapper("rank-roles", "Create the default ranks f
 				console.error(error);
 			}
 		});
+		logicBlob.ranks.findCompanyRanks(interaction.guild.id)
+				.map(r => r.roleId)
+				.filter(id => !!id)
+				.forEach(id => interaction.guild.roles.delete(id, 'Cleaning up BountyBot roles during default rank creation.'));
 		const deletedCount = await logicLayer.ranks.deleteRanks(interaction.guild.id);
 		const roles = await interaction.guild.roles.fetch().then(existingGuildRoles => {
 			return Promise.all(

--- a/source/commands/create-default/rankroles.js
+++ b/source/commands/create-default/rankroles.js
@@ -16,11 +16,11 @@ module.exports = new SubcommandWrapper("rank-roles", "Create the default ranks f
 				console.error(error);
 			}
 		});
-		logicBlob.ranks.findCompanyRanks(interaction.guild.id)
+		(await logicLayer.ranks.findAllRanks(interaction.guild.id))
 				.map(r => r.roleId)
 				.filter(id => !!id)
 				.forEach(id => interaction.guild.roles.delete(id, 'Cleaning up BountyBot roles during default rank creation.'));
-		const deletedCount = await logicLayer.ranks.deleteRanks(interaction.guild.id);
+		const deletedCount = await logicLayer.ranks.deleteCompanyRanks(interaction.guild.id);
 		const roles = await interaction.guild.roles.fetch().then(existingGuildRoles => {
 			return Promise.all(
 				[

--- a/source/commands/rank/remove.js
+++ b/source/commands/rank/remove.js
@@ -9,7 +9,9 @@ module.exports = new SubcommandWrapper("remove", "Remove an existing seasonal ra
 			interaction.reply({ content: `Could not find a seasonal rank with variance threshold of ${varianceThreshold}.`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
-
+		if (rank.roleId) {
+			interaction.guild.ranks.delete(rank.roleId, 'Removing rank role during rank removal.')
+		}
 		rank.destroy();
 		interaction.reply({ content: "The rank has been removed.", flags: [MessageFlags.Ephemeral] });
 	}

--- a/source/commands/rank/remove.js
+++ b/source/commands/rank/remove.js
@@ -10,7 +10,7 @@ module.exports = new SubcommandWrapper("remove", "Remove an existing seasonal ra
 			return;
 		}
 		if (rank.roleId) {
-			interaction.guild.ranks.delete(rank.roleId, 'Removing rank role during rank removal.')
+			interaction.guild.roles.delete(rank.roleId, 'Removing rank role during rank removal.')
 		}
 		rank.destroy();
 		interaction.reply({ content: "The rank has been removed.", flags: [MessageFlags.Ephemeral] });


### PR DESCRIPTION
Added code in the 3 main locations where ranks are removed to also remove associated roles. Removing a singular rank removes the associated role, if that role existed. Bulk rank removal collects a list of the role IDs, removes empy/invalid entries, and then deletes each role by that ID reference. (There is no bulk role removal provided by Discord, unfortunately.) While it may make sense to try to move this code to the logic layer (since this action should alway happen when removing one or more ranks), this interaction with Discord likely doesn't belong on that layer, so we have a minor amount of duplication.

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] Removing single rank removes associated role (visible changes in old messages)
- [X] Removing all ranks through `create-default` removes associated roles
- [X] Removing the bot removes rank roles

Issue
-----
Closes #447
