### PR TITLE
#468: switch `/bounty remove-completers` hunter options from String to User

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering.
 - `/toast` now accepts 1 required toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
+- `/bounty remove-completers` has been renamed to `/bounty revoke-turn-in` and now requires 1 hunter and up to 4 optional ones.
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts

--- a/source/commands/bounty/index.js
+++ b/source/commands/bounty/index.js
@@ -12,7 +12,7 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"swap.js",
 	"showcase.js",
 	"addcompleters.js",
-	"removecompleters.js",
+	"revoke-turn-in.js",
 	"complete.js",
 	"takedown.js",
 	"list.js"

--- a/source/commands/bounty/removecompleters.js
+++ b/source/commands/bounty/removecompleters.js
@@ -1,5 +1,5 @@
 const { MessageFlags, userMention } = require("discord.js");
-const { extractUserIdsFromMentions, listifyEN } = require("../../util/textUtil");
+const { listifyEN } = require("../../util/textUtil");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("remove-completers", "Remove hunter(s) from a bounty's list of completers",
@@ -11,37 +11,63 @@ module.exports = new SubcommandWrapper("remove-completers", "Remove hunter(s) fr
 				return;
 			}
 
-			const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
-			if (mentionedIds.length < 1) {
-				interaction.reply({ content: "Could not find any user mentions in `hunters`.", flags: [MessageFlags.Ephemeral] });
-				return;
+			const hunterIds = [];
+			for (const potentialHunter of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
+				const guildMember = interaction.options.getMember(potentialHunter);
+				if (guildMember) {
+					hunterIds.push(guildMember.id);
+				}
 			}
 
-			logicLayer.bounties.deleteSelectedBountyCompletions(bounty.id, mentionedIds);
+			logicLayer.bounties.deleteSelectedBountyCompletions(bounty.id, hunterIds);
 			const company = await logicLayer.companies.findCompanyByPK(interaction.guildId);
 			bounty.updatePosting(interaction.guild, company, (await logicLayer.hunters.findOneHunter(posterId, interaction.guild.id)).level, await logicLayer.bounties.findBountyCompletions(bounty.id));
 			if (company.bountyBoardId) {
 				interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 					return bountyBoard.threads.fetch(bounty.postingId);
 				}).then(posting => {
-					posting.send({ content: `${listifyEN(mentionedIds.map(id => `<@${id}>`))} ${mentionedIds.length === 1 ? "has" : "have"} been removed as ${mentionedIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
+					posting.send({ content: `${listifyEN(hunterIds.map(id => `<@${id}>`))} ${hunterIds.length === 1 ? "has" : "have"} been removed as ${hunterIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
 				});
 			}
 
-			interaction.reply({ content: `The following bounty hunters have been removed as completers from **${bounty.title}**: ${listifyEN(mentionedIds.map(id => userMention(id)))}`, flags: [MessageFlags.Ephemeral] });
+			interaction.reply({ content: `The following bounty hunters have been removed as completers from **${bounty.title}**: ${listifyEN(hunterIds.map(id => userMention(id)))}`, flags: [MessageFlags.Ephemeral] });
 		})
 	}
 ).setOptions(
 	{
 		type: "Integer",
 		name: "bounty-slot",
-		description: "The slot number of the bounty from which to remove completers",
+		description: "The slot number of your bounty",
 		required: true
 	},
 	{
 		type: "String",
-		name: "hunters",
-		description: "The bounty hunter(s) to remove",
+		name: "bounty-hunter",
+		description: "A bounty hunter to uncredit",
 		required: true
+	},
+	{
+		type: "String",
+		name: "second-bounty-hunter",
+		description: "A bounty hunter to uncredit",
+		required: false
+	},
+	{
+		type: "String",
+		name: "third-bounty-hunter",
+		description: "A bounty hunter to uncredit",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fourth-bounty-hunter",
+		description: "A bounty hunter to uncredit",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fifth-bounty-hunter",
+		description: "A bounty hunter to uncredit",
+		required: false
 	}
 );

--- a/source/commands/bounty/revoke-turn-in.js
+++ b/source/commands/bounty/revoke-turn-in.js
@@ -1,8 +1,8 @@
-const { MessageFlags, userMention } = require("discord.js");
+const { MessageFlags, userMention, bold } = require("discord.js");
 const { listifyEN } = require("../../util/textUtil");
 const { SubcommandWrapper } = require("../../classes");
 
