### PR TITLE
#333 & #460: refactor rank and placement calculation

### DIFF
--- a/migrations/20250508183230-refactorRankCalculation.js
+++ b/migrations/20250508183230-refactorRankCalculation.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+	//TODONOW add Season.xpStandardDeviation
+	//TODONOW add Participation.rankIndex
+	//TODONOW remove Hunter.rank
+	//TODONOW remove Hunter.lastRank
+	//TODONOW remove Hunter.nextRankXP
+  },
+
+  async down (queryInterface, Sequelize) {
+	//TODONOW remove Season.xpStandardDeviation
+	//TODONOW remove Participation.rankIndex
+	//TODONOW recalculate Hunter.rank
+	//TODONOW recalculate Hunter.lastRank
+	//TODONOW recalculate Hunter.nextRankXP
+  }
+};

--- a/source/database/models/seasons/Participation.js
+++ b/source/database/models/seasons/Participation.js
@@ -9,6 +9,10 @@ class Participation extends Model {
 			foreignKey: "companyId"
 		})
 	}
+
+	nextRankXP(season, descendingRanks) { //TODONOW replace Hunter.nextRankXP usages
+		return Math.ceil(season.xpStandardDeviation * descendingRanks[this.rankIndex].varianceThreshold + season.xpMean - this.xp);
+	}
 }
 
 /** @param {Sequelize} sequelize */
@@ -46,6 +50,9 @@ function initModel(sequelize) {
 		placement: {
 			type: DataTypes.INTEGER,
 			defaultValue: 0
+		},
+		rankIndex: {
+			type: DataTypes.INTEGER
 		},
 		postingsCompleted: {
 			type: DataTypes.INTEGER,

--- a/source/database/models/seasons/Season.js
+++ b/source/database/models/seasons/Season.js
@@ -6,6 +6,26 @@ class Season extends Model {
 			foreignKey: "seasonId"
 		})
 	}
+
+	static calculateXPMean(participations) {
+		if (participations.length < 1) {
+			return null;
+		}
+		const totalXP = participations.reduce((total, particpation) => total + particpation.xp, 0);
+		return totalXP / participations.length;
+	}
+
+	/**
+	 *
+	 * @param {Participation[]} participations
+	 */
+	static calculateXPStandardDeviation(participations) {
+		if (participations.length < 1) {
+			return null;
+		}
+		const mean = Season.calculateXPMean(participations);
+		return Math.sqrt(participations.reduce((total, particpation) => total + (particpation.xp - mean) ** 2, 0) / participations.length);
+	}
 }
 
 /** @param {Sequelize} sequelize */
@@ -27,6 +47,12 @@ function initModel(sequelize) {
 		isPreviousSeason: {
 			type: DataTypes.BOOLEAN,
 			defaultValue: false,
+		},
+		xpMean: { //TODONOW does this really need to be cached?
+			type: DataTypes.DOUBLE
+		},
+		xpStandardDeviation: { //TODONOW does this really need to be cached?
+			type: DataTypes.DOUBLE
 		},
 		totalXP: {
 			type: DataTypes.VIRTUAL,

--- a/source/database/models/users/Hunter.js
+++ b/source/database/models/users/Hunter.js
@@ -55,17 +55,6 @@ function initModel(sequelize) {
 			type: DataTypes.BIGINT,
 			defaultValue: 0
 		},
-		rank: {
-			type: DataTypes.INTEGER,
-			defaultValue: null
-		},
-		lastRank: {
-			type: DataTypes.INTEGER,
-			defaultValue: null
-		},
-		nextRankXP: {
-			type: DataTypes.BIGINT,
-		},
 		lastShowcaseTimestamp: {
 			type: DataTypes.DATE
 		},


### PR DESCRIPTION
Summary
-------
- replace `frontend/shared/toBeMoved.getRankUpdates()` with `logicLayer.seasons.updateCompanyPlacementsAndRanks()`
- fixed typo "particiaptionProperty" to "participationProperty"

Paradigm Shifts
---------------
- Moving `rank` from Hunter to Participation allows `updateCompanyPlacementsAndRanks()` to function with only the current Season's Participations, rather than all of the Company's Hunters AND the current Season's Participations. This means the frontend store can shift to passing Participation maps around instead of Hunter maps.
- Using `Map`s instead of `Object`s for map data structures. This PR is leveraging `Map` functionality of being iterable and having a size property (instead of needing to `Object.keys().length`).
- `Participation.rankIndex` was originally going to be refactored to a rank's id, but needs to be kept as an index to encode rank order (so we can detect "rank up" vs "rank down"). Efforts will be made to formalize "descending" as the official ordering.

Local Tests Performed
---------------------
- [ ] bot still turns on (no build errors, circular dependencies, or start-up errors)

Test plan tbw

Issue
-----
Closes #333 
Closes #460