### PR TITLE
#492 & #493: switch `/evergreen complete` input to in-message selects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,13 +6,13 @@ Slash commands originally accepted users as a string (instead of Discord's user 
 - `/bounty add-completers` has been renamed to `/bounty verify-turn-in`. It receives both its bounty and hunter inputs from message selects.
 - `/bounty complete` now accepts up to 5 optional hunters.
 - `/bounty remove-completers` has been renamed to `/bounty revoke-turn-in` and now requires 1 hunter and up to 4 optional ones.
-- `/evergreen complete` now requires 1 hunter and up to 4 optional ones. Duplicate hunters are now accepted in case the hunter has multiple turn-ins to be awarded for.
+- `/evergreen complete` now uses message selects.
 ### Premium
 - Added the ability to customize the Goal Completion embed's thumbnail with `/config-premium goal-completion-thumbnail-url`
 - Changed `/rank remove` to use a select and confirmation button and accept multiple roles at the same time
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
-- Fixed BountyBot banned users being able to receive toasts
+- Fixed BountyBot banned users being able to receive toasts and credit for evergreen bounties
 
 ## BountyBot Version 2.9.0:
 ### Server Goals

--- a/source/frontend/buttons/secondtoast.js
+++ b/source/frontend/buttons/secondtoast.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder, MessageFlags } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
-const { getRankUpdates, generateTextBar, buildCompanyLevelUpLine, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, buildHunterLevelUpLine, generateCompletionEmbed, generateSecondingRewardString } = require('../shared');
+const { getRankUpdates, generateTextBar, buildCompanyLevelUpLine, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, buildHunterLevelUpLine, generateCompletionEmbed, generateSecondingRewardString, sendToRewardsThread } = require('../shared');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -122,16 +122,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		}
 		interaction.update({ embeds: [embed] });
 		getRankUpdates(interaction.guild, logicLayer).then(async rankUpdates => {
-			const content = generateSecondingRewardString(interaction.member.displayName, recipientIds, rankUpdates, rewardTexts);
-			if (interaction.channel.isThread()) {
-				interaction.channel.send({ content, flags: MessageFlags.SuppressNotifications });
-			} else if (interaction.message.thread !== null) {
-				interaction.message.thread.send({ content, flags: MessageFlags.SuppressNotifications });
-			} else {
-				interaction.message.startThread({ name: "Rewards" }).then(thread => {
-					thread.send({ content, flags: MessageFlags.SuppressNotifications });
-				})
-			}
+			sendToRewardsThread(interaction.message, generateSecondingRewardString(interaction.member.displayName, recipientIds, rankUpdates, rewardTexts), "Rewards");
 			const embeds = [];
 			const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 			const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed } = require("../../shared");
+const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, sendToRewardsThread } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
@@ -107,13 +107,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 			} else {
 				acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
 				interaction.editReply(acknowledgeOptions).then(message => {
-					if (interaction.channel.isThread()) {
-						interaction.channel.send({ content, flags: MessageFlags.SuppressNotifications });
-					} else {
-						message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
-							thread.send({ content, flags: MessageFlags.SuppressNotifications });
-						})
-					}
+					sendToRewardsThread(message, content, `${bounty.title} Rewards`);
 				})
 			}
 

--- a/source/frontend/commands/evergreen/complete.js
+++ b/source/frontend/commands/evergreen/complete.js
@@ -9,7 +9,7 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
 		const evergreenBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
 		if (evergreenBounties.length < 1) {
-			interaction.reply({ content: `This server doesn't currently have any evergreen bounties. Post one with ${commandMention("evergreen post")}?`, flags: [MessageFlags.Ephemeral] });
+			interaction.reply({ content: `This server doesn't currently have any evergreen bounties. Post one with ${commandMention("evergreen post")}?`, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
@@ -23,7 +23,7 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 				),
 				disabledSelectRow("Select bounty hunters...")
 			],
-			flags: [MessageFlags.Ephemeral],
+			flags: MessageFlags.Ephemeral,
 			withResponse: true
 		}).then(response => response.resource.message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms") })).then(collector => {
 			let bounty;
@@ -54,7 +54,7 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 						}
 
 						if (validatedHunterIds.length < 1) {
-							collectedInteraction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: [MessageFlags.Ephemeral] })
+							collectedInteraction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: MessageFlags.Ephemeral })
 							return;
 						}
 

