### PR TITLE
consolidate BountyBot banned check to interactionCreate listener

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -147,6 +147,12 @@ dAPIClient.on(Events.ClientReady, () => {
 
 dAPIClient.on(Events.InteractionCreate, async interaction => {
 	await dbReady;
+	const [interactingHunter] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
+	if (interactingHunter.isBanned && !(interaction.isCommand() && interaction.commandName === "moderation")) {
+		interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
+		return;
+	}
+
 	if (interaction.isAutocomplete()) {
 		const command = getCommand(interaction.commandName);
 		const focusedOption = interaction.options.getFocused(true);

--- a/source/buttons/secondtoast.js
+++ b/source/buttons/secondtoast.js
@@ -12,12 +12,6 @@ const mainId = "secondtoast";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Provide each recipient of a toast an extra XP, roll crit toast for author, and update embed */
 	async (interaction, runMode, [toastId]) => {
-		const [seconder] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
-		if (seconder.isBanned) {
-			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
-			return;
-		}
-
 		const originalToast = await logicLayer.toasts.findToastByPK(toastId);
 		if (runMode === "production" && originalToast.senderId === interaction.user.id) {
 			interaction.reply({ content: "You cannot second your own toast.", flags: [MessageFlags.Ephemeral] });
@@ -29,6 +23,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			return;
 		}
 
+		const [seconder] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
 		seconder.increment("toastsSeconded");
 		originalToast.increment("secondings");
 		const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);

--- a/source/commands/bounty/index.js
+++ b/source/commands/bounty/index.js
@@ -22,11 +22,6 @@ module.exports = new CommandWrapper(mainId, "Bounties are user-created objective
 		const userId = interaction.user.id;
 		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(userId, interaction.guild.id);
-		if (hunter.isBanned) {
-			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
-			return;
-		}
-
 		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer, userId, hunter);
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/commands/moderation/bountybotban.js
+++ b/source/commands/moderation/bountybotban.js
@@ -11,7 +11,7 @@ module.exports = new SubcommandWrapper("bountybot-ban", "Toggle whether the prov
 			hunter.hasBeenBanned = true;
 		}
 		hunter.save();
-		interaction.reply({ content: `${discordUser} has been ${hunter.isBanned ? "" : "un"}banned from interacting with BountyBot.`, flags: [MessageFlags.Ephemeral] });
+		interaction.reply({ content: `${discordUser} has been ${hunter.isBanned ? "" : "un"}banned from interacting with BountyBot on this server.`, flags: [MessageFlags.Ephemeral] });
 		if (!discordUser.bot) {
 			discordUser.send(`You have been ${hunter.isBanned ? "" : "un"}banned from interacting with BountyBot on ${interaction.guild.name}. The reason provided was: ${interaction.options.getString("reason")}`);
 		}

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -14,11 +14,6 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 	async (interaction, runMode) => {
 		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		const hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
-		const [sender] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guildId);
-		if (sender.isBanned) {
-			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
-			return;
-		}
 
 		const errors = [];
 
@@ -69,6 +64,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		}
 
 		const season = await logicLayer.seasons.incrementSeasonStat(interaction.guild.id, "toastsRaised");
+		const [sender] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guildId);
 
 		const { toastId, rewardedHunterIds, rewardTexts, critValue } = await logicLayer.toasts.raiseToast(interaction.guild, company, interaction.member, sender, validatedToasteeIds, season.id, toastText, imageURL);
 		const embeds = [Toast.generateEmbed(company.toastThumbnailURL, toastText, validatedToasteeIds, interaction.member)];

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -23,13 +23,6 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			return;
 		}
 
-		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
-		const [sender] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guildId);
-		if (sender.isBanned) {
-			interaction.reply({ content: `You are banned from interacting with BountyBot on ${interaction.guild.name}.`, flags: [MessageFlags.Ephemeral] });
-			return;
-		}
-
 		const [toastee] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.targetId, interaction.guildId);
 		if (toastee.isBanned) {
 			interaction.reply({ content: `${userMention(interaction.targetId)} cannot receive toasts because they are banned from interacting with BountyBot on this server.`, flags: [MessageFlags.Ephemeral] });
@@ -55,6 +48,8 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			}
 
 			const season = await logicLayer.seasons.incrementSeasonStat(modalSubmission.guild.id, "toastsRaised");
+			const [sender] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guildId);
+			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
 
 			const { toastId, rewardedHunterIds, rewardTexts, critValue } = await logicLayer.toasts.raiseToast(modalSubmission.guild, company, modalSubmission.member, sender, [interaction.targetId], season.id, toastText);
 			const embeds = [Toast.generateEmbed(company.toastThumbnailURL, toastText, [interaction.targetId], modalSubmission.member)];


### PR DESCRIPTION
Summary
-------
- consolidate BountyBot banned check to interactionCreate listener

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] banned users are barred from interacting with BountyBot
- [x] unbanned users can still interact with BountyBot
- [x] banned managers can still use `/moderation` in case they accidentally banned themselves