### PR TITLE
refactor `logicLayer.bounties.completeBounty()`

### DIFF
--- a/source/frontend/buttons/bbcomplete.js
+++ b/source/frontend/buttons/bbcomplete.js
@@ -1,7 +1,7 @@
-const { MessageFlags, ActionRowBuilder, ChannelType, ChannelSelectMenuBuilder, userMention, ComponentType, DiscordjsErrorCodes, bold } = require('discord.js');
+const { MessageFlags, ActionRowBuilder, ChannelType, ChannelSelectMenuBuilder, userMention, ComponentType, DiscordjsErrorCodes } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { getRankUpdates, commandMention, generateTextBar, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, buildHunterLevelUpLine } = require('../shared');
+const { getRankUpdates, commandMention, generateTextBar, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, formatHunterResultsToRewardTexts } = require('../shared');
 const { timeConversion } = require('../../shared');
 
 /** @type {typeof import("../../logic")} */
@@ -68,18 +68,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				for (const id of validatedHunterIds.concat(bounty.userId)) {
 					hunterMap[id] = await hunterMap[id].reload();
 				}
-				const rewardTexts = [];
-				for (const id in hunterResults) {
-					const { previousLevel, dropChance } = hunterResults[id];
-					const hunterLevelLine = buildHunterLevelUpLine(hunterMap[id], previousLevel, company.xpCoefficient, company.maxSimBounties);
-					if (hunterLevelLine) {
-						rewardTexts.push(hunterLevelLine);
-					}
-					const [itemRow] = await logicLayer.items.rollItemForHunter(dropChance, hunterMap[id]);
-					if (itemRow) {
-						rewardTexts.push(`${userMention(id)} has found a ${bold(itemRow.itemName)}!`);
-					}
-				}
+				const rewardTexts = formatHunterResultsToRewardTexts(hunterResults, hunterMap, company);
 				const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, Object.values(hunterMap), collectedInteraction.guild.name);
 				if (companyLevelLine) {
 					rewardTexts.push(companyLevelLine);

--- a/source/frontend/buttons/bbcomplete.js
+++ b/source/frontend/buttons/bbcomplete.js
@@ -1,7 +1,7 @@
 const { MessageFlags, ActionRowBuilder, ChannelType, ChannelSelectMenuBuilder, userMention, ComponentType, DiscordjsErrorCodes, bold } = require('discord.js');
 const { ButtonWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { getRankUpdates, commandMention, generateTextBar, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed } = require('../shared');
+const { getRankUpdates, commandMention, generateTextBar, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, buildHunterLevelUpLine } = require('../shared');
 const { timeConversion } = require('../../shared');
 
 /** @type {typeof import("../../logic")} */
@@ -60,24 +60,31 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				]
 			}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
 				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
+				const [company] = await logicLayer.companies.findOrCreateCompany(collectedInteraction.guildId);
 
-				const poster = await logicLayer.hunters.findOneHunter(bounty.userId, bounty.companyId);
-				const { completerXP, posterXP, rewardTexts, itemRollMap } = await logicLayer.bounties.completeBounty(bounty, poster, validatedHunters, await logicLayer.hunters.findCompanyHunters(collectedInteraction.guild.id), collectedInteraction.guild.name);
-				for (const hunterId of itemRollMap.hunters) {
-					const hunter = validatedHunters.find(hunter => hunter.userId === hunterId);
-					const [itemRow] = await logicLayer.items.rollItemForHunter(1 / 8, hunter);
+				const hunterMap = await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id);
+				const previousCompanyLevel = company.getLevel(Object.values(hunterMap));
+				const { completerXP, posterXP, hunterResults } = await logicLayer.bounties.completeBounty(bounty, hunterMap[bounty.userId], validatedHunters, season, company);
+				for (const id of validatedHunterIds.concat(bounty.userId)) {
+					hunterMap[id] = await hunterMap[id].reload();
+				}
+				const rewardTexts = [];
+				for (const id in hunterResults) {
+					const { previousLevel, dropChance } = hunterResults[id];
+					const hunterLevelLine = buildHunterLevelUpLine(hunterMap[id], previousLevel, company.xpCoefficient, company.maxSimBounties);
+					if (hunterLevelLine) {
+						rewardTexts.push(hunterLevelLine);
+					}
+					const [itemRow] = await logicLayer.items.rollItemForHunter(dropChance, hunterMap[id]);
 					if (itemRow) {
-						rewardTexts.push(`${userMention(hunterId)} has found a ${bold(itemRow.itemName)}`)
+						rewardTexts.push(`${userMention(id)} has found a ${bold(itemRow.itemName)}!`);
 					}
 				}