--- a/source/frontend/commands/evergreen/complete.js
+++ b/source/frontend/commands/evergreen/complete.js
@@ -1,140 +1,136 @@
-const { MessageFlags } = require("discord.js");
+const { MessageFlags, ActionRowBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty } = require("../../../database/models");
-const { getRankUpdates, generateTextBar, buildBountyEmbed, generateBountyRewardString, buildCompanyLevelUpLine, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, buildHunterLevelUpLine, generateCompletionEmbed } = require("../../shared");
+const { getRankUpdates, generateTextBar, buildBountyEmbed, generateBountyRewardString, buildCompanyLevelUpLine, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, buildHunterLevelUpLine, generateCompletionEmbed, disabledSelectRow, bountiesToSelectOptions, sendToRewardsThread } = require("../../shared");
+const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../../constants");
+const { timeConversion } = require("../../../shared");
 
-module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-ins of an evergreen bounty",
+module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-ins of an evergreen bounty to up to 5 bounty hunters",
 	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
-		const slotNumber = interaction.options.getInteger("bounty-slot");
-		const bounty = await logicLayer.bounties.findOneEvergreenBounty(interaction.guild.id, slotNumber);
-		if (!bounty) {
-			interaction.reply({ content: "There isn't an evergreen bounty in the `bounty-slot` provided.", flags: [MessageFlags.Ephemeral] });
+		const evergreenBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
+		if (evergreenBounties.length < 1) {
+			interaction.reply({ content: `This server doesn't currently have any evergreen bounties. Post one with ${commandMention("evergreen post")}?`, flags: [MessageFlags.Ephemeral] });
 			return;
 		}
 
-		const company = await logicLayer.companies.findCompanyByPK(interaction.guild.id);
-		const hunterMembers = [];
-		for (const potentialHunter of ["bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
-			const guildMember = interaction.options.getMember(potentialHunter);
-			if (guildMember) {
-				if (runMode !== "production" || !guildMember.user.bot) {
-					hunterMembers.push(guildMember);
+		interaction.reply({
+			content: "Select an evergreen bounty and some bounty hunters to distribute its rewards to.",
+			components: [
+				new ActionRowBuilder().addComponents(
+					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}bounty`)
+						.setPlaceholder("Select bounty...")
+						.setOptions(bountiesToSelectOptions(evergreenBounties))
+				),
+				disabledSelectRow("Select bounty hunters...")
+			],
+			flags: [MessageFlags.Ephemeral],
+			withResponse: true
+		}).then(response => response.resource.message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms") })).then(collector => {
+			let bounty;
+			collector.on("collect", async collectedInteraction => {
+				const [_, stepId] = collectedInteraction.customId.split(SAFE_DELIMITER);
+				switch (stepId) {
+					case "bounty":
+						bounty = evergreenBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
+						collectedInteraction.update({
+							components: [
+								disabledSelectRow(`Selected Bounty: ${bounty.title}`),
+								new ActionRowBuilder().addComponents(
+									new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}hunters`)
+										.setPlaceholder("Select bounty hunters...")
+										.setMaxValues(5)
+								)
+							]
+						});
+						break;
+					case "hunters":
+						const company = await logicLayer.companies.findCompanyByPK(collectedInteraction.guild.id);
+						const validatedHunterIds = [];
+						for (const guildMember of collectedInteraction.members.values()) {
+							const hunter = await logicLayer.hunters.findOrCreateBountyHunter(guildMember.id, guildMember.guild.id);
+							if (runMode !== "production" || (!guildMember.user.bot && !hunter.isBanned)) {
+								validatedHunterIds.push(guildMember.id);
+							}
+						}
+
+						if (validatedHunterIds.length < 1) {
+							collectedInteraction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: [MessageFlags.Ephemeral] })
+							return;
+						}
+
+						const season = await logicLayer.seasons.incrementSeasonStat(collectedInteraction.guild.id, "bountiesCompleted");
+
+						// Evergreen bounties are not eligible for showcase bonuses
+						const allHunters = await logicLayer.hunters.findCompanyHunters(collectedInteraction.guild.id);
+						const previousCompanyLevel = company.getLevel(allHunters);
+						const bountyBaseValue = Bounty.calculateCompleterReward(company.getLevel(allHunters), bounty.slotNumber, 0);
+						const bountyValue = bountyBaseValue * company.festivalMultiplier;
+						const completions = await logicLayer.bounties.bulkCreateCompletions(bounty.id, collectedInteraction.guild.id, validatedHunterIds, bountyValue);
+
+						const levelTexts = [];
+						let totalGP = 0;
+						let wasGoalCompleted = false;
+						const finalContributorIds = new Set(validatedHunterIds);
+						for (const userId of validatedHunterIds) {
+							const hunter = await logicLayer.hunters.findOneHunter(userId, collectedInteraction.guild.id);
+							const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
+							await hunter.increment({ othersFinished: 1, xp: bountyValue }).then(hunter => hunter.reload());
+							const levelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
+							if (levelLine) {
+								levelTexts.push(levelLine);
+							}
+							logicLayer.seasons.changeSeasonXP(userId, collectedInteraction.guildId, season.id, bountyValue);
+							const { gpContributed, goalCompleted, contributorIds } = await logicLayer.goals.progressGoal(collectedInteraction.guildId, "bounties", hunter, season);
+							totalGP += gpContributed;
+							wasGoalCompleted ||= goalCompleted;
+							contributorIds.forEach(id => finalContributorIds.add(id));
+						}
+
+						const reloadedHunters = await Promise.all(allHunters.map(hunter => {
+							if (validatedHunterIds.includes(hunter.userId)) {
+								return hunter.reload();
+							} else {
+								return hunter;
+							}
+						}))
+						const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, collectedInteraction.guild.name);
+						if (companyLevelLine) {
+							levelTexts.push(companyLevelLine);
+						}
+						buildBountyEmbed(bounty, collectedInteraction.guild, company.getLevel(allHunters), true, company, completions).then(async embed => {
+							const announcementPayload = { embeds: [embed], withResponse: true };
+							if (totalGP > 0) {
+								levelTexts.push(`This bounty contributed ${totalGP} GP to the Server Goal!`);
+								const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(collectedInteraction.guildId);
+								if (goalId !== null) {
+									embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
+								} else {
+									embed.addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
+								}
+							}
+							if (wasGoalCompleted) {
+								announcementPayload.embeds.push(generateCompletionEmbed([...finalContributorIds.keys()]));
+							}
+							await collectedInteraction.update({ components: [] });
+							interaction.deleteReply();
+							return collectedInteraction.channel.send(announcementPayload);
+						}).then(message => {
+							getRankUpdates(collectedInteraction.guild, logicLayer).then(async rankUpdates => {
+								sendToRewardsThread(message, generateBountyRewardString(validatedHunterIds, bountyBaseValue, null, null, company.festivalMultiplierString(), rankUpdates, levelTexts), `${bounty.title} Rewards`);
+								const embeds = [];
+								const ranks = await logicLayer.ranks.findAllRanks(collectedInteraction.guild.id);
+								const goalProgress = await logicLayer.goals.findLatestGoalProgress(collectedInteraction.guild.id);
+								if (company.scoreboardIsSeasonal) {
+									embeds.push(await seasonalScoreboardEmbed(company, collectedInteraction.guild, await logicLayer.seasons.findSeasonParticipations(season.id), ranks, goalProgress));
+								} else {
+									embeds.push(await overallScoreboardEmbed(company, collectedInteraction.guild, await logicLayer.hunters.findCompanyHunters(collectedInteraction.guild.id), ranks, goalProgress));
+								}
+								updateScoreboard(company, collectedInteraction.guild, embeds);
+							});
+						})
+						break;
 				}
