### PR TITLE
#467: switch `/bounty complete` hunter options from String to User

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering.
 - `/toast` now accepts 1 required toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
+- `/bounty complete` now accepts up to 5 optional hunters.
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -118,31 +118,31 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 	{
 		type: "String",
 		name: "first-bounty-hunter",
-		description: "A bounty hunter who completed this bounty",
+		description: "A bounty hunter who completed the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "second-bounty-hunter",
-		description: "A bounty hunter who completed this bounty",
+		description: "A bounty hunter who completed the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "third-bounty-hunter",
-		description: "A bounty hunter who completed this bounty",
+		description: "A bounty hunter who completed the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "fourth-bounty-hunter",
-		description: "A bounty hunter who completed this bounty",
+		description: "A bounty hunter who completed the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "fifth-bounty-hunter",
-		description: "A bounty hunter who completed this bounty",
+		description: "A bounty hunter who completed the bounty",
 		required: false
 	}
 );

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -5,7 +5,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
 const { Goal } = require("../../models/companies/Goal");
 const { SubcommandWrapper } = require("../../classes");
 
-module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, awarding XP to completers",
+module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, awarding XP to hunters who turned it in",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer, posterId]) {
 		const slotNumber = interaction.options.getInteger("bounty-slot");
 		const bounty = await logicLayer.bounties.findBounty({ userId: posterId, slotNumber, companyId: interaction.guild.id });
@@ -44,7 +44,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		}
 
 		if (validatedCompleterIds.length < 1) {
-			interaction.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: [MessageFlags.Ephemeral] })
+			interaction.reply({ content: `No bounty hunters have turn-ins recorded for this bounty. If you'd like to close your bounty without distributng rewards, use ${commandMention("bounty take-down")}.`, flags: [MessageFlags.Ephemeral] })
 			return;
 		}
 
@@ -118,25 +118,25 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 	{
 		type: "String",
 		name: "first-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "second-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "third-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
 		type: "String",
 		name: "fourth-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
+		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -5,7 +5,7 @@ const { getRankUpdates } = require("../../util/scoreUtil");
 const { Goal } = require("../../models/companies/Goal");
 const { SubcommandWrapper } = require("../../classes");
 
-module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, awarding XP to hunters who turned it in",
+module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer, posterId]) {
 		const slotNumber = interaction.options.getInteger("bounty-slot");
 		const bounty = await logicLayer.bounties.findBounty({ userId: posterId, slotNumber, companyId: interaction.guild.id });
@@ -27,6 +27,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 			const guildMember = interaction.options.getMember(optionalHunter);
 			if (guildMember?.id !== interaction.user.id && !allCompleterIds.includes(id)) {
 				completerMembers.push(guildMember);
+				allCompleterIds.push(guildMember.id);
 			}
 		}
 

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -21,30 +21,30 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		}
 
 		const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
