### PR TITLE
#484: switch `/bounty revoke-turn-in` input to in-message selects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,9 +3,9 @@
 ### User Options in Slash Commands
 Slash commands originally accepted users as a string (instead of Discord's user filtering) to allow users to mention as many users as they wanted. However, this doesn't work on mobile, so those slash commands have been remade to use Discord's user filtering or message selects.
 - `/toast` now requires 1 toastee and up to 4 optional ones. The `message` option has been changed to the first option to group the toastee options.
-- `/bounty add-completers` has been renamed to `/bounty verify-turn-in`. It receives both its bounty and hunter inputs from message selects.
+- `/bounty add-completers` has been renamed to `/bounty verify-turn-in` and now uses message selects.
+- `/bounty remove-completers` has been renamed to `/bounty revoke-turn-in` and now uses message selects.
 - `/bounty complete` now accepts up to 5 optional hunters.
-- `/bounty remove-completers` has been renamed to `/bounty revoke-turn-in` and now requires 1 hunter and up to 4 optional ones.
 - `/evergreen complete` now requires 1 hunter and up to 4 optional ones. Duplicate hunters are now accepted in case the hunter has multiple turn-ins to be awarded for.
 ### Premium
 - Added the ability to customize the Goal Completion embed's thumbnail with `/config-premium goal-completion-thumbnail-url`

--- a/source/frontend/commands/bounty/showcase.js
+++ b/source/frontend/commands/bounty/showcase.js
@@ -56,7 +56,7 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for one of yo
 			const completions = await logicLayer.bounties.findBountyCompletions(collectedInteraction.values[0]);
 			const currentPosterLevel = poster.getLevel(company.xpCoefficient);
 			updatePosting(collectedInteraction.guild, company, bounty, currentPosterLevel, completions);
-			return buildBountyEmbed(bounty, collectedInteraction.guild, currentPosterLevel, false, company.getThumbnailURLMap(), company.festivalMultiplierString(), completions).then(async embed => {
+			return buildBountyEmbed(bounty, collectedInteraction.guild, currentPosterLevel, false, company, completions).then(async embed => {
 				if (interaction.channel.archived) {
 					await interaction.channel.setArchived(false, "bounty showcased");
 				}

--- a/source/frontend/commands/bounty/verify-turn-in.js
+++ b/source/frontend/commands/bounty/verify-turn-in.js
@@ -1,7 +1,6 @@
 const { userMention, bold, MessageFlags, ActionRowBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder } = require("discord.js");
-const { SelectMenuLimits } = require("@sapphire/discord.js-utilities");
 const { SubcommandWrapper } = require("../../classes");
-const { listifyEN, commandMention, updatePosting, congratulationBuilder, truncateTextToLength, disabledSelectRow } = require("../../shared");
+const { listifyEN, commandMention, updatePosting, congratulationBuilder, disabledSelectRow, bountiesToSelectOptions } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../../constants");
 
@@ -13,20 +12,13 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 			return;
 		}
 
-		const options = openBounties.map(bounty => {
-			const option = { label: bounty.title, value: bounty.id };
-			if (bounty.description) {
-				option.description = truncateTextToLength(bounty.description, SelectMenuLimits.MaximumLengthOfDescriptionOfOption);
-			}
-			return option;
-		});
 		interaction.reply({
 			content: `Select one of your bounties and some bounty hunters who have turned it in. XP and drops will be distributed to those hunters when you use ${commandMention("bounty complete")}.`,
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}bounty`)
 						.setPlaceholder("Select a bounty...")
-						.addOptions(options)
+						.addOptions(bountiesToSelectOptions(openBounties))
 				),
 				new ActionRowBuilder().addComponents(
 					new UserSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
@@ -39,12 +31,12 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 		}).then(response => response.resource.message).then(message => {
 			const collector = message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms") });
 			let bounty;
-			collector.on("collect", async collectedInteration => {
-				const [_, stepId] = collectedInteration.customId.split(SAFE_DELIMITER);
+			collector.on("collect", async collectedInteraction => {
+				const [_, stepId] = collectedInteraction.customId.split(SAFE_DELIMITER);
 				switch (stepId) {
 					case "bounty":
-						bounty = openBounties.find(bounty => bounty.id === collectedInteration.values[0]);
-						collectedInteration.update({
+						bounty = openBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
+						collectedInteraction.update({
 							components: [
 								disabledSelectRow(bounty.title),
 								new ActionRowBuilder().addComponents(
@@ -57,8 +49,8 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 						break;
 					case "hunters":
 						try {
-							let { bounty: returnedBounty, allCompleters, company, validatedCompleterIds, bannedIds } = await logicLayer.bounties.addCompleters(bounty, interaction.guild, [...collectedInteration.members.values()], runMode);
-							const post = await updatePosting(collectedInteration.guild, company, returnedBounty, poster.getLevel(company.xpCoefficient), allCompleters);
+							let { bounty: returnedBounty, allCompleters, company, validatedCompleterIds, bannedIds } = await logicLayer.bounties.addCompleters(bounty, interaction.guild, [...collectedInteraction.members.values()], runMode);
+							const post = await updatePosting(collectedInteraction.guild, company, returnedBounty, poster.getLevel(company.xpCoefficient), allCompleters);
 							const sentences = [];
 							if (validatedCompleterIds.length > 0) {
 								sentences.push(`The following bounty hunters' turn-ins of ${bold(returnedBounty.title)} have been recorded: ${listifyEN(validatedCompleterIds.map(id => userMention(id)))}`);
@@ -69,7 +61,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 							if (bannedIds.length > 0) {
 								sentences.push(`The following users were skipped due to currently being banned from using BountyBot: ${listifyEN(bannedIds.map(id => userMention(id)))}`);
 							}
-							collectedInteration.update({
+							collectedInteraction.update({
 								content: sentences.join("\n\n"),
 								components: []
 							});
@@ -77,7 +69,7 @@ module.exports = new SubcommandWrapper("verify-turn-in", "Verify up to 5 bounty 
 							if (typeof e !== 'string') {
 								console.error(e);
 							} else {
-								collectedInteration.update({ content: e, components: [] });
+								collectedInteraction.update({ content: e, components: [] });
 							}
 							return;
 						}

--- a/source/frontend/commands/rank/remove.js
+++ b/source/frontend/commands/rank/remove.js
@@ -4,7 +4,7 @@ const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { rankArrayToSelectOptions, listifyEN, getRankUpdates, disabledSelectRow } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 
-module.exports = new SubcommandWrapper("remove", "Remove an existing seasonal rank",
+module.exports = new SubcommandWrapper("remove", "Remove one or more existing seasonal ranks",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		const guildRoles = await interaction.guild.roles.fetch();

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -123,7 +123,7 @@ async function updatePosting(guild, company, bounty, posterLevel, completions) {
 		thread.edit({ name: bounty.title });
 		return thread.fetchStarterMessage();
 	}).then(async posting => {
-		return buildBountyEmbed(bounty, guild, posterLevel, false, company.getThumbnailURLMap(), company.festivalMultiplierString(), completions).then(embed => {
+		return buildBountyEmbed(bounty, guild, posterLevel, false, company, completions).then(embed => {
 			posting.edit({
 				embeds: [embed],
 				components: generateBountyBoardButtons(bounty)

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -1,6 +1,6 @@
 const { CommandInteraction, GuildTextThreadManager, EmbedBuilder, Guild, ActionRowBuilder, StringSelectMenuBuilder, Collection, Role } = require("discord.js");
 const { SubcommandWrapper } = require("../classes");
-const { Bounty, Company, Rank } = require("../../database/models");
+const { Bounty, Company, Rank, Completion } = require("../../database/models");
 const { getNumberEmoji, buildBountyEmbed, generateBountyBoardButtons } = require("./messageParts");
 const { SelectMenuLimits, MessageLimits } = require("@sapphire/discord.js-utilities");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");


### PR DESCRIPTION
Summary
-------
- switch `/bounty revoke-turn-in` input to in-message selects
- use `bountiesToSelectOptions()` in `/bounty verify-turn-in`
- fix outdated arguments in `buildBountyEmbed()`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty revoke turn-in` removes Completions for provided users or does nothing if no Completion found
- [x] `/bounty revoke turn-in` works for bounties on a bounty board

Issue
-----
Closes #484 