-			}
-		}
-
-		const validatedCompleterIds = hunterMembers.map(member => member.id);
-		if (validatedCompleterIds.length < 1) {
-			interaction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: [MessageFlags.Ephemeral] })
-			return;
-		}
-
-		const season = await logicLayer.seasons.incrementSeasonStat(interaction.guild.id, "bountiesCompleted");
-
-		// Evergreen bounties are not eligible for showcase bonuses
-		const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-		const previousCompanyLevel = company.getLevel(allHunters);
-		const bountyBaseValue = Bounty.calculateCompleterReward(company.getLevel(allHunters), slotNumber, 0);
-		const bountyValue = bountyBaseValue * company.festivalMultiplier;
-		const completions = await logicLayer.bounties.bulkCreateCompletions(bounty.id, interaction.guild.id, validatedCompleterIds, bountyValue);
-
-		const levelTexts = [];
-		let totalGP = 0;
-		let wasGoalCompleted = false;
-		const finalContributorIds = new Set(validatedCompleterIds);
-		for (const userId of validatedCompleterIds) {
-			const hunter = await logicLayer.hunters.findOneHunter(userId, interaction.guild.id);
-			const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
-			await hunter.increment({ othersFinished: 1, xp: bountyValue }).then(hunter => hunter.reload());
-			const levelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
-			if (levelLine) {
-				levelTexts.push(levelLine);
-			}
-			logicLayer.seasons.changeSeasonXP(userId, interaction.guildId, season.id, bountyValue);
-			const { gpContributed, goalCompleted, contributorIds } = await logicLayer.goals.progressGoal(interaction.guildId, "bounties", hunter, season);
-			totalGP += gpContributed;
-			wasGoalCompleted ||= goalCompleted;
-			contributorIds.forEach(id => finalContributorIds.add(id));
-		}
-
-		const reloadedHunters = await Promise.all(allHunters.map(hunter => {
-			if (validatedCompleterIds.includes(hunter.userId)) {
-				return hunter.reload();
-			} else {
-				return hunter;
-			}
-		}))
-		const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
-		if (companyLevelLine) {
-			levelTexts.push(companyLevelLine);
-		}
-		buildBountyEmbed(bounty, interaction.guild, company.getLevel(allHunters), true, company, completions).then(async embed => {
-			const acknowledgeOptions = { embeds: [embed], withResponse: true };
-			if (totalGP > 0) {
-				levelTexts.push(`This bounty contributed ${totalGP} GP to the Server Goal!`);
-				const { goalId, currentGP, requiredGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);
-				if (goalId !== null) {
-					embed.addFields({ name: "Server Goal", value: `${generateTextBar(currentGP, requiredGP, 15)} ${currentGP}/${requiredGP} GP` });
-				} else {
-					embed.addFields({ name: "Server Goal", value: `${generateTextBar(15, 15, 15)} Completed!` });
-				}
-			}
-			if (wasGoalCompleted) {
-				acknowledgeOptions.embeds.push(generateCompletionEmbed([...finalContributorIds.keys()]));
-			}
-			return interaction.reply(acknowledgeOptions);
-		}).then(response => {
-			getRankUpdates(interaction.guild, logicLayer).then(async rankUpdates => {
-				response.resource.message.startThread({ name: `${bounty.title} Rewards` }).then(thread => {
-					thread.send({ content: generateBountyRewardString(validatedCompleterIds, bountyBaseValue, null, null, company.festivalMultiplierString(), rankUpdates, levelTexts), flags: MessageFlags.SuppressNotifications });
-				})
-				const embeds = [];
-				const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-				const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-				if (company.scoreboardIsSeasonal) {
-					embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, await logicLayer.seasons.findSeasonParticipations(season.id), ranks, goalProgress));
-				} else {
-					embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), ranks, goalProgress));
-				}
-				updateScoreboard(company, interaction.guild, embeds);
-			});
+			})
 		})