-		const allCompleterIds = completions.map(reciept => reciept.userId);
-		const completerMembers = (await interaction.guild.members.fetch({ user: allCompleterIds })).values();
-		for (const optionalHunter of ["first-bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
-			const guildMember = interaction.options.getMember(optionalHunter);
-			if (guildMember?.id !== interaction.user.id && !allCompleterIds.includes(id)) {
-				completerMembers.push(guildMember);
-				allCompleterIds.push(guildMember.id);
+		const hunterCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
+		for (const optionKey of ["first-bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
+			const guildMember = interaction.options.getMember(optionKey);
+			if (guildMember) {
+				if (guildMember?.id !== interaction.user.id && !hunterCollection.has(guildMember.id)) {
+					hunterCollection.set(guildMember.id, guildMember);
+				}
 			}
 		}
 
-		const validatedCompleterIds = [];
+		const validatedHunterIds = [];
 		const validatedHunters = [];
-		for (const member of completerMembers) {
+		for (const member of hunterCollection.values()) {
 			if (runMode !== "production" || !member.user.bot) {
 				const memberId = member.id;
 				const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
 				if (!hunter.isBanned) {
-					validatedCompleterIds.push(memberId);
+					validatedHunterIds.push(memberId);
 					validatedHunters.push(hunter);
 				}
 			}
 		}
 
-		if (validatedCompleterIds.length < 1) {
+		if (validatedHunterIds.length < 1) {
 			interaction.reply({ content: `No bounty hunters have turn-ins recorded for this bounty. If you'd like to close your bounty without distributng rewards, use ${commandMention("bounty take-down")}.`, flags: [MessageFlags.Ephemeral] })
 			return;
 		}
@@ -61,7 +61,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		}
 		const rankUpdates = await getRankUpdates(interaction.guild, logicLayer);
 		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
-		const content = Bounty.generateRewardString(validatedCompleterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts);
+		const content = Bounty.generateRewardString(validatedHunterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts);
 
 		bounty.embed(interaction.guild, poster.getLevel(company.xpCoefficient), true, company.getThumbnailURLMap(), company.festivalMultiplierString(), completions).then(async embed => {
 			if (goalUpdate.gpContributed > 0) {
@@ -117,31 +117,31 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		required: true
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "first-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "second-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "third-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fourth-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fifth-bounty-hunter",
 		description: "A bounty hunter who completed the bounty",
 		required: false

--- a/source/commands/bounty/complete.js
+++ b/source/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
 const { Bounty } = require("../../models/bounties/Bounty");
-const { extractUserIdsFromMentions, timeConversion, commandMention, generateTextBar } = require("../../util/textUtil");
+const { timeConversion, commandMention, generateTextBar } = require("../../util/textUtil");
 const { getRankUpdates } = require("../../util/scoreUtil");
 const { Goal } = require("../../models/companies/Goal");
 const { SubcommandWrapper } = require("../../classes");
@@ -22,16 +22,14 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 
 		const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
 		const allCompleterIds = completions.map(reciept => reciept.userId);
-		const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
-		const completerIdsWithoutReciept = [];
-		for (const id of mentionedIds) {
-			if (!allCompleterIds.includes(id)) {
-				allCompleterIds.push(id);
-				completerIdsWithoutReciept.push(id);
+		const completerMembers = (await interaction.guild.members.fetch({ user: allCompleterIds })).values();
+		for (const optionalHunter of ["first-bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
+			const guildMember = interaction.options.getMember(optionalHunter);
+			if (guildMember?.id !== interaction.user.id && !allCompleterIds.includes(id)) {
+				completerMembers.push(guildMember);
 			}
 		}
 
-		const completerMembers = allCompleterIds.length > 0 ? (await interaction.guild.members.fetch({ user: allCompleterIds })).values() : [];
 		const validatedCompleterIds = [];
 		const validatedHunters = [];
 		for (const member of completerMembers) {
@@ -114,13 +112,37 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 	{
 		type: "Integer",
 		name: "bounty-slot",
-		description: "The slot number of the bounty to complete",
+		description: "The slot number of your bounty",
 		required: true
 	},
 	{
 		type: "String",
-		name: "hunters",
-		description: "The bounty hunter(s) to credit with completion",
+		name: "first-bounty-hunter",
+		description: "A bounty hunter who completed this bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "second-bounty-hunter",
+		description: "A bounty hunter who completed this bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "third-bounty-hunter",
+		description: "A bounty hunter who completed this bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fourth-bounty-hunter",
+		description: "A bounty hunter who completed this bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fifth-bounty-hunter",
+		description: "A bounty hunter who completed this bounty",
 		required: false
 	}
 );


### PR DESCRIPTION
Summary
-------
- switch `/bounty complete` option from String to User
- refactor initial member collection to use Collection instead of two Arrays
   - Collection uses Map's key-based `.has()`, so it should be as performant as an Array and a Set

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty complete` resolves when not given hunter options
- [x] `/bounty complete` credits hunters given by hunter options

Issue
-----
Closes #467