### PR TITLE
#455: make  `/rank info` usable by all bounty hunters as `/seasonal-ranks`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # BountyBot Change Log
 ## BountyBot Version 2.9.0:
+- Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
+
+## BountyBot Version 2.9.0:
 ### Server Goals
 Server Goals are BountyBot objectives everyone on the server contributes to. A goal can require bounty completions, toasts, or toast secondings, with numbers depending on active bounty hunters on your server. A goal can be started by a bounty hunter using a Goal Initializer item on your server, and will reward contributors to the goal with XP and double item find on their next bounty completion. Server Goal progress can be found on the scoreboard. The bounty hunter with the most Server Goal contributions will receive a shoutout at the end of the season.
 

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -21,6 +21,7 @@ exports.commandFiles = [
 	"reset",
 	"scoreboard.js",
 	"season-end.js",
+	"seasonal-ranks",
 	"stats.js",
 	"toast.js",
 	"tutorial.js",

--- a/source/commands/rank/index.js
+++ b/source/commands/rank/index.js
@@ -4,7 +4,6 @@ const { createSubcommandMappings } = require('../../util/fileUtil.js');
 
 const mainId = "rank";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
-	"info.js",
 	"add.js",
 	"edit.js",
 	"remove.js"

--- a/source/commands/seasonal-ranks.js
+++ b/source/commands/seasonal-ranks.js
@@ -14,7 +14,7 @@ module.exports = new CommandWrapper(mainId, "Look up this server's seasonal rank
 			return;
 		}
 		const content = `${heading("Seasonal Ranks", 1)}\nBounty Hunters who earn more XP compared to their contemporaries are given special roles to distinguish themselves for the season. These roles are as follows:\n\n${ranks.map((rank, index) => {
-			return `${rank.rankmoji ?? ""}${rank.roleId ? roleMention(rank.roleId) : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}\n`;
+			return `${rank.rankmoji ? `${rank.rankmoji} ` : ""}${rank.roleId ? roleMention(rank.roleId) : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}\n`;
 		}).join('\n')}`;
 
 		const messagePayload = { flags: [MessageFlags.Ephemeral] };

--- a/source/commands/seasonal-ranks.js
+++ b/source/commands/seasonal-ranks.js
@@ -1,9 +1,13 @@
-const { MessageFlags } = require("discord.js");
-const { SubcommandWrapper } = require("../../classes");
-const { MAX_MESSAGE_CONTENT_LENGTH } = require("../../constants");
+const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
+const { CommandWrapper } = require('../classes/index.js');
+const { MAX_MESSAGE_CONTENT_LENGTH } = require("../constants.js");
 
-module.exports = new SubcommandWrapper("info", "Get the information about an existing seasonal rank",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+/** @type {typeof import("../logic/index.js")} */
+let logicLayer;
+
+const mainId = "seasonal-ranks";
+module.exports = new CommandWrapper(mainId, "Look up this server's seasonal ranks", PermissionFlagsBits.ViewChannel, false, [InteractionContextType.Guild], 3000,
+	async (interaction, runMode) => {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		if (!ranks || !ranks.length) {
 			interaction.reply({ content: `Could not find aany seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: [MessageFlags.Ephemeral] });
@@ -22,4 +26,6 @@ module.exports = new SubcommandWrapper("info", "Get the information about an exi
 
 		interaction.reply(msgJson);
 	}
-);
+).setLogicLinker(logicBlob => {
+	logicLayer = logicBlob;
+});

--- a/source/commands/seasonal-ranks.js
+++ b/source/commands/seasonal-ranks.js
@@ -1,4 +1,4 @@
-const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
+const { PermissionFlagsBits, InteractionContextType, MessageFlags, roleMention, AttachmentBuilder, heading } = require('discord.js');
 const { CommandWrapper } = require('../classes/index.js');
 const { MAX_MESSAGE_CONTENT_LENGTH } = require("../constants.js");
 
@@ -10,21 +10,21 @@ module.exports = new CommandWrapper(mainId, "Look up this server's seasonal rank
 	async (interaction, runMode) => {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		if (!ranks || !ranks.length) {
-			interaction.reply({ content: `Could not find aany seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: [MessageFlags.Ephemeral] });
+			interaction.reply({ content: `Could not find any seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
-		const allRanksMsg = ranks.map((rank, index) => {
-			return `${rank.rankmoji ?? ""}${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}`;
-		}).join('\n');
+		const content = `${heading("Seasonal Ranks", 1)}\nBounty Hunters who earn more XP compared to their contemporaries are given special roles to distinguish themselves for the season. These roles are as follows:\n\n${ranks.map((rank, index) => {
+			return `${rank.rankmoji ?? ""}${rank.roleId ? roleMention(rank.roleId) : `Rank ${index}`}\nVariance Threshold: ${rank.varianceThreshold}\n`;
+		}).join('\n')}`;
 
-		const msgJson = { flags: [MessageFlags.Ephemeral] };
-		if (allRanksMsg.length < MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
-			msgJson.content = allRanksMsg;
+		const messagePayload = { flags: [MessageFlags.Ephemeral] };
+		if (content.length < MAX_MESSAGE_CONTENT_LENGTH) { // Send large content as a text file
+			messagePayload.content = content;
 		} else {
-			msgJson.files = [new AttachmentBuilder(Buffer.from(allRanksMsg, 'utf16le'), { name: 'ranks.txt' })];
+			messagePayload.files = [new AttachmentBuilder(Buffer.from(content, 'utf16le'), { name: 'ranks.txt' })];
 		}
 
-		interaction.reply(msgJson);
+		interaction.reply(messagePayload);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;


### PR DESCRIPTION
Summary
-------
- make  `/rank info` usable by all bounty hunters as `/seasonal-ranks`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/seaasonal-ranks` provides the user with the server's list of seasonal ranks

Issue
-----
Closes #455