### PR TITLE
#418: fix `/raffle by-rank` replying to an ephemeral message

### DIFF
--- a/source/commands/raffle/byrank.js
+++ b/source/commands/raffle/byrank.js
@@ -44,7 +44,8 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 				return;
 			}
 			const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
-			collectedInteraction.reply(`The winner of this raffle is: ${winner}`);
+			collectedInteraction.update({ components: [] });
+			collectedInteraction.channel.send(`The winner of this raffle is: ${winner}`);
 			logicLayer.companies.findCompanyByPK(interaction.guild.id).then(company => {
 				company.update("nextRaffleString", null);
 			});


### PR DESCRIPTION
Summary
-------
- fix `/raffle by-rank` replying to an ephemeral message

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/raffle by-rank` no longer replies to an ephemeral message

Issue
-----
Closes #418