### PR TITLE
maintenance pass on `deferReply()` usages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Slash commands originally accepted users as a string (instead of Discord's user 
 ### Other Changes
 - Added `/seasonal-ranks`, which allows all bounty hunters to look up the server's list of seasonal ranks (removed `/rank info` which was only usable by Premium users)
 - Fixed BountyBot banned users being able to receive toasts and credit for evergreen bounties
+- Fixed Completing bounties from within their thread on the Bounty Board timing out
 
 ## BountyBot Version 2.9.0:
 ### Server Goals

--- a/source/frontend/buttons/bbcomplete.js
+++ b/source/frontend/buttons/bbcomplete.js
@@ -61,7 +61,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				withResponse: true
 			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
 				await collectedInteraction.deferReply({ flags: MessageFlags.SuppressNotifications });
-				console.time("TODONOW complete")
 				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 				const [company] = await logicLayer.companies.findOrCreateCompany(collectedInteraction.guildId);
 
@@ -84,7 +83,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					await collectedInteraction.channel.setArchived(false, "bounty complete");
 				}
 				collectedInteraction.channel.setAppliedTags([company.bountyBoardCompletedTagId]);
-				console.timeEnd("TODONOW complete")
 				collectedInteraction.editReply({ content: generateBountyRewardString(validatedHunterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts) });
 				buildBountyEmbed(bounty, collectedInteraction.guild, hunterMap[bounty.userId].getLevel(company.xpCoefficient), true, company, completions)
 					.then(async embed => {

--- a/source/frontend/buttons/bbcomplete.js
+++ b/source/frontend/buttons/bbcomplete.js
@@ -26,7 +26,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			const hunterCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
 			const validatedHunterIds = [];
 			const validatedHunters = [];
-			hunterCollection.forEach(async member => {
+			for (const member of hunterCollection.values()) {
 				if (runMode !== "production" || !member.user.bot) {
 					const memberId = member.id;
 					const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
@@ -35,7 +35,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 						validatedHunters.push(hunter);
 					}
 				}
-			})
+			}
 
 			if (validatedHunters.length < 1) {
 				interaction.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
@@ -61,6 +61,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				withResponse: true
 			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
 				await collectedInteraction.deferReply({ flags: MessageFlags.SuppressNotifications });
+				console.time("TODONOW complete")
 				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 				const [company] = await logicLayer.companies.findOrCreateCompany(collectedInteraction.guildId);
 
@@ -83,6 +84,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					await collectedInteraction.channel.setArchived(false, "bounty complete");
 				}
 				collectedInteraction.channel.setAppliedTags([company.bountyBoardCompletedTagId]);
+				console.timeEnd("TODONOW complete")
 				collectedInteraction.editReply({ content: generateBountyRewardString(validatedHunterIds, completerXP, bounty.userId, posterXP, company.festivalMultiplierString(), rankUpdates, rewardTexts) });
 				buildBountyEmbed(bounty, collectedInteraction.guild, hunterMap[bounty.userId].getLevel(company.xpCoefficient), true, company, completions)
 					.then(async embed => {

--- a/source/frontend/buttons/bbtakedown.js
+++ b/source/frontend/buttons/bbtakedown.js
@@ -10,13 +10,12 @@ const mainId = "bbtakedown";
 module.exports = new ButtonWrapper(mainId, 3000,
 	(interaction, runMode, [bountyId]) => {
 		logicLayer.bounties.findBounty(bountyId).then(async bounty => {
-			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 			if (bounty.userId !== interaction.user.id) {
-				interaction.editReply({ content: "Only the bounty poster can take down their bounty." });
+				interaction.reply({ content: "Only the bounty poster can take down their bounty.", flags: MessageFlags.Ephemeral });
 				return;
 			}
 
-			interaction.editReply({
+			interaction.reply({
 				content: `Really take down this bounty?`,
 				components: [
 					new ActionRowBuilder().addComponents(
@@ -25,8 +24,11 @@ module.exports = new ButtonWrapper(mainId, 3000,
 							.setEmoji("✔")
 							.setLabel("Confirm")
 					)
-				]
-			}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
+				],
+				flags: MessageFlags.Ephemeral,
+				withResponse: true
+			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
+				await collectedInteraction.deferReply({ flags: MessageFlags.Ephemeral });
 				await bounty.reload();
 				bounty.state = "deleted";
 				bounty.save();
@@ -40,7 +42,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					getRankUpdates(interaction.guild, logicLayer);
 				})
 
-				return collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
+				return collectedInteraction.editReply({ content: "Your bounty has been taken down." });
 			}).catch(error => {
 				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
 					console.error(error);

--- a/source/frontend/buttons/bbtakedown.js
+++ b/source/frontend/buttons/bbtakedown.js
@@ -28,7 +28,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				flags: MessageFlags.Ephemeral,
 				withResponse: true
 			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
-				await collectedInteraction.deferReply({ flags: MessageFlags.Ephemeral });
 				await bounty.reload();
 				bounty.state = "deleted";
 				bounty.save();
@@ -42,7 +41,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 					getRankUpdates(interaction.guild, logicLayer);
 				})
 
-				return collectedInteraction.editReply({ content: "Your bounty has been taken down." });
+				return collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
 			}).catch(error => {
 				if (error.code !== DiscordjsErrorCodes.InteractionCollectorError) {
 					console.error(error);

--- a/source/frontend/commands/item.js
+++ b/source/frontend/commands/item.js
@@ -13,7 +13,6 @@ const mainId = "item";
 module.exports = new CommandWrapper(mainId, "Get details on a selected item and a button to use it", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
 	async (interaction, runMode) => {
 		const itemName = interaction.options.getString("item-name");
-		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const itemRow = await logicLayer.items.findUserItemEntry(interaction.user.id, itemName);
 		const hasItem = itemRow !== null && itemRow.count > 0 || runMode !== "production";
 		let embedColor = Colors.Blurple;
@@ -21,7 +20,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 			const [color] = itemName.split("Profile Colorizer");
 			embedColor = Colors[color.replace(/ /g, "")];
 		}
-		interaction.editReply({
+		interaction.reply({
 			embeds: [
 				new EmbedBuilder().setColor(embedColor)
 					.setAuthor(ihpAuthorPayload)
@@ -37,8 +36,10 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 						.setLabel(`Use a ${itemName}`)
 						.setDisabled(!hasItem)
 				)
-			]
-		}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteration => {
+			],
+			flags: MessageFlags.Ephemeral,
+			withResponse: true
+		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteration => {
 			if (runMode === "production" && Date.now() < collectedInteration.member.joinedTimestamp + timeConversion(1, "d", "ms")) {
 				collectedInteration.reply({ content: `Items cannot be used in servers that have been joined less than 24 hours ago.`, flags: MessageFlags.Ephemeral });
 				return;

--- a/source/frontend/commands/raffle/byrank.js
+++ b/source/frontend/commands/raffle/byrank.js
@@ -10,8 +10,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			interaction.reply({ content: "This server doesn't have any ranks configured.", flags: MessageFlags.Ephemeral });
 			return;
 		}
-		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-		interaction.editReply({
+		interaction.reply({
 			content: "Select a rank to be the eligibility threshold for this raffle:",
 			components: [
 				new ActionRowBuilder().addComponents(
@@ -20,8 +19,10 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 						.addOptions(rankArrayToSelectOptions(ranks, await interaction.guild.roles.fetch()))
 				)
 			],
+			flags: MessageFlags.Ephemeral,
 			withResponse: true
-		}).then(message => message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
+		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
+			await collectedInteraction.deferUpdate();
 			const varianceThreshold = Number(collectedInteraction.values[0]);
 			const reloadedRanks = await Promise.all(ranks.map(rank => rank.reload()));
 			const rankIndex = reloadedRanks.findIndex(rank => rank.varianceThreshold === varianceThreshold);


### PR DESCRIPTION
Summary
-------
This PR started by noticing the Bounty Board Complete Button was returning an unknown interaction error on its final interaction (`collectedInteraction`) acknowledgement. This error has been diagnosed to be due to interaction timeouts for the following reasons:
- The code is only capable of acknowledging `collectedInteraction` once
- Bounty completions have had history of timing out
- The circumstance of "happens more often on first command after a period of inactivity" fits with "server setting of anaemic slows down first responses after inactivity, but saves on resources overall"

Analytical code inspection discovered that the Bounty Board Complete Button's `deferReply()` was being applied to the initial interaction (`interaction`) rather than the one that was throwing the unknown interaction error (`collectedInteraction`). This lines up with the fact that `interaction` only runs some initial validations and the assembly of the instructions message, while all the database transactions are run by `collectedInteraction`.

This led to a review of all uses of `deferReply()`, to ensure they were applied to the correct interaction in their own respective flows as well. Because there is performance variance between my local setup and the server, I chose to do short-term triage around references to known behavior. `/about` as chosen for the "low load reference": it's expected to never time out given the lack of logic and database transactions required for its resolution. The Bounty Board Complete Button was chosen as a "high load reference": the failures in that flow have been seen to happen on the server. The Bounty Board Complete Button test was found to be 2 orders of magnitude longer than `/about`, which seems reasonably detectable given the amount of precision expected of this methodology.

No unexpected variances were found, but the current methodology has much room for improvement on rigor. Expected variances were found and include:
- First run of a timer is slower than subsequent runs (even without anaemic settings on local environment)
- Variance between runs of the same flow roughly proportional to the run's time

Of the existing uses of `deferReply()`, the following actions were taken:
- Bounty Board Complete Button: move deferral to interaction executing database transactions (`collectedInteraction`)
- `/create-default rank-roles`: left as is, the usage was added in response to the command timing out
- `/bounty complete`: left as is, run time found to be in range of high load reference
- Bounty Board Take Down Button: removed -- run time found to be in range of low load reference
- `/item`: removed -- run time found to be in range of low load reference

While related to #174, this triage doesn't systemically mitigate future timeout issues or improve detection, so the issue should remain open to gather ideas and data.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] used `console.time()` and `console.timeEnd()` to see various flow times ([`/about` as low load reference, Bounty Board Complete Button as high load reference, and `/item`](https://github.com/Imaginary-Horizons-Productions/BountyBot/issues/174#issuecomment-2859272953))