-	}
-).setOptions(
-	{
-		type: "Integer",
-		name: "bounty-slot",
-		description: "The slot number of the bounty",
-		required: true
-	},
-	{
-		type: "User",
-		name: "bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: true
-	},
-	{
-		type: "User",
-		name: "second-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "third-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fourth-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fifth-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
 	}
 );

--- a/source/frontend/commands/evergreen/complete.js
+++ b/source/frontend/commands/evergreen/complete.js
@@ -36,13 +36,7 @@ module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-
 		const previousCompanyLevel = company.getLevel(allHunters);
 		const bountyBaseValue = Bounty.calculateCompleterReward(company.getLevel(allHunters), slotNumber, 0);
 		const bountyValue = bountyBaseValue * company.festivalMultiplier;
-		const rawCompletions = validatedCompleterIds.map(userId => ({
-			bountyId: bounty.id,
-			userId,
-			companyId: interaction.guildId,
-			xpAwarded: bountyValue
-		}));
-		const completions = await logicLayer.bounties.bulkCreateCompletions(rawCompletions);
+		const completions = await logicLayer.bounties.bulkCreateCompletions(bounty.id, interaction.guild.id, validatedCompleterIds, bountyValue);
 
 		const levelTexts = [];
 		let totalGP = 0;

--- a/source/frontend/commands/toast.js
+++ b/source/frontend/commands/toast.js
@@ -1,6 +1,6 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags, userMention } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { textsHaveAutoModInfraction, generateTextBar, listifyEN, getRankUpdates, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateToastEmbed, generateSecondingActionRow, generateToastRewardString, generateCompletionEmbed } = require('../shared');
+const { textsHaveAutoModInfraction, generateTextBar, listifyEN, getRankUpdates, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateToastEmbed, generateSecondingActionRow, generateToastRewardString, generateCompletionEmbed, sendToRewardsThread } = require('../shared');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -104,13 +104,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 			}
 
 			if (content) {
-				if (interaction.channel.isThread()) {
-					interaction.channel.send({ content, flags: MessageFlags.SuppressNotifications });
-				} else {
-					response.resource.message.startThread({ name: "Rewards" }).then(thread => {
-						thread.send({ content, flags: MessageFlags.SuppressNotifications });
-					})
-				}
+				sendToRewardsThread(response.resource.message, content, "Rewards");
 				const embeds = [];
 				const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 				const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);

--- a/source/frontend/context_menus/Raise_a_Toast.js
+++ b/source/frontend/context_menus/Raise_a_Toast.js
@@ -1,7 +1,7 @@
 const { InteractionContextType, PermissionFlagsBits, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, MessageFlags, userMention, DiscordjsErrorCodes } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { textsHaveAutoModInfraction, generateTextBar, getRankUpdates, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateToastEmbed, generateSecondingActionRow, generateToastRewardString, generateCompletionEmbed } = require('../shared');
+const { textsHaveAutoModInfraction, generateTextBar, getRankUpdates, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateToastEmbed, generateSecondingActionRow, generateToastRewardString, generateCompletionEmbed, sendToRewardsThread } = require('../shared');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -79,13 +79,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				}
 
 				if (content) {
-					if (modalSubmission.channel.isThread()) {
-						modalSubmission.channel.send({ content, flags: MessageFlags.SuppressNotifications });
-					} else {
-						response.resource.message.startThread({ name: "Rewards" }).then(thread => {
-							thread.send({ content, flags: MessageFlags.SuppressNotifications });
-						})
-					}
+					sendToRewardsThread(response.resource.message, content, "Rewards");
 					const embeds = [];
 					const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 					const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -1,4 +1,4 @@
-const { CommandInteraction, GuildTextThreadManager, EmbedBuilder, Guild, ActionRowBuilder, StringSelectMenuBuilder, Collection, Role } = require("discord.js");
+const { CommandInteraction, GuildTextThreadManager, EmbedBuilder, Guild, ActionRowBuilder, StringSelectMenuBuilder, Collection, Role, MessageFlags, Message } = require("discord.js");
 const { SubcommandWrapper } = require("../classes");
 const { Bounty, Company, Rank } = require("../../database/models");
 const { getNumberEmoji, buildBountyEmbed, generateBountyBoardButtons } = require("./messageParts");
@@ -158,6 +158,27 @@ function disabledSelectRow(placeholderText) {
 	)
 }
 