-module.exports = new SubcommandWrapper("remove-completers", "Remove hunter(s) from a bounty's list of completers",
+module.exports = new SubcommandWrapper("revoke-turn-in", "Revoke the turn-ins of up to 5 bounty hunters on one of your bounties",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer, posterId]) {
 		const slotNumber = interaction.options.getInteger("bounty-slot");
 		logicLayer.bounties.findBounty({ userId: posterId, companyId: interaction.guild.id, slotNumber }).then(async bounty => {
@@ -30,7 +30,7 @@ module.exports = new SubcommandWrapper("remove-completers", "Remove hunter(s) fr
 				});
 			}
 
-			interaction.reply({ content: `The following bounty hunters have been removed as completers from **${bounty.title}**: ${listifyEN(hunterIds.map(id => userMention(id)))}`, flags: [MessageFlags.Ephemeral] });
+			interaction.reply({ content: `The bounty hunters' turn-ins of ${bold(bounty.title)} have been revoked: ${listifyEN(hunterIds.map(id => userMention(id)))}`, flags: [MessageFlags.Ephemeral] });
 		})
 	}
 ).setOptions(

--- a/source/commands/bounty/revoke-turn-in.js
+++ b/source/commands/bounty/revoke-turn-in.js
@@ -41,31 +41,31 @@ module.exports = new SubcommandWrapper("revoke-turn-in", "Revoke the turn-ins of
 		required: true
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "bounty-hunter",
 		description: "A bounty hunter to uncredit",
 		required: true
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "second-bounty-hunter",
 		description: "A bounty hunter to uncredit",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "third-bounty-hunter",
 		description: "A bounty hunter to uncredit",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fourth-bounty-hunter",
 		description: "A bounty hunter to uncredit",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fifth-bounty-hunter",
 		description: "A bounty hunter to uncredit",
 		required: false

--- a/source/commands/bounty/revoke-turn-in.js
+++ b/source/commands/bounty/revoke-turn-in.js
@@ -26,7 +26,7 @@ module.exports = new SubcommandWrapper("revoke-turn-in", "Revoke the turn-ins of
 				interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
 					return bountyBoard.threads.fetch(bounty.postingId);
 				}).then(posting => {
-					posting.send({ content: `${listifyEN(hunterIds.map(id => `<@${id}>`))} ${hunterIds.length === 1 ? "has" : "have"} been removed as ${hunterIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
+					posting.send({ content: `${listifyEN(hunterIds.map(id => `<@${id}>`))} ${hunterIds.length === 1 ? "has had their turn-in" : "have had their turn-ins"} revoked.` });
 				});
 			}
 

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -125,31 +125,31 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 	{
 		type: "User",
 		name: "toastee",
-		description: "The first bounty hunter to whom you are raising a toast",
+		description: "A bounty hunter you are toasting to",
 		required: true
 	},
 	{
 		type: "User",
 		name: "second-toastee",
-		description: "The second bounty hunter to whom you are raising a toast",
+		description: "A bounty hunter you are toasting to",
 		required: false
 	},
 	{
 		type: "User",
 		name: "third-toastee",
-		description: "The third bounty hunter to whom you are raising a toast",
+		description: "A bounty hunter you are toasting to",
 		required: false
 	},
 	{
 		type: "User",
 		name: "fourth-toastee",
-		description: "The fourth bounty hunter to whom you are raising a toast",
+		description: "A bounty hunter you are toasting to",
 		required: false
 	},
 	{
 		type: "User",
 		name: "fifth-toastee",
-		description: "The fifth bounty hunter to whom you are raising a toast",
+		description: "A bounty hunter you are toasting to",
 		required: false
 	},
 	{

--- a/source/models/bounties/Bounty.js
+++ b/source/models/bounties/Bounty.js
@@ -55,9 +55,9 @@ class Bounty extends Model {
 			const uniqueCompleters = new Set(completions.map(reciept => reciept.userId));
 			const completersFieldText = listifyEN([...uniqueCompleters].map(id => userMention(id)));
 			if (completersFieldText.length <= MAX_EMBED_FIELD_VALUE_LENGTH) {
-				fields.push({ name: "Completers", value: completersFieldText });
+				fields.push({ name: "Turned in by:", value: completersFieldText });
 			} else {
-				fields.push({ name: "Completers", value: "Too many to display!" });
+				fields.push({ name: "Turned in by:", value: "Too many to display!" });
 			}
 		}
 


### PR DESCRIPTION
Summary
-------
- switch `/bounty remove-completers` option from String to User
- reduce wordiness in `/toast` option descriptions
- rename to `/bounty revoke-turn-in`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty revoke-turn-in` removes hunters from the bounty, who aren't credited on completion

Issue
-----
Closes #468