### PR TITLE
#466: switch `/bounty add-completers` option from String to User

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,8 @@
 ## BountyBot Version 2.10.0:
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering.
-- `/toast` now accepts 1 required toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
+- `/toast` now requires 1 toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
+- `/bounty add-completers` now requires 1 bounty hunter and up to 4 optional ones.
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering.
 - `/toast` now requires 1 toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
-- `/bounty add-completers` now requires 1 bounty hunter and up to 4 optional ones.
+- `/bounty add-completers` has been renamed to `/bounty verify-turn-in` and now requires 1 bounty hunter and up to 4 optional ones.
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts

--- a/source/commands/bounty/addcompleters.js
+++ b/source/commands/bounty/addcompleters.js
@@ -44,30 +44,12 @@ module.exports = new SubcommandWrapper("add-completers", "Add hunter(s) to a bou
 			return;
 		}
 
-		const hunterMap = logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
-		const bannedIds = [];
 		const completerMembers = [];
 		for (const optionalToastee of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(optionalToastee);
-			if (guildMember) {
-				if (hunterMap[guildMember.id]?.isBanned) {
-					bannedIds.push(guildMember.id);
-				} else if (runMode !== "production" || (!guildMember.user.bot && guildMember.user.id !== interaction.user.id)) {
-					completerMembers.push(guildMember);
-				}
+			if (guildMember?.id !== interaction.user.id) {
+				completerMembers.push(guildMember);
 			}
-		}
-
-		let bannedText;
-		if (bannedIds.length > 1) {
-			bannedText = ` ${listifyEN(bannedIds.map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
-		} else if (bannedIds.length === 1) {
-			bannedText = ` ${userMention(bannedIds[0])} was skipped because they're banned from using BountyBot on this server.`;
-		}
-
-		if (completerMembers.length < 1) {
-			interaction.reply({ content: `No valid bounty hunters received. You cannot credit yourself or bots with bounty completion.${bannedText ?? ""}`, flags: [MessageFlags.Ephemeral] });
-			return;
 		}
 
 		try {

--- a/source/commands/bounty/index.js
+++ b/source/commands/bounty/index.js
@@ -7,15 +7,15 @@ let logicLayer;
 
 const mainId = "bounty";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, [
-	"post.js",
-	"edit.js",
-	"swap.js",
-	"showcase.js",
-	"addcompleters.js",
-	"removecompleters.js",
 	"complete.js",
+	"edit.js",
+	"list.js",
+	"post.js",
+	"removecompleters.js",
+	"showcase.js",
+	"swap.js",
 	"takedown.js",
-	"list.js"
+	"verify-turn-in.js",
 ]);
 module.exports = new CommandWrapper(mainId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
 	async (interaction, runMode) => {

--- a/source/commands/bounty/verify-turn-in.js
+++ b/source/commands/bounty/verify-turn-in.js
@@ -1,10 +1,10 @@
 const { userMention, bold, MessageFlags, Guild } = require("discord.js");
-const { listifyEN, commandMention, congratulationBuilder } = require("../../util/textUtil");
+const { listifyEN, commandMention, congratulationBuilder } = require("../../util/textUtil.js");
 const { Completion } = require("../../models/bounties/Completion.js");
 const { Bounty } = require("../../models/bounties/Bounty.js");
 const { Company } = require("../../models/companies/Company.js");
 const { Hunter } = require("../../models/users/Hunter.js");
-const { SubcommandWrapper } = require("../../classes");
+const { SubcommandWrapper } = require("../../classes/index.js");
 
 /**
  * Updates the board posting for the bounty after adding the completers
@@ -34,7 +34,7 @@ async function updateBoardPosting(bounty, company, poster, newCompleterIds, comp
 	});
 }
 
-module.exports = new SubcommandWrapper("add-completers", "Add hunter(s) to a bounty's list of completers",
+module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty hunters have turned in one of your bounties",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer, posterId]) {
 		const slotNumber = interaction.options.getInteger("bounty-slot");
 
@@ -56,7 +56,7 @@ module.exports = new SubcommandWrapper("add-completers", "Add hunter(s) to a bou
 			let { bounty: returnedBounty, allCompleters, poster, company, validatedCompleterIds, bannedIds } = await logicLayer.bounties.addCompleters(bounty, interaction.guild, completerMembers, runMode);
 			updateBoardPosting(returnedBounty, company, poster, validatedCompleterIds, allCompleters, interaction.guild);
 			interaction.reply({
-				content: `The following bounty hunters have been added as completers to ${bold(returnedBounty.title)}: ${listifyEN(validatedCompleterIds.map(id => userMention(id)))}\n\nThey will recieve the reward XP when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were not added, due to currently being banned from using BountyBot: ${listifyEN(bannedIds.map(id => userMention(id)))}` : ""}`,
+				content: `Bounty turn-ins for following bounty hunters have been recorded: ${bold(returnedBounty.title)}: ${listifyEN(validatedCompleterIds.map(id => userMention(id)))}\n\nXP and drops will be distributed when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were skipped due to currently being banned from using BountyBot: ${listifyEN(bannedIds.map(id => userMention(id)))}` : ""}`,
 				flags: [MessageFlags.Ephemeral]
 			});
 		} catch (e) {
@@ -78,31 +78,31 @@ module.exports = new SubcommandWrapper("add-completers", "Add hunter(s) to a bou
 	{
 		type: "User",
 		name: "bounty-hunter",
-		description: "The bounty hunter to award",
+		description: "A bounty hunter who turned in the bounty",
 		required: true
 	},
 	{
 		type: "User",
 		name: "second-bounty-hunter",
-		description: "The second bounty hunter to award",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "User",
 		name: "third-bounty-hunter",
-		description: "The third bounty hunter to award",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "User",
 		name: "fourth-bounty-hunter",
-		description: "The fourth bounty hunter to award",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "User",
 		name: "fifth-bounty-hunter",
-		description: "The fifth bounty hunter to award",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	}
 );

--- a/source/commands/bounty/verify-turn-in.js
+++ b/source/commands/bounty/verify-turn-in.js
@@ -47,7 +47,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 		const completerMembers = [];
 		for (const optionalToastee of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(optionalToastee);
-			if (guildMember?.id !== interaction.user.id && !completerMembers.some(member => member.id === guildMember.id)) {
+			if (guildMember?.id !== interaction.user.id) {
 				completerMembers.push(guildMember);
 			}
 		}

--- a/source/commands/bounty/verify-turn-in.js
+++ b/source/commands/bounty/verify-turn-in.js
@@ -47,7 +47,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 		const completerMembers = [];
 		for (const optionalToastee of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(optionalToastee);
-			if (guildMember?.id !== interaction.user.id) {
+			if (guildMember?.id !== interaction.user.id && !completerMembers.some(member => member.id === guildMember.id)) {
 				completerMembers.push(guildMember);
 			}
 		}

--- a/source/commands/bounty/verify-turn-in.js
+++ b/source/commands/bounty/verify-turn-in.js
@@ -47,7 +47,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 		const completerMembers = [];
 		for (const optionalToastee of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(optionalToastee);
-			if (guildMember?.id !== interaction.user.id) {
+			if (guildMember && guildMember.id !== interaction.user.id) {
 				completerMembers.push(guildMember);
 			}
 		}
@@ -56,7 +56,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 			let { bounty: returnedBounty, allCompleters, poster, company, validatedCompleterIds, bannedIds } = await logicLayer.bounties.addCompleters(bounty, interaction.guild, completerMembers, runMode);
 			updateBoardPosting(returnedBounty, company, poster, validatedCompleterIds, allCompleters, interaction.guild);
 			interaction.reply({
-				content: `Bounty turn-ins for following bounty hunters have been recorded: ${bold(returnedBounty.title)}: ${listifyEN(validatedCompleterIds.map(id => userMention(id)))}\n\nXP and drops will be distributed when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were skipped due to currently being banned from using BountyBot: ${listifyEN(bannedIds.map(id => userMention(id)))}` : ""}`,
+				content: `The following bounty hunters' turn-ins of ${bold(returnedBounty.title)} have been recorded: ${listifyEN(validatedCompleterIds.map(id => userMention(id)))}\n\nXP and drops will be distributed when you ${commandMention("bounty complete")}.${bannedIds.length > 0 ? `\n\nThe following users were skipped due to currently being banned from using BountyBot: ${listifyEN(bannedIds.map(id => userMention(id)))}` : ""}`,
 				flags: [MessageFlags.Ephemeral]
 			});
 		} catch (e) {

--- a/source/commands/bounty/verify-turn-in.js
+++ b/source/commands/bounty/verify-turn-in.js
@@ -26,7 +26,7 @@ async function updateBoardPosting(bounty, company, poster, newCompleterIds, comp
 	}
 	post.edit({ name: bounty.title });
 	let numCompleters = newCompleterIds.length;
-	post.send({ content: `${listifyEN(newCompleterIds.map(id => userMention(id)))} ${numCompleters === 1 ? "has" : "have"} been added as ${numCompleters === 1 ? "a completer" : "completers"} of this bounty! ${congratulationBuilder()}!` });
+	post.send({ content: `${listifyEN(newCompleterIds.map(id => userMention(id)))} ${numCompleters === 1 ? "has" : "have"} turned in this bounty! ${congratulationBuilder()}!` });
 	let starterMessage = await post.fetchStarterMessage();
 	starterMessage.edit({
 		embeds: [await bounty.embed(guild, poster.level, false, company, completers)],

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -116,7 +116,7 @@ async function addCompleters(bounty, guild, completerMembers, runMode) {
 	}
 
 	if (validatedCompleterIds.length < 1) {
-		throw `Could not find any new non-bot mentions in \`hunters\`.${bannedIds.length ? ' The completer(s) mentioned are currently banned.' : ''}`;
+		throw `No new turn-ins were able to be recorded. Bots cannot turn-in bounties. ${bannedIds.length ? ' The completer(s) mentioned are currently banned.' : ''}`;
 	}
 
 	const rawCompletions = [];


### PR DESCRIPTION
Summary
-------
- switch `/bounty add-completers` option from String to User
- rename command to `bounty verify-turn-in`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty verify-turn-in` resolves without regression

Issue
-----
Closes #466