### PR TITLE
#505: update `sequelize-cli` to v6.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 				"@sapphire/discord.js-utilities": "7.3.2",
 				"discord.js": "14.18.0",
 				"sequelize": "6.37.7",
-				"sequelize-cli": "6.6.2",
+				"sequelize-cli": "6.6.3",
 				"sqlite3": "5.1.7"
 			}
 		},
@@ -603,21 +603,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/cli-color": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
-			"integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
-			"dependencies": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.64",
-				"es6-iterator": "^2.0.3",
-				"memoizee": "^0.4.15",
-				"timers-ext": "^0.1.7"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -760,18 +745,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/d": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-			"integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-			"dependencies": {
-				"es5-ext": "^0.10.64",
-				"type": "^2.7.2"
-			},
-			"engines": {
-				"node": ">=0.12"
 			}
 		},
 		"node_modules/debug": {
@@ -928,54 +901,6 @@
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
 			"optional": true
 		},
-		"node_modules/es5-ext": {
-			"version": "0.10.64",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"esniff": "^2.0.1",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"node_modules/es6-symbol": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-			"integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-			"dependencies": {
-				"d": "^1.0.2",
-				"ext": "^1.7.0"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/es6-weak-map": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "^0.10.46",
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.1"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -984,43 +909,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/esniff": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-			"dependencies": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.62",
-				"event-emitter": "^0.3.5",
-				"type": "^2.7.2"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
 			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/ext": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-			"dependencies": {
-				"type": "^2.7.2"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1405,11 +1299,6 @@
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"optional": true
 		},
-		"node_modules/is-promise": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1489,14 +1378,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
-		"node_modules/lru-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-			"dependencies": {
-				"es5-ext": "~0.10.2"
-			}
-		},
 		"node_modules/magic-bytes.js": {
 			"version": "1.12.1",
 			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
@@ -1551,24 +1432,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/memoizee": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-			"integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-			"dependencies": {
-				"d": "^1.0.2",
-				"es5-ext": "^0.10.64",
-				"es6-weak-map": "^2.0.3",
-				"event-emitter": "^0.3.5",
-				"is-promise": "^2.2.2",
-				"lru-queue": "^0.1.0",
-				"next-tick": "^1.1.0",
-				"timers-ext": "^0.1.7"
-			},
-			"engines": {
-				"node": ">=0.12"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -1814,11 +1677,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-		},
 		"node_modules/node-abi": {
 			"version": "3.75.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
@@ -2022,6 +1880,11 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.0.tgz",
 			"integrity": "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ=="
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
@@ -2306,14 +2169,14 @@
 			}
 		},
 		"node_modules/sequelize-cli": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-6.6.2.tgz",
-			"integrity": "sha512-V8Oh+XMz2+uquLZltZES6MVAD+yEnmMfwfn+gpXcDiwE3jyQygLt4xoI0zG8gKt6cRcs84hsKnXAKDQjG/JAgg==",
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-6.6.3.tgz",
+			"integrity": "sha512-1YYPrcSRt/bpMDDSKM5ubY1mnJ2TEwIaGZcqITw4hLtGtE64nIqaBnLtMvH8VKHg6FbWpXTiFNc2mS/BtQCXZw==",
 			"dependencies": {
-				"cli-color": "^2.0.3",
 				"fs-extra": "^9.1.0",
-				"js-beautify": "^1.14.5",
+				"js-beautify": "1.15.4",
 				"lodash": "^4.17.21",
+				"picocolors": "^1.1.1",
 				"resolve": "^1.22.1",
 				"umzug": "^2.3.0",
 				"yargs": "^16.2.0"
@@ -2674,18 +2537,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/timers-ext": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-			"integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
-			"dependencies": {
-				"es5-ext": "^0.10.64",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/toposort-class": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
@@ -2711,11 +2562,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/type": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-			"integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
 		},
 		"node_modules/umzug": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"@sapphire/discord.js-utilities": "7.3.2",
 		"discord.js": "14.18.0",
 		"sequelize": "6.37.7",
-		"sequelize-cli": "6.6.2",
+		"sequelize-cli": "6.6.3",
 		"sqlite3": "5.1.7"
 	}
 }


### PR DESCRIPTION
Summary
-------
- update `sequelize-cli` to v6.6.3

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] no changes listed in sequelize-cli change notes read as breaking

Issue
-----
Closes #505