### PR TITLE
avoid duplicating toastees

### DIFF
--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -39,7 +39,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		let bannedText;
 		if (bannedIds.size > 1) {
 			bannedText = `${listifyEN([...bannedIds.values()].map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
-		} else if (bannedIds.length === 1) {
+		} else if (bannedIds.size === 1) {
 			bannedText = `${userMention(bannedIds.values().next().value)} was skipped because they're banned from using BountyBot on this server.`;
 		}
 		if (validatedToasteeIds.size < 1) {

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -30,7 +30,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 			if (guildMember) {
 				if (hunterMap[guildMember.id]?.isBanned) {
 					bannedIds.push(guildMember.id);
-				} else if (runMode !== "production" || (!guildMember.user.bot && guildMember.user.id !== interaction.user.id)) {
+				} else if (runMode !== "production" || (!guildMember.user.bot && guildMember.user.id !== interaction.user.id && !validatedToasteeIds.includes(guildMember.id))) {
 					validatedToasteeIds.push(guildMember.id);
 				}
 			}

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -23,26 +23,26 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		const errors = [];
 
 		// Find valid toastees
-		const bannedIds = [];
-		const validatedToasteeIds = [];
+		const bannedIds = new Set();
+		const validatedToasteeIds = new Set();
 		for (const optionalToastee of ["toastee", "second-toastee", "third-toastee", "fourth-toastee", "fifth-toastee"]) {
 			const guildMember = interaction.options.getMember(optionalToastee);
 			if (guildMember) {
 				if (hunterMap[guildMember.id]?.isBanned) {
-					bannedIds.push(guildMember.id);
-				} else if (runMode !== "production" || (!guildMember.user.bot && guildMember.user.id !== interaction.user.id && !validatedToasteeIds.includes(guildMember.id))) {
-					validatedToasteeIds.push(guildMember.id);
+					bannedIds.add(guildMember.id);
+				} else if (runMode !== "production" || (!guildMember.user.bot && guildMember.user.id !== interaction.user.id)) {
+					validatedToasteeIds.add(guildMember.id);
 				}
 			}
 		}
 
 		let bannedText;
-		if (bannedIds.length > 1) {
-			bannedText = ` ${listifyEN(bannedIds.map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
+		if (bannedIds.size > 1) {
+			bannedText = ` ${listifyEN([...bannedIds.values()].map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
 		} else if (bannedIds.length === 1) {
-			bannedText = ` ${userMention(bannedIds[0])} was skipped because they're banned from using BountyBot on this server.`;
+			bannedText = ` ${userMention(bannedIds.values().next().value)} was skipped because they're banned from using BountyBot on this server.`;
 		}
-		if (validatedToasteeIds.length < 1) {
+		if (validatedToasteeIds.size < 1) {
 			errors.push(`No valid toastees received. You cannot raise a toast to yourself or a bot.${bannedText ?? ""}`);
 		}
 

--- a/source/commands/toast.js
+++ b/source/commands/toast.js
@@ -38,12 +38,16 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 
 		let bannedText;
 		if (bannedIds.size > 1) {
-			bannedText = ` ${listifyEN([...bannedIds.values()].map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
+			bannedText = `${listifyEN([...bannedIds.values()].map(id => userMention(id)))} were skipped because they're banned from using BountyBot on this server.`;
 		} else if (bannedIds.length === 1) {
-			bannedText = ` ${userMention(bannedIds.values().next().value)} was skipped because they're banned from using BountyBot on this server.`;
+			bannedText = `${userMention(bannedIds.values().next().value)} was skipped because they're banned from using BountyBot on this server.`;
 		}
 		if (validatedToasteeIds.size < 1) {
-			errors.push(`No valid toastees received. You cannot raise a toast to yourself or a bot.${bannedText ?? ""}`);
+			const sentences = ["No valid toastees received. You cannot raise a toast to yourself or a bot."];
+			if (bannedText) {
+				sentences.push(bannedText);
+			}
+			errors.push(sentences.join(" "));
 		}
 
 		// Validate image-url is a URL
@@ -97,6 +101,9 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 			components: [Toast.generateSecondingActionRow(toastId)],
 			withResponse: true
 		}).then(async response => {
+			if (bannedText) {
+				interaction.followUp({ content: bannedText, flags: [MessageFlags.Ephemeral] });
+			}
 			let content = "";
 			if (rewardedHunterIds.length > 0) {
 				const rankUpdates = await getRankUpdates(interaction.guild, logicLayer);

--- a/source/context_menus/Raise_a_Toast.js
+++ b/source/context_menus/Raise_a_Toast.js
@@ -57,7 +57,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			const season = await logicLayer.seasons.incrementSeasonStat(modalSubmission.guild.id, "toastsRaised");
 
 			const { toastId, rewardedHunterIds, rewardTexts, critValue } = await logicLayer.toasts.raiseToast(modalSubmission.guild, company, modalSubmission.member, sender, [interaction.targetId], season.id, toastText);
-			const embeds = [Toast.generateEmbed(company.toastThumbnailURL, toastText, [interaction.targetId], modalSubmission.member)];
+			const embeds = [Toast.generateEmbed(company.toastThumbnailURL, toastText, new Set([interaction.targetId]), modalSubmission.member)];
 
 			if (rewardedHunterIds.length > 0) {
 				const goalUpdate = await logicLayer.goals.progressGoal(modalSubmission.guild.id, "toasts", sender, season);

--- a/source/models/toasts/Toast.js
+++ b/source/models/toasts/Toast.js
@@ -23,14 +23,14 @@ class Toast extends Model {
 	/**
 	 * @param {string?} thumbnailURL
 	 * @param {string} toastText
-	 * @param {string[]} recipientIds
+	 * @param {Set<string>} recipientIdSet
 	 * @param {GuildMember} senderMember
 	 */
-	static generateEmbed(thumbnailURL, toastText, recipientIds, senderMember) {
+	static generateEmbed(thumbnailURL, toastText, recipientIdSet, senderMember) {
 		return new EmbedBuilder().setColor("e5b271")
 			.setThumbnail(thumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
 			.setTitle(toastText)
-			.setDescription(`A toast to ${listifyEN(recipientIds.map(id => userMention(id)))}!`)
+			.setDescription(`A toast to ${listifyEN([...recipientIdSet.values()].map(id => userMention(id)))}!`)
 			.setFooter({ text: senderMember.displayName, iconURL: senderMember.user.avatarURL() });
 	}
 


### PR DESCRIPTION
Summary
-------
- `/toast` filters out duplicate toastees
- `/toast` provides a followup on successful toasts if any toastees were banned

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/toast` filters out duplicate toastees
- [x] `/toast` provides a followup on successful toasts if any toastees were banned