### PR TITLE
#469: switch `/evergreen complete` hunter options from String to User

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering.
 - `/toast` now accepts 1 required toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
+- `/evergreen complete` now requires 1 hunter and up to 4 optional ones. Duplicate hunters are now accepted in case the hunter has multiple turn-ins to be awarded for.
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -18,8 +18,10 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 		const hunterMembers = [];
 		for (const potentialHunter of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(potentialHunter);
-			if (runMode !== "production" || !guildMember.user.bot) {
-				hunterMembers.push(guildMember);
+			if (guildMember) {
+				if (runMode !== "production" || !guildMember.user.bot) {
+					hunterMembers.push(guildMember);
+				}
 			}
 		}
 

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -1,11 +1,11 @@
 const { MessageFlags } = require("discord.js");
 const { Bounty } = require("../../models/bounties/Bounty");
 const { getRankUpdates } = require("../../util/scoreUtil");
-const { extractUserIdsFromMentions, generateTextBar } = require("../../util/textUtil");
+const { generateTextBar } = require("../../util/textUtil");
 const { Goal } = require("../../models/companies/Goal");
 const { SubcommandWrapper } = require("../../classes");
 
-module.exports = new SubcommandWrapper("complete", "Awarding XP to a hunter for completing an evergreen bounty",
+module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-ins of an evergreen bounty",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
 		const slotNumber = interaction.options.getInteger("bounty-slot");
 		const bounty = await logicLayer.bounties.findOneEvergreenBounty(interaction.guild.id, slotNumber);
@@ -15,31 +15,15 @@ module.exports = new SubcommandWrapper("complete", "Awarding XP to a hunter for 
 		}
 
 		const company = await logicLayer.companies.findCompanyByPK(interaction.guild.id);
-
-		const mentionedIds = extractUserIdsFromMentions(interaction.options.getString("hunters"), []);
-		if (mentionedIds.length < 1) {
-			interaction.reply({ content: "Could not find any bounty hunter ids in `hunters`.", flags: [MessageFlags.Ephemeral] })
-			return;
-		}
-
-		const dedupedCompleterIds = [];
-		for (const id of mentionedIds) {
-			if (!dedupedCompleterIds.includes(id)) {
-				dedupedCompleterIds.push(id);
+		const hunterMembers = [];
+		for (const potentialHunter of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
+			const guildMember = interaction.options.getMember(potentialHunter);
+			if (runMode !== "production" || !(guildMember?.id !== interaction.user.id && !guildMember.user.bot)) {
+				hunterMembers.push(guildMember);
 			}
 		}
 
-		const validatedCompleterIds = [];
-		for (const member of (await interaction.guild.members.fetch({ user: dedupedCompleterIds })).values()) {
-			if (runMode !== "production" || !member.user.bot) {
-				const memberId = member.id;
-				const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
-				if (!hunter.isBanned) {
-					validatedCompleterIds.push(memberId);
-				}
-			}
-		}
-
+		const validatedCompleterIds = hunterMembers.map(member => member.id);
 		if (validatedCompleterIds.length < 1) {
 			interaction.reply({ content: "There aren't any eligible bounty hunters to credit with completing this evergreen bounty.", flags: [MessageFlags.Ephemeral] })
 			return;
@@ -104,13 +88,37 @@ module.exports = new SubcommandWrapper("complete", "Awarding XP to a hunter for 
 	{
 		type: "Integer",
 		name: "bounty-slot",
-		description: "The slot number of the bounty to complete",
+		description: "The slot number of the bounty",
 		required: true
 	},
 	{
 		type: "String",
-		name: "hunters",
-		description: "The bounty hunter(s) to credit with completion",
+		name: "bounty-hunter",
+		description: "A bounty hunter who turned in the bounty",
 		required: true
+	},
+	{
+		type: "String",
+		name: "second-bounty-hunter",
+		description: "A bounty hunter who turned in the bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "third-bounty-hunter",
+		description: "A bounty hunter who turned in the bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fourth-bounty-hunter",
+		description: "A bounty hunter who turned in the bounty",
+		required: false
+	},
+	{
+		type: "String",
+		name: "fifth-bounty-hunter",
+		description: "A bounty hunter who turned in the bounty",
+		required: false
 	}
 );

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -18,14 +18,14 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 		const hunterMembers = [];
 		for (const potentialHunter of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
 			const guildMember = interaction.options.getMember(potentialHunter);
-			if (runMode !== "production" || !(guildMember?.id !== interaction.user.id && !guildMember.user.bot)) {
+			if (runMode !== "production" || !guildMember.user.bot) {
 				hunterMembers.push(guildMember);
 			}
 		}
 
 		const validatedCompleterIds = hunterMembers.map(member => member.id);
 		if (validatedCompleterIds.length < 1) {
-			interaction.reply({ content: "There aren't any eligible bounty hunters to credit with completing this evergreen bounty.", flags: [MessageFlags.Ephemeral] })
+			interaction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: [MessageFlags.Ephemeral] })
 			return;
 		}
 

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -116,31 +116,31 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 		required: true
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: true
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "second-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "third-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fourth-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false
 	},
 	{
-		type: "String",
+		type: "User",
 		name: "fifth-bounty-hunter",
 		description: "A bounty hunter who turned in the bounty",
 		required: false

--- a/source/commands/evergreen/complete.js
+++ b/source/commands/evergreen/complete.js
@@ -33,20 +33,17 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 
 		const season = await logicLayer.seasons.incrementSeasonStat(interaction.guild.id, "bountiesCompleted");
 
-		const rawCompletions = [];
 		// Evergreen bounties are not eligible for showcase bonuses
 		const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
 		const previousCompanyLevel = company.getLevel(allHunters);
 		const bountyBaseValue = Bounty.calculateCompleterReward(company.getLevel(allHunters), slotNumber, 0);
 		const bountyValue = bountyBaseValue * company.festivalMultiplier;
-		for (const userId of dedupedCompleterIds) {
-			rawCompletions.push({
-				bountyId: bounty.id,
-				userId,
-				companyId: interaction.guildId,
-				xpAwarded: bountyValue
-			});
-		}
+		const rawCompletions = validatedCompleterIds.map(userId => ({
+			bountyId: bounty.id,
+			userId,
+			companyId: interaction.guildId,
+			xpAwarded: bountyValue
+		}));
 		const completions = await logicLayer.bounties.bulkCreateCompletions(rawCompletions);
 
 		const levelTexts = [];

--- a/source/util/textUtil.js
+++ b/source/util/textUtil.js
@@ -156,23 +156,6 @@ function dateInFuture(timeMap) {
 	return new Date(nowTimestamp);
 }
 
-/** Extracting user ids from mentions in a string allows us to accept an arbitrary number of users from a single string input
- * @param {string} mentionsText
- * @param {string[]} excludedIds
- */
-function extractUserIdsFromMentions(mentionsText, excludedIds) {
-	const idRegExp = RegExp(/<@(\d+)>/, "g");
-	const ids = [];
-	let results;
-	while ((results = idRegExp.exec(mentionsText)) != null) {
-		const id = results[1];
-		if (!excludedIds.includes(id)) {
-			ids.push(id);
-		}
-	}
-	return ids;
-}
-
 /** Simulate auto mod actions for texts input to BountyBot
  * @param {TextChannel} channel
  * @param {GuildMember} member
@@ -276,7 +259,6 @@ module.exports = {
 	timeConversion,
 	dateInPast,
 	dateInFuture,
-	extractUserIdsFromMentions,
 	textsHaveAutoModInfraction,
 	listifyEN,
 	trimForSelectOptionDescription,


### PR DESCRIPTION
Summary
-------
- switch `/evergreen complete` `hunters` option from String to User
- remove deduplication from hunter list to allow awarding for multiple turn-ins in same command

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/evergreen complete` still resolves with only required hunter
- [x] `/evergreen complete` still resolves with an optional hunter

Issue
-----
Closes #469