### PR TITLE
fix unknown interaction in bounty board complete

### DIFF
--- a/source/buttons/bbcomplete.js
+++ b/source/buttons/bbcomplete.js
@@ -13,12 +13,12 @@ const mainId = "bbcomplete";
 module.exports = new ButtonWrapper(mainId, 3000,
 	(interaction, runMode, [bountyId]) => {
 		logicLayer.bounties.findBounty(bountyId).then(async bounty => {
+			await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
 			if (!bounty) {
-				interaction.reply({ content: "This bounty could not be found.", flags: [MessageFlags.Ephemeral] });
+				interaction.editReply({ content: "This bounty could not be found." });
 				return;
 			}
 
-			await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
 			if (bounty.userId !== interaction.user.id) {
 				interaction.editReply({ content: "Only the bounty poster can mark a bounty completed." });
 				return;


### PR DESCRIPTION
Summary
-------
This was found while investigating the April 2nd Unknown Interaction, but I don't think it's the same one. This one happens because `interaction` is acknowledged twice (once if the bounty isn't found, again on clean up), but the one being looked for is on `collectedInteraction` (the payload being sent is the rewards message).

I also wasn't able find the original Unknown Interaction.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)