+/**
+ * @param {Message} embedMessage
+ * @param {string} content
+ * @param {string} threadTitle
+ */
+function sendToRewardsThread(embedMessage, content, threadTitle) {
+	const rewardsPayload = { content, flags: MessageFlags.SuppressNotifications };
+	if (embedMessage.channel.isThread()) {
+		// If already in thread, send message
+		embedMessage.channel.send(rewardsPayload);
+	} else if (embedMessage.thread !== null) {
+		// If not in thread but thread exists, send in thread
+		embedMessage.thread.send(rewardsPayload);
+	} else {
+		// If not in thread and thread doesn't exist, make one
+		embedMessage.startThread({ name: threadTitle }).then(thread => {
+			thread.send(rewardsPayload);
+		})
+	}
+}
+
 module.exports = {
 	createSubcommandMappings,
 	bountiesToSelectOptions,
@@ -167,5 +188,6 @@ module.exports = {
 	generateBountyBoardThread,
 	updatePosting,
 	updateScoreboard,
-	disabledSelectRow
+	disabledSelectRow,
+	sendToRewardsThread
 };

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -68,14 +68,6 @@ function bulkFindOpenBounties(userId, companyId, slotNumbers) {
 	return db.models.Bounty.findAll({ where: { userId, companyId, slotNumber: { [Op.in]: slotNumbers }, state: "open" } });
 }
 
-/** *Finds the specified Evergreen Bounty*
- * @param {string} companyId
- * @param {number} slotNumber
- */
-function findOneEvergreenBounty(companyId, slotNumber) {
-	return db.models.Bounty.findOne({ where: { companyId, slotNumber, isEvergreen: true, state: "open" } });
-}
-
 /** @param {string} companyId */
 function findEvergreenBounties(companyId) {
 	return db.models.Bounty.findAll({ where: { isEvergreen: true, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
@@ -248,7 +240,6 @@ module.exports = {
 	findBounty,
 	findOpenBounties,
 	bulkFindOpenBounties,
-	findOneEvergreenBounty,
 	findEvergreenBounties,
 	findBountyCompletions,
 	findCompanyBountiesByCreationDate,

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -19,10 +19,24 @@ function createBounty(rawBounty) {
 	return db.models.Bounty.create(rawBounty);
 }
 
-/** *Create many Completions*
- * @param {{ bountyId: string, userId: string, companyId: string, xpAwarded?: number}[]} rawCompletions
+/** *Create Completions for multiple Hunters for the same Bounty*
+ * @param {string} bountyId
+ * @param {string} companyId
+ * @param {string[]} userIds
+ * @param {number?} xpAwarded
  */
-function bulkCreateCompletions(rawCompletions) {
+function bulkCreateCompletions(bountyId, companyId, userIds, xpAwarded) {
+	const rawCompletions = userIds.map(id => {
+		const rawCompletion = {
+			bountyId,
+			userId: id,
+			companyId
+		};
+		if (xpAwarded) {
+			rawCompletion.xpAwarded = xpAwarded;
+		}
+		return rawCompletion;
+	});
 	return db.models.Completion.bulkCreate(rawCompletions);
 }
 
@@ -116,15 +130,7 @@ async function addCompleters(bounty, guild, completerMembers, runMode) {
 		throw `No new turn-ins were able to be recorded. You cannot credit yourself or bots for your own bounties. ${bannedIds.length ? ' The completer(s) mentioned are currently banned.' : ''}`;
 	}
 
-	const rawCompletions = [];
-	for (const userId of validatedCompleterIds) {
-		rawCompletions.push({
-			bountyId: bounty.id,
-			userId,
-			companyId: guild.id
-		})
-	}
-	await bulkCreateCompletions(rawCompletions);
+	await bulkCreateCompletions(bounty.id, guild.id, validatedCompleterIds, null);
 	let allCompleters = await db.models.Completion.findAll({
 		where: {
 			bountyId: bounty.id


### PR DESCRIPTION
Summary
-------
- switch `/evergreen complete` input to in-message selects
- fix crash when `/evergreen complete` creates Completion for not yet existing Hunter
- fix banned hunters being able to be credited with evergreen bounties
- move raw completion mapping into `bulkCreateCompletion()`
- create dAPI request `sendToRewardThread()`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/evergreen complete` still resolves

Issue
-----
Closes #492, Closes #493