-				for (const posterId of itemRollMap.poster) {
-					const hunter = validatedHunters.find(hunter => hunter.userId === posterId);
-					const [itemRow] = await logicLayer.items.rollItemForHunter(1 / 4, hunter);
-					if (itemRow) {
-						rewardTexts.push(`${userMention(posterId)} has found a ${bold(itemRow.itemName)}`)
-					}
+				const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, Object.values(hunterMap), collectedInteraction.guild.name);
+				if (companyLevelLine) {
+					rewardTexts.push(companyLevelLine);
 				}
-				const goalUpdate = await logicLayer.goals.progressGoal(bounty.companyId, "bounties", poster, season);
+				const goalUpdate = await logicLayer.goals.progressGoal(bounty.companyId, "bounties", hunterMap[bounty.userId], season);
 				if (goalUpdate.gpContributed > 0) {
 					rewardTexts.push(`This bounty contributed ${goalUpdate.gpContributed} GP to the Server Goal!`);
 				}
@@ -86,10 +93,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				if (collectedInteraction.channel.archived) {
 					await collectedInteraction.channel.setArchived(false, "bounty complete");
 				}
-				const [company] = await logicLayer.companies.findOrCreateCompany(collectedInteraction.guildId);
 				collectedInteraction.channel.setAppliedTags([company.bountyBoardCompletedTagId]);
 				collectedInteraction.reply({ content: generateBountyRewardString(validatedHunterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts), flags: MessageFlags.SuppressNotifications });
-				buildBountyEmbed(bounty, collectedInteraction.guild, poster.getLevel(company.xpCoefficient), true, company, completions)
+				buildBountyEmbed(bounty, collectedInteraction.guild, hunterMap[bounty.userId].getLevel(company.xpCoefficient), true, company, completions)
 					.then(async embed => {
 						if (goalUpdate.gpContributed > 0) {
 							const { goalId, requiredGP, currentGP } = await logicLayer.goals.findLatestGoalProgress(interaction.guildId);

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, buildHunterLevelUpLine } = require("../../shared");
+const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, formatHunterResultsToRewardTexts } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
@@ -58,18 +58,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		for (const id of validatedHunterIds.concat(poster.userId)) {
 			hunterMap[id] = await hunterMap[id].reload();
 		}
-		const rewardTexts = [];
-		for (const id in hunterResults) {
-			const { previousLevel, dropChance } = hunterResults[id];
-			const hunterLevelLine = buildHunterLevelUpLine(hunterMap[id], previousLevel, company.xpCoefficient, company.maxSimBounties);
-			if (hunterLevelLine) {
-				rewardTexts.push(hunterLevelLine);
-			}
-			const [itemRow] = await logicLayer.items.rollItemForHunter(dropChance, hunterMap[id]);
-			if (itemRow) {
-				rewardTexts.push(`${userMention(id)} has found a ${bold(itemRow.itemName)}!`);
-			}
-		}
+		const rewardTexts = formatHunterResultsToRewardTexts(hunterResults, hunterMap, company);
 		const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, Object.values(hunterMap), interaction.guild.name);
 		if (companyLevelLine) {
 			rewardTexts.push(companyLevelLine);

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed } = require("../../shared");
+const { commandMention, generateTextBar, getRankUpdates, buildBountyEmbed, generateBountyRewardString, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed, generateCompletionEmbed, buildCompanyLevelUpLine, buildHunterLevelUpLine } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
@@ -50,28 +50,35 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		await interaction.deferReply();
 
 		const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
+		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
 
-		const { completerXP, posterXP, rewardTexts, itemRollMap } = await logicLayer.bounties.completeBounty(bounty, poster, validatedHunters, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), interaction.guild.name);
-		for (const hunterId of itemRollMap.hunters) {
-			const hunter = validatedHunters.find(hunter => hunter.userId === hunterId);
-			const [itemRow] = await logicLayer.items.rollItemForHunter(1 / 8, hunter);
+		const hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
+		const previousCompanyLevel = company.getLevel(Object.values(hunterMap));
+		const { completerXP, posterXP, hunterResults } = await logicLayer.bounties.completeBounty(bounty, poster, validatedHunters, season, company);
+		for (const id of validatedHunterIds.concat(poster.userId)) {
+			hunterMap[id] = await hunterMap[id].reload();
+		}
+		const rewardTexts = [];
+		for (const id in hunterResults) {
+			const { previousLevel, dropChance } = hunterResults[id];
+			const hunterLevelLine = buildHunterLevelUpLine(hunterMap[id], previousLevel, company.xpCoefficient, company.maxSimBounties);
+			if (hunterLevelLine) {
+				rewardTexts.push(hunterLevelLine);
+			}
+			const [itemRow] = await logicLayer.items.rollItemForHunter(dropChance, hunterMap[id]);
 			if (itemRow) {
-				rewardTexts.push(`${userMention(hunterId)} has found a ${bold(itemRow.itemName)}`)
+				rewardTexts.push(`${userMention(id)} has found a ${bold(itemRow.itemName)}!`);
 			}
 		}
-		for (const posterId of itemRollMap.poster) {
-			const hunter = validatedHunters.find(hunter => hunter.userId === posterId);
-			const [itemRow] = await logicLayer.items.rollItemForHunter(1 / 4, hunter);
-			if (itemRow) {
-				rewardTexts.push(`${userMention(posterId)} has found a ${bold(itemRow.itemName)}`)
-			}
+		const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, Object.values(hunterMap), interaction.guild.name);
+		if (companyLevelLine) {
+			rewardTexts.push(companyLevelLine);
 		}
 		const goalUpdate = await logicLayer.goals.progressGoal(bounty.companyId, "bounties", poster, season);
 		if (goalUpdate.gpContributed > 0) {
 			rewardTexts.push(`This bounty contributed ${goalUpdate.gpContributed} GP to the Server Goal!`);
 		}
 		const rankUpdates = await getRankUpdates(interaction.guild, logicLayer);
-		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
 		const content = generateBountyRewardString(validatedHunterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts);
 
 		buildBountyEmbed(bounty, interaction.guild, poster.getLevel(company.xpCoefficient), true, company, completions).then(async embed => {

--- a/source/frontend/shared/index.js
+++ b/source/frontend/shared/index.js
@@ -1,6 +1,7 @@
 module.exports = {
 	...require("./dAPIRequests"),
 	...require("./messageParts"),
+	...require("./storeManagement"),
 	...require("./toBeMoved"),
 	...require("./validations")
 };

--- a/source/frontend/shared/messageParts.js
+++ b/source/frontend/shared/messageParts.js
@@ -602,6 +602,27 @@ function generateSecondingRewardString(seconderDisplayName, recipientIds, rankUp
 	return text;
 }
 
+/**
+ * @param {Record<string, { previousLevel: number, droppedItem: string | null }>} hunterResults
+ * @param {Record<string, Hunter>} hunterMap
+ * @param {Company} company
+ */
+function formatHunterResultsToRewardTexts(hunterResults, hunterMap, company) {
+	/** @type {string[]} */
+	const rewardTexts = [];
+	for (const id in hunterResults) {
+		const { previousLevel, droppedItem } = hunterResults[id];
+		const hunterLevelLine = buildHunterLevelUpLine(hunterMap[id], previousLevel, company.xpCoefficient, company.maxSimBounties);
+		if (hunterLevelLine) {
+			rewardTexts.push(hunterLevelLine);
+		}
+		if (droppedItem) {
+			rewardTexts.push(`${userMention(id)} has found a ${bold(droppedItem)}!`);
+		}
+	}
+	return rewardTexts;
+}
+
 module.exports = {
 	commandMention,
 	congratulationBuilder,
@@ -626,5 +647,6 @@ module.exports = {
 	generateSecondingActionRow,
 	generateToastRewardString,
 	generateCompletionEmbed,
-	generateSecondingRewardString
+	generateSecondingRewardString,
+	formatHunterResultsToRewardTexts
 };

--- a/source/frontend/shared/storeManagement.js
+++ b/source/frontend/shared/storeManagement.js
@@ -1,0 +1,16 @@
+const { Hunter } = require("../../database/models");
+
+/** Reloads a subset of a map of a Company's Hunters
+ * @param {Record<string, Hunter>} hunterMap
+ * @param {string[]} reloadIds
+ */
+async function reloadHunterMapSubset(hunterMap, reloadIds) {
+	for (const id of reloadIds) {
+		hunterMap[id] = await hunterMap[id].reload();
+	}
+	return hunterMap;
+}
+
+module.exports = {
+	reloadHunterMapSubset
+};

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -1,7 +1,6 @@
 const { Sequelize, Op } = require("sequelize");
 const { Guild, GuildMember } = require("discord.js");
-const { Bounty, Hunter } = require("../database/models");
-const { buildCompanyLevelUpLine, buildHunterLevelUpLine } = require("../frontend/shared");
+const { Bounty, Hunter, Season, Company } = require("../database/models");
 
 /** @type {Sequelize} */
 let db;
@@ -151,64 +150,40 @@ async function addCompleters(bounty, guild, completerMembers, runMode) {
  * @param {Bounty} bounty
  * @param {Hunter} poster
  * @param {Hunter[]} validatedHunters
- * @param {Hunter[]} allHunters
- * @param {string} guildName
+ * @param {Season} season
+ * @param {Company} company
  */
-async function completeBounty(bounty, poster, validatedHunters, allHunters, guildName) {
+async function completeBounty(bounty, poster, validatedHunters, season, company) {
 	bounty.update({ state: "completed", completedAt: new Date() });
-	const rewardTexts = [];
 
-	const company = await db.models.Company.findByPk(bounty.companyId);
-	const previousCompanyLevel = company.getLevel(allHunters);
 	const bountyBaseValue = Bounty.calculateCompleterReward(poster.getLevel(company.xpCoefficient), bounty.slotNumber, bounty.showcaseCount);
 	const bountyValue = bountyBaseValue * company.festivalMultiplier;
-	const [season] = await db.models.Season.findOrCreate({ where: { companyId: bounty.companyId, isCurrentSeason: true } });
 	db.models.Completion.update({ xpAwarded: bountyValue }, { where: { bountyId: bounty.id } });
-	const itemRollMap = { hunters: [], poster: [] };
+	/** @type {Record<string, { previousLevel: number, dropChance: number }>} */
+	const hunterResults = {};
 	for (const hunter of validatedHunters) {
-		const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
+		hunterResults[hunter.userId] = { previousLevel: hunter.getLevel(company.xpCoefficient) };
 		await hunter.increment({ othersFinished: 1, xp: bountyValue }).then(hunter => hunter.reload());
-		const hunterLevelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
-		if (hunterLevelLine) {
-			rewardTexts.push(hunterLevelLine);
-		}
+		hunterResults[hunter.userId].dropChance = 1 / 8;
 		const [participation, participationCreated] = await db.models.Participation.findOrCreate({ where: { companyId: bounty.companyId, userId: hunter.userId, seasonId: season.id }, defaults: { xp: bountyValue } });
 		if (!participationCreated) {
 			participation.increment({ xp: bountyValue });
 		}
-		itemRollMap.hunters.push(hunter.userId);
 	}
 
 	const posterXP = bounty.calculatePosterReward(validatedHunters.length);
-	const previousPosterLevel = poster.getLevel(company.xpCoefficient);
+	hunterResults[poster.userId] = { previousLevel: poster.getLevel(company.xpCoefficient) };
 	await poster.increment({ mineFinished: 1, xp: posterXP * company.festivalMultiplier }).then(poster => poster.reload());
-	const posterLevelLine = buildHunterLevelUpLine(poster, previousPosterLevel, company.xpCoefficient, company.maxSimBounties);
-	if (posterLevelLine) {
-		rewardTexts.push(posterLevelLine);
-	}
+	hunterResults[poster.userId].dropChance = 1 / 4;
 	const [participation, participationCreated] = await db.models.Participation.findOrCreate({ where: { companyId: bounty.companyId, userId: bounty.userId, seasonId: season.id }, defaults: { xp: posterXP * company.festivalMultiplier, postingsCompleted: 1 } });
 	if (!participationCreated) {
 		participation.increment({ xp: posterXP * company.festivalMultiplier, postingsCompleted: 1 });
 	}
-	itemRollMap.poster.push(poster.userId);
 
-	const xpChangedIds = validatedHunters.map(hunter => hunter.userId).concat(poster.userId);
-	const reloadedHunters = await Promise.all(allHunters.map(hunter => {
-		if (xpChangedIds.includes(hunter.userId)) {
-			return hunter.reload();
-		} else {
-			return hunter;
-		}
-	}))
-	const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, guildName);
-	if (companyLevelLine) {
-		rewardTexts.push(companyLevelLine);
-	}
 	return {
-		itemRollMap,
 		completerXP: bountyBaseValue,
 		posterXP,
-		rewardTexts
+		hunterResults
 	};
 }
 

--- a/source/logic/hunters.js
+++ b/source/logic/hunters.js
@@ -46,6 +46,7 @@ function findCompanyHunters(companyId) {
  * @param {string} companyId
  */
 async function getCompanyHunterMap(companyId) {
+	/** @type {Record<string, Hunter} */
 	const hunterMap = {};
 	const hunters = await db.models.Hunter.findAll({ where: { companyId } });
 	for (const hunter of hunters) {


### PR DESCRIPTION
Summary
-------
- accept company and season as parameters
- move reward text generation to frontend
- create `frontend/shared/storeManagement.reloadHunterMapSubset()` for reloading select Hunter objects in a `Record<hunter userId, Hunter>` object (the upcoming advised data structure for "all of a Company's Hunters" for the purpose of rank calculation)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] completing a bounty via slash command still outputs level up texts for both hunter and company
- [x] completing a bounty via bounty board button still outputs level up texts for both hunter and company
- [x] completing a bounty via slash command still reports item drops
- [x] completing a bounty via bounty board button still reports item drops