### PR TITLE
#494: pass Hunter and Company from `InteractionCreate` validations to frontend execute functions

### DIFF
--- a/source/frontend/buttons/_button_blueprint.js
+++ b/source/frontend/buttons/_button_blueprint.js
@@ -6,7 +6,7 @@ let logicLayer;
 const mainId = "";
 module.exports = new ButtonWrapper(mainId, 3000,
 	/** Specs */
-	(interaction, runMode, args) => {
+	(interaction, origin, runMode, args) => {
 
 	}
 ).setLogicLinker(logicBundle => {

--- a/source/frontend/buttons/bbaddcompleters.js
+++ b/source/frontend/buttons/bbaddcompleters.js
@@ -9,7 +9,7 @@ let logicLayer;
 
 const mainId = "bbaddcompleters";
 module.exports = new ButtonWrapper(mainId, 3000,
-	async (interaction, runMode, [bountyId]) => {
+	async (interaction, origin, runMode, [bountyId]) => {
 		const bounty = await logicLayer.bounties.findBounty(bountyId);
 		if (!bounty) {
 			interaction.reply({ content: "This bounty appears to no longer exist. Has this bounty already been completed?", flags: MessageFlags.Ephemeral })
@@ -38,8 +38,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}
 
 			await logicLayer.bounties.bulkCreateCompletions(bounty.id, bounty.companyId, Array.from(eligibleTurnInIds), null);
-			const poster = await logicLayer.hunters.findOneHunter(bounty.userId, bounty.companyId);
-			const company = await logicLayer.companies.findCompanyByPK(bounty.companyId);
 			if (!collectedInteraction.channel) return;
 			if (collectedInteraction.channel.archived) {
 				await collectedInteraction.channel.setArchived(false, "Unarchived to update posting");
@@ -47,7 +45,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			collectedInteraction.channel.send({ content: `${listifyEN(Array.from(newTurnInIds.values().map(id => userMention(id))))} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${congratulationBuilder()}!` });
 			const starterMessage = await collectedInteraction.channel.fetchStarterMessage();
 			starterMessage.edit({
-				embeds: [await buildBountyEmbed(bounty, collectedInteraction.guild, poster.getLevel(company.xpCoefficient), false, company, eligibleTurnInIds)],
+				embeds: [await buildBountyEmbed(bounty, collectedInteraction.guild, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds)],
 				components: generateBountyBoardButtons(bounty)
 			});
 			return collectedInteraction.update({

--- a/source/frontend/buttons/bbremovecompleters.js
+++ b/source/frontend/buttons/bbremovecompleters.js
@@ -9,7 +9,7 @@ let logicLayer;
 
 const mainId = "bbremovecompleters";
 module.exports = new ButtonWrapper(mainId, 3000,
-	(interaction, runMode, [bountyId]) => {
+	(interaction, origin, runMode, [bountyId]) => {
 		logicLayer.bounties.findBounty(bountyId).then(async bounty => {
 			if (bounty.userId !== interaction.user.id) {
 				interaction.reply({ content: "Only the bounty poster can remove completers.", flags: MessageFlags.Ephemeral });
@@ -30,9 +30,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			}).then(response => response.resource.message.awaitMessageComponent({ time: timeConversion(2, "m", "ms"), componentType: ComponentType.UserSelect })).then(async collectedInteraction => {
 				const removedIds = collectedInteraction.members.map((_, key) => key);
 				await logicLayer.bounties.deleteSelectedBountyCompletions(bountyId, removedIds);
-				const poster = await logicLayer.hunters.findOneHunter(collectedInteraction.user.id, collectedInteraction.guild.id);
-				const company = await logicLayer.companies.findCompanyByPK(collectedInteraction.guildId);
-				buildBountyEmbed(bounty, collectedInteraction.guild, poster.getLevel(company.xpCoefficient), false, company, await logicLayer.bounties.getHunterIdSet(bountyId))
+				buildBountyEmbed(bounty, collectedInteraction.guild, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId))
 					.then(async embed => {
 						if (collectedInteraction.channel.archived) {
 							await collectedInteraction.channel.setArchived(false, "completers removed from bounty");

--- a/source/frontend/buttons/bbtakedown.js
+++ b/source/frontend/buttons/bbtakedown.js
@@ -8,7 +8,7 @@ let logicLayer;
 
 const mainId = "bbtakedown";
 module.exports = new ButtonWrapper(mainId, 3000,
-	(interaction, runMode, [bountyId]) => {
+	(interaction, origin, runMode, [bountyId]) => {
 		logicLayer.bounties.findBounty(bountyId).then(async bounty => {
 			if (bounty.userId !== interaction.user.id) {
 				interaction.reply({ content: "Only the bounty poster can take down their bounty.", flags: MessageFlags.Ephemeral });
@@ -34,14 +34,12 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				logicLayer.bounties.deleteBountyCompletions(bountyId);
 				bounty.destroy();
 
-				logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
-					hunter.decrement("xp");
-					const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-					await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
-					const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-					const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks);
-					syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.id);
-				})
+				origin.hunter.decrement("xp");
+				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
+				await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
+				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+				const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks);
+				syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.id);
 
 				return collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
 			}).catch(error => {

--- a/source/frontend/classes/CommandWrapper.js
+++ b/source/frontend/classes/CommandWrapper.js
@@ -1,6 +1,6 @@
 const { PermissionFlagsBits, CommandInteraction, SlashCommandBuilder, InteractionContextType } = require("discord.js");
 const { BuildError } = require("./BuildError.js");
-const { InteractionWrapper } = require("./InteractionWrapper.js");
+const { InteractionWrapper, InteractionOrigin } = require("./InteractionWrapper.js");
 
 class CommandWrapper extends InteractionWrapper {
 	/** Additional wrapper properties for command parsing
@@ -10,7 +10,7 @@ class CommandWrapper extends InteractionWrapper {
 	 * @param {boolean} isPremiumCommand
 	 * @param {InteractionContextType[]} contextEnums
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: CommandInteraction, runMode: "development" | "test" | "production") => void} executeFunction
+	 * @param {(interaction: CommandInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production") => void} executeFunction
 	 */
 	constructor(mainIdInput, descriptionInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);
@@ -78,7 +78,7 @@ class SubcommandWrapper {
 	/**
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
-	 * @param {(interaction: CommandInteraction, runMode: string, ...args: [typeof import("../../logic/index.js"), unknown]) => Promise<void>} executeFunction
+	 * @param {(interaction: CommandInteraction, origin: InteractionOrigin, runMode: string, logicLayer: typeof import("../../logic/index.js")) => Promise<void>} executeFunction
 	 */
 	constructor(nameInput, descriptionInput, executeFunction) {
 		this.data = {

--- a/source/frontend/classes/InteractionWrapper.js
+++ b/source/frontend/classes/InteractionWrapper.js
@@ -1,12 +1,22 @@
 const { MAX_SET_TIMEOUT } = require("../../constants.js");
 const { Interaction, PermissionFlagsBits, InteractionContextType, ContextMenuCommandBuilder, ApplicationCommandType, ContextMenuCommandInteraction, UserContextMenuCommandInteraction, MessageContextMenuCommandInteraction } = require("discord.js");
 const { BuildError } = require("./BuildError.js");
+const { Company, User, Hunter } = require("../../database/models/index.js");
+
+class InteractionOrigin {
+	/** @type {Company} */
+	company;
+	/** @type {User} */
+	user;
+	/** @type {Hunter} */
+	hunter;
+}
 
 class InteractionWrapper {
 	/** IHP wrapper for interaction responses
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: Interaction, args: string[]) => void} executeFunction
+	 * @param {(interaction: Interaction, origin: InteractionOrigin, args: string[]) => void} executeFunction
 	*/
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		if (cooldownInMS > MAX_SET_TIMEOUT) {
@@ -59,7 +69,7 @@ class ContextMenuWrapper extends InteractionWrapper {
 	 * @param {boolean} isPremiumCommand
 	 * @param {InteractionContextType[]} contextEnums
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: ContextMenuCommandInteraction, runMode: "development" | "test" | "production") => void} executeFunction
+	 * @param {(interaction: ContextMenuCommandInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production") => void} executeFunction
 	 */
 	constructor(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);
@@ -81,7 +91,7 @@ class UserContextMenuWrapper extends ContextMenuWrapper {
 	 * @param {boolean} isPremiumCommand
 	 * @param {InteractionContextType[]} contextEnums
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: UserContextMenuCommandInteraction, runMode: "development" | "test" | "production") => void} executeFunction
+	 * @param {(interaction: UserContextMenuCommandInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production") => void} executeFunction
 	 */
 	constructor(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction) {
 		super(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction);
@@ -97,7 +107,7 @@ class MessageContextMenuWrapper extends ContextMenuWrapper {
 	 * @param {boolean} isPremiumCommand
 	 * @param {InteractionContextType[]} contextEnums
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: MessageContextMenuCommandInteraction, runMode: "development" | "test" | "production") => void} executeFunction
+	 * @param {(interaction: MessageContextMenuCommandInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production") => void} executeFunction
 	 */
 	constructor(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction) {
 		super(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction);
@@ -105,4 +115,4 @@ class MessageContextMenuWrapper extends ContextMenuWrapper {
 	}
 };
 
-module.exports = { InteractionWrapper, ContextMenuWrapper, UserContextMenuWrapper, MessageContextMenuWrapper };
+module.exports = { InteractionOrigin, InteractionWrapper, ContextMenuWrapper, UserContextMenuWrapper, MessageContextMenuWrapper };

--- a/source/frontend/classes/ItemTemplate.js
+++ b/source/frontend/classes/ItemTemplate.js
@@ -1,4 +1,5 @@
 const { CommandInteraction } = require("discord.js");
+const { InteractionOrigin } = require("./InteractionWrapper");
 
 class ItemTemplateSet {
 	/** @param {ItemTemplate[]} itemTemplates */
@@ -18,7 +19,7 @@ class ItemTemplate {
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: CommandInteraction) => Promise<boolean>} effectFunction
+	 * @param {(interaction: CommandInteraction, origin: InteractionOrigin) => Promise<boolean>} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, cooldownInMS, effectFunction) {
 		this.name = nameInput;

--- a/source/frontend/classes/MessageComponentWrapper.js
+++ b/source/frontend/classes/MessageComponentWrapper.js
@@ -1,11 +1,11 @@
 const { ButtonInteraction, AnySelectMenuInteraction } = require("discord.js");
-const { InteractionWrapper } = require("./InteractionWrapper.js");
+const { InteractionWrapper, InteractionOrigin } = require("./InteractionWrapper.js");
 
 class MessageComponentWrapper extends InteractionWrapper {
 	/** IHP parent wrapper for buttons and selects
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: ButtonInteraction | AnySelectMenuInteraction, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
+	 * @param {(interaction: ButtonInteraction | AnySelectMenuInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
 	 */
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);
@@ -18,7 +18,7 @@ class ButtonWrapper extends MessageComponentWrapper {
 	/** IHP wrapper for button responses
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: ButtonInteraction, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
+	 * @param {(interaction: ButtonInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
 	 */
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);
@@ -29,7 +29,7 @@ class SelectWrapper extends MessageComponentWrapper {
 	/** IHP wrapper for any select responses
 	 * @param {string} mainIdInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: AnySelectMenuInteraction, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
+	 * @param {(interaction: AnySelectMenuInteraction, origin: InteractionOrigin, runMode: "development" | "test" | "production", ...args: string[]) => void} executeFunction
 	 */
 	constructor(mainIdInput, cooldownInMS, executeFunction) {
 		super(mainIdInput, cooldownInMS, executeFunction);

--- a/source/frontend/commands/_command_blueprint.js
+++ b/source/frontend/commands/_command_blueprint.js
@@ -9,7 +9,7 @@ const mainId = "";
 const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDictionary } = createSubcommandMappings(mainId, []);
 module.exports = new CommandWrapper(mainId, "description", PermissionFlagsBits.ViewChannel, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Command specifications go here */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 
 	}
 ).setOptions(

--- a/source/frontend/commands/_subcommand_blueprint.js
+++ b/source/frontend/commands/_subcommand_blueprint.js
@@ -1,7 +1,7 @@
 const { SubcommandWrapper } = require("../classes");
 
 module.exports = new SubcommandWrapper("", "",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 
 	}
 ).setOptions(

--- a/source/frontend/commands/about.js
+++ b/source/frontend/commands/about.js
@@ -6,14 +6,14 @@ const { BOUNTYBOT_INVITE_URL } = require("../../constants");
 const mainId = "about";
 module.exports = new CommandWrapper(mainId, "Get BountyBot's description and contributors", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Get BountyBot's description and contributors */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		fs.promises.stat(__filename).then(stats => {
 			const avatarURL = interaction.client.user.avatarURL();
 			interaction.reply({
 				embeds: [
 					new EmbedBuilder().setColor(Colors.Blurple)
 						.setAuthor({ name: "Imaginary Horizons Productions", iconURL: "https://cdn.discordapp.com/icons/353575133157392385/c78041f52e8d6af98fb16b8eb55b849a.png", url: "https://discord.gg/3QqFqHc" })
-						.setTitle("About BountyBot (v2.9.0)")
+						.setTitle("About BountyBot (v2.10.0fi)")
 						.setURL(BOUNTYBOT_INVITE_URL)
 						.setThumbnail(avatarURL)
 						.setDescription("BountyBot is a Discord bot that facilitates community interaction by allowing users to create server-wide quests and rewarding active server particpation.")

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -6,7 +6,7 @@ const { textsHaveAutoModInfraction, commandMention, bountiesToSelectOptions, bui
 const { SKIP_INTERACTION_HANDLING, YEAR_IN_MS } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("edit", "Edit the title, description, image, or time of one of your bounties",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, poster]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: "You don't seem to have any open bounties at the moment.", flags: MessageFlags.Ephemeral });
@@ -181,10 +181,9 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				bounty.save();
 
 				// update bounty board
-				const [company] = await logicLayer.companies.findOrCreateCompany(modalSubmission.guildId);
-				const bountyEmbed = await buildBountyEmbed(bounty, modalSubmission.guild, poster.getLevel(company.xpCoefficient), false, company, await logicLayer.bounties.getHunterIdSet(bountyId));
-				if (company.bountyBoardId) {
-					interaction.guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
+				const bountyEmbed = await buildBountyEmbed(bounty, modalSubmission.guild, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId));
+				if (origin.company.bountyBoardId) {
+					interaction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
 						return bountyBoard.threads.fetch(bounty.postingId);
 					}).then(async thread => {
 						if (thread.archived) {

--- a/source/frontend/commands/bounty/index.js
+++ b/source/frontend/commands/bounty/index.js
@@ -18,10 +18,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"take-down.js",
 ]);
 module.exports = new CommandWrapper(mainId, "Bounties are user-created objectives for other server members to complete", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
-	async (interaction, runMode) => {
-		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
-		const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer, hunter);
+	async (interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/bounty/record-turn-ins.js
+++ b/source/frontend/commands/bounty/record-turn-ins.js
@@ -5,7 +5,7 @@ const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("record-turn-ins", "Record turn-ins of one of your bounties for up to 5 bounty hunters",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, poster]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: `You don't currently have any open bounties. Post one with ${commandMention("bounty post")}?`, flags: MessageFlags.Ephemeral });
@@ -57,10 +57,9 @@ module.exports = new SubcommandWrapper("record-turn-ins", "Record turn-ins of on
 							sentences.unshift("No new turn-ins were able to be recorded. You cannot credit yourself or bots for your own bounties.");
 						} else {
 							await logicLayer.bounties.bulkCreateCompletions(bounty.id, bounty.companyId, Array.from(eligibleTurnInIds), null);
-							const company = await logicLayer.companies.findCompanyByPK(bounty.companyId);
 							const newTurnInList = listifyEN(Array.from(newTurnInIds.values().map(id => userMention(id))));
 							sentences.unshift(`Turn-ins of ${bold(bounty.title)} have been recorded for the following hunters: ${newTurnInList}`);
-							const post = await updatePosting(collectedInteraction.guild, company, bounty, poster.getLevel(company.xpCoefficient), eligibleTurnInIds);
+							const post = await updatePosting(collectedInteraction.guild, origin.company, bounty, origin.hunter.getLevel(origin.company.xpCoefficient), eligibleTurnInIds);
 							if (post) {
 								post.channel.send({ content: `${newTurnInList} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${congratulationBuilder()}!` });
 							}

--- a/source/frontend/commands/bounty/revoke-turn-ins.js
+++ b/source/frontend/commands/bounty/revoke-turn-ins.js
@@ -5,7 +5,7 @@ const { timeConversion } = require("../../../shared");
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("revoke-turn-ins", "Revoke the turn-ins of up to 5 bounty hunters on one of your bounties",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, poster]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: `You don't currently have any open bounties. Post one with ${commandMention("bounty post")}?`, flags: MessageFlags.Ephemeral });
@@ -44,8 +44,7 @@ module.exports = new SubcommandWrapper("revoke-turn-ins", "Revoke the turn-ins o
 						break;
 					case "hunters":
 						await logicLayer.bounties.deleteSelectedBountyCompletions(bounty.id, collectedInteraction.values);
-						const company = await logicLayer.companies.findCompanyByPK(collectedInteraction.guildId);
-						const post = await updatePosting(collectedInteraction.guild, company, bounty, poster.getLevel(company.xpCoefficient), await logicLayer.bounties.getHunterIdSet(bounty.id));
+						const post = await updatePosting(collectedInteraction.guild, origin.company, bounty, origin.hunter.getLevel(origin.company.xpCoefficient), await logicLayer.bounties.getHunterIdSet(bounty.id));
 						if (post) {
 							post.channel.send({ content: `${listifyEN(collectedInteraction.values.map(id => `<@${id}>`))} ${collectedInteraction.values.length === 1 ? "has had their turn-in" : "have had their turn-ins"} revoked.` });
 						}

--- a/source/frontend/commands/commands.js
+++ b/source/frontend/commands/commands.js
@@ -4,7 +4,7 @@ const { CommandWrapper } = require('../classes');
 const mainId = "commands";
 module.exports = new CommandWrapper(mainId, "Get a link to BountyBot's commands wiki", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Link the user to the repo Commands wiki page (automatically updated) */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		interaction.reply({ content: "Here's a [link to the BountyBot Commands page](<https://github.com/Imaginary-Horizons-Productions/BountyBot/wiki/Commands>).", flags: MessageFlags.Ephemeral });
 	}
 );

--- a/source/frontend/commands/config-premium.js
+++ b/source/frontend/commands/config-premium.js
@@ -2,109 +2,104 @@ const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('d
 const { CommandWrapper } = require('../classes');
 const { GLOBAL_MAX_BOUNTY_SLOTS } = require('../../constants');
 
-/** @type {typeof import("../../logic")} */
-let logicLayer;
-
 const mainId = "config-premium";
 module.exports = new CommandWrapper(mainId, "Configure premium BountyBot settings for this server", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		logicLayer.companies.findOrCreateCompany(interaction.guild.id).then(([company]) => {
-			const updatePayload = {};
-			let content = "The following server settings have been configured:";
-			const errors = [];
+	(interaction, origin, runMode) => {
+		const updatePayload = {};
+		let content = "The following server settings have been configured:";
+		const errors = [];
 
-			const xpCoefficient = interaction.options.getNumber("level-threshold-multiplier");
-			if (xpCoefficient !== null) {
-				if (xpCoefficient <= 0) {
-					errors.push(`${xpCoefficient} could not be set for Level Threshold Multiplier. It must be a number greater than 0.`)
-				} else {
-					updatePayload.xpCoefficient = xpCoefficient;
-					content += `\n- The Level Threshold Multiplier has been set to ${xpCoefficient}.`;
-				}
+		const xpCoefficient = interaction.options.getNumber("level-threshold-multiplier");
+		if (xpCoefficient !== null) {
+			if (xpCoefficient <= 0) {
+				errors.push(`${xpCoefficient} could not be set for Level Threshold Multiplier. It must be a number greater than 0.`)
+			} else {
+				updatePayload.xpCoefficient = xpCoefficient;
+				content += `\n- The Level Threshold Multiplier has been set to ${xpCoefficient}.`;
 			}
+		}
 
-			const slots = interaction.options.getInteger("bounty-slots");
-			if (slots !== null) {
-				if (slots < 1 || slots > GLOBAL_MAX_BOUNTY_SLOTS) {
-					errors.push(`${slots} could not be set for Bounty Slots. It must be a number between 1 and ${GLOBAL_MAX_BOUNTY_SLOTS} (inclusive).`);
-				} else {
-					updatePayload.maxSimBounties = slots;
-					content += `\n- Max bounty slots a bounty hunter can have (including earned slots) has been set to ${slots}.`;
-				}
+		const slots = interaction.options.getInteger("bounty-slots");
+		if (slots !== null) {
+			if (slots < 1 || slots > GLOBAL_MAX_BOUNTY_SLOTS) {
+				errors.push(`${slots} could not be set for Bounty Slots. It must be a number between 1 and ${GLOBAL_MAX_BOUNTY_SLOTS} (inclusive).`);
+			} else {
+				updatePayload.maxSimBounties = slots;
+				content += `\n- Max bounty slots a bounty hunter can have (including earned slots) has been set to ${slots}.`;
 			}
+		}
 
-			const toastThumbnailURL = interaction.options.getString("toast-thumbnail-url");
-			if (toastThumbnailURL) {
-				try {
-					new URL(toastThumbnailURL);
-					updatePayload.toastThumbnailURL = toastThumbnailURL;
-					content += `\n- The toast thumbnail was set to <${toastThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const toastThumbnailURL = interaction.options.getString("toast-thumbnail-url");
+		if (toastThumbnailURL) {
+			try {
+				new URL(toastThumbnailURL);
+				updatePayload.toastThumbnailURL = toastThumbnailURL;
+				content += `\n- The toast thumbnail was set to <${toastThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			const openBountyThumbnailURL = interaction.options.getString("open-bounty-thumbnail-url");
-			if (openBountyThumbnailURL) {
-				try {
-					new URL(openBountyThumbnailURL);
-					updatePayload.openBountyThumbnailURL = openBountyThumbnailURL;
-					content += `\n- The open bounty thumbnail was set to <${openBountyThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const openBountyThumbnailURL = interaction.options.getString("open-bounty-thumbnail-url");
+		if (openBountyThumbnailURL) {
+			try {
+				new URL(openBountyThumbnailURL);
+				updatePayload.openBountyThumbnailURL = openBountyThumbnailURL;
+				content += `\n- The open bounty thumbnail was set to <${openBountyThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			const completedBountyThumbnailURL = interaction.options.getString("completed-bounty-thumbnail-url");
-			if (completedBountyThumbnailURL) {
-				try {
-					new URL(completedBountyThumbnailURL);
-					updatePayload.completedBountyThumbnailURL = completedBountyThumbnailURL;
-					content += `\n- The completed bounty thumbnail was set to <${completedBountyThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const completedBountyThumbnailURL = interaction.options.getString("completed-bounty-thumbnail-url");
+		if (completedBountyThumbnailURL) {
+			try {
+				new URL(completedBountyThumbnailURL);
+				updatePayload.completedBountyThumbnailURL = completedBountyThumbnailURL;
+				content += `\n- The completed bounty thumbnail was set to <${completedBountyThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			const deletedBountyThumbnailURL = interaction.options.getString("deleted-bounty-thumbnail-url");
-			if (deletedBountyThumbnailURL) {
-				try {
-					new URL(deletedBountyThumbnailURL);
-					updatePayload.deletedBountyThumbnailURL = deletedBountyThumbnailURL;
-					content += `\n- The deleted bounty thumbnail was set to <${deletedBountyThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const deletedBountyThumbnailURL = interaction.options.getString("deleted-bounty-thumbnail-url");
+		if (deletedBountyThumbnailURL) {
+			try {
+				new URL(deletedBountyThumbnailURL);
+				updatePayload.deletedBountyThumbnailURL = deletedBountyThumbnailURL;
+				content += `\n- The deleted bounty thumbnail was set to <${deletedBountyThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			const scoreboardThumbnailURL = interaction.options.getString("scoreboard-thumbnail-url");
-			if (scoreboardThumbnailURL) {
-				try {
-					new URL(scoreboardThumbnailURL);
-					updatePayload.scoreboardThumbnailURL = scoreboardThumbnailURL;
-					content += `\n- The scoreboard thumbnail was set to <${scoreboardThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const scoreboardThumbnailURL = interaction.options.getString("scoreboard-thumbnail-url");
+		if (scoreboardThumbnailURL) {
+			try {
+				new URL(scoreboardThumbnailURL);
+				updatePayload.scoreboardThumbnailURL = scoreboardThumbnailURL;
+				content += `\n- The scoreboard thumbnail was set to <${scoreboardThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			const goalCompletionThumbnailURL = interaction.options.getString("goal-completion-thumbnail-url");
-			if (goalCompletionThumbnailURL) {
-				try {
-					new URL(goalCompletionThumbnailURL);
-					updatePayload.goalCompletionThumbnailURL = goalCompletionThumbnailURL;
-					content += `\n- The server bonuses thumbnail was set to <${goalCompletionThumbnailURL}>.`;
-				} catch (error) {
-					errors.push(error.message);
-				}
+		const goalCompletionThumbnailURL = interaction.options.getString("goal-completion-thumbnail-url");
+		if (goalCompletionThumbnailURL) {
+			try {
+				new URL(goalCompletionThumbnailURL);
+				updatePayload.goalCompletionThumbnailURL = goalCompletionThumbnailURL;
+				content += `\n- The server bonuses thumbnail was set to <${goalCompletionThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
 			}
+		}
 
-			company.update(updatePayload);
-			if (errors.length > 0) {
-				content += `\n\nThe following errors were encountered:\n- ${errors.join("\n- ")}`;
-			}
-			interaction.reply({ content, flags: MessageFlags.Ephemeral });
-		});
+		origin.company.update(updatePayload);
+		if (errors.length > 0) {
+			content += `\n\nThe following errors were encountered:\n- ${errors.join("\n- ")}`;
+		}
+		interaction.reply({ content, flags: MessageFlags.Ephemeral });
 	}
 ).setOptions(
 	{
@@ -155,6 +150,4 @@ module.exports = new CommandWrapper(mainId, "Configure premium BountyBot setting
 		description: "Configure the image shown in the thumbnail of the server goal completion message",
 		required: false
 	}
-).setLogicLinker(logicBlob => {
-	logicLayer = logicBlob;
-});
+);

--- a/source/frontend/commands/config-server.js
+++ b/source/frontend/commands/config-server.js
@@ -1,25 +1,20 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags } = require('discord.js');
 const { CommandWrapper } = require('../classes');
 
-/** @type {typeof import("../../logic")} */
-let logicLayer;
-
 const mainId = "config-server";
 module.exports = new CommandWrapper(mainId, "Configure BountyBot settings for this server", PermissionFlagsBits.ManageGuild, false, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		logicLayer.companies.findOrCreateCompany(interaction.guild.id).then(([company]) => {
-			const updatePayload = {};
-			let content = "The following server settings have been configured:";
+	(interaction, origin, runMode) => {
+		const updatePayload = {};
+		let content = "The following server settings have been configured:";
 
-			const prefix = interaction.options.getString("notification");
-			if (prefix !== null) {
-				updatePayload.announcementPrefix = prefix === "(nothing)" ? "" : prefix;
-				content += `\n- The announcment prefix was set to ${prefix}`;
-			}
+		const prefix = interaction.options.getString("notification");
+		if (prefix !== null) {
+			updatePayload.announcementPrefix = prefix === "(nothing)" ? "" : prefix;
+			content += `\n- The announcment prefix was set to ${prefix}`;
+		}
 
-			company.update(updatePayload);
-			interaction.reply({ content, flags: MessageFlags.Ephemeral });
-		});
+		origin.company.update(updatePayload);
+		interaction.reply({ content, flags: MessageFlags.Ephemeral });
 	}
 ).setOptions(
 	{
@@ -34,6 +29,4 @@ module.exports = new CommandWrapper(mainId, "Configure BountyBot settings for th
 			{ name: "Suppress notifications (@silent)", value: "@silent" }
 		]
 	}
-).setLogicLinker(logicBlob => {
-	logicLayer = logicBlob;
-});
+);

--- a/source/frontend/commands/create-default/bounty-board-forum.js
+++ b/source/frontend/commands/create-default/bounty-board-forum.js
@@ -5,7 +5,7 @@ const { SAFE_DELIMITER } = require("../../../constants");
 const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("bounty-board-forum", "Create a new bounty board forum channel sibling to this channel",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, company]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const bountyBoard = await interaction.guild.channels.create({
 			parent: interaction.channel.parentId,
 			name: "the-bounty-board",
@@ -29,21 +29,21 @@ module.exports = new SubcommandWrapper("bounty-board-forum", "Create a new bount
 			reason: `/create-default bounty-board-forum by ${interaction.user}`
 		});
 
-		company.bountyBoardId = bountyBoard.id;
+		origin.company.bountyBoardId = bountyBoard.id;
 		const [{ id: openTagId }, { id: completedTagId }] = bountyBoard.availableTags;
-		company.bountyBoardOpenTagId = openTagId;
-		company.bountyBoardCompletedTagId = completedTagId;
+		origin.company.bountyBoardOpenTagId = openTagId;
+		origin.company.bountyBoardCompletedTagId = completedTagId;
 
 		const evergreenBounties = [];
 		logicLayer.bounties.findCompanyBountiesByCreationDate(interaction.guildId).then(async bounties => {
-			const allHunters = await logicLayer.hunters.findCompanyHunters(company.id);
+			const allHunters = await logicLayer.hunters.findCompanyHunters(origin.company.id);
 			for (const bounty of bounties) {
 				if (bounty.isEvergreen) {
 					evergreenBounties.unshift(bounty);
 					continue;
 				}
 				const poster = allHunters.find(hunter => hunter.userId === bounty.userId);
-				buildBountyEmbed(bounty, interaction.guild, bounty.userId == interaction.client.user.id ? company.getLevel(allHunters) : poster.getLevel(company.xpCoefficient), false, company, await logicLayer.bounties.getHunterIdSet(bounty.id)).then(bountyEmbed => {
+				buildBountyEmbed(bounty, interaction.guild, bounty.userId == interaction.client.user.id ? origin.company.getLevel(allHunters) : poster.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id)).then(bountyEmbed => {
 					return bountyBoard.threads.create({
 						name: bounty.title,
 						message: {
@@ -77,14 +77,14 @@ module.exports = new SubcommandWrapper("bounty-board-forum", "Create a new bount
 
 			// make Evergreen Bounty list
 			if (evergreenBounties.length > 0) {
-				const companyLevel = company.getLevel(allHunters);
-				Promise.all(evergreenBounties.map(async bounty => buildBountyEmbed(bounty, interaction.guild, companyLevel, false, company, await logicLayer.bounties.getHunterIdSet(bounty.id)))).then(embeds => {
-					generateBountyBoardThread(bountyBoard.threads, embeds, company);
+				const companyLevel = origin.company.getLevel(allHunters);
+				Promise.all(evergreenBounties.map(async bounty => buildBountyEmbed(bounty, interaction.guild, companyLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id)))).then(embeds => {
+					generateBountyBoardThread(bountyBoard.threads, embeds, origin.company);
 				})
 			}
 		});
 
-		company.save();
+		origin.company.save();
 		interaction.reply({ content: `A new bounty board has been created: ${bountyBoard}`, flags: MessageFlags.Ephemeral });
 	}
 );

--- a/source/frontend/commands/create-default/index.js
+++ b/source/frontend/commands/create-default/index.js
@@ -12,10 +12,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"rank-roles.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Create a Discord resource for use by BountyBot", PermissionFlagsBits.ManageChannels, false, [InteractionContextType.Guild], 30000,
-	(interaction, runMode) => {
-		logicLayer.companies.findOrCreateCompany(interaction.guild.id).then(([company]) => {
-			subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer, company);
-		});
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/create-default/rank-roles.js
+++ b/source/frontend/commands/create-default/rank-roles.js
@@ -2,7 +2,7 @@ const { GuildPremiumTier, MessageFlags } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("rank-roles", "Create the default ranks for this server including Discord roles (and delete old ranks)",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		await Promise.all(
 			(await logicLayer.ranks.findAllRanks(interaction.guild.id))

--- a/source/frontend/commands/create-default/scoreboard-reference.js
+++ b/source/frontend/commands/create-default/scoreboard-reference.js
@@ -3,7 +3,7 @@ const { SubcommandWrapper } = require("../../classes");
 const { seasonalScoreboardEmbed, overallScoreboardEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("scoreboard-reference", "Create a reference channel with the BountyBot Scoreboard",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, company]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const scoreboard = await interaction.guild.channels.create({
 			parent: interaction.channel.parentId,
 			name: "bountybot-scoreboard",
@@ -27,15 +27,15 @@ module.exports = new SubcommandWrapper("scoreboard-reference", "Create a referen
 		const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
 		if (isSeasonal) {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-			embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
+			embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
 		} else {
-			embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
 		}
 		scoreboard.send({ embeds }).then(message => {
-			company.scoreboardChannelId = scoreboard.id;
-			company.scoreboardMessageId = message.id;
-			company.scoreboardIsSeasonal = isSeasonal;
-			company.save();
+			origin.company.scoreboardChannelId = scoreboard.id;
+			origin.company.scoreboardMessageId = message.id;
+			origin.company.scoreboardIsSeasonal = isSeasonal;
+			origin.company.save();
 		});
 		interaction.reply({ content: `A new scoreboard reference channel has been created: ${scoreboard}`, flags: MessageFlags.Ephemeral });
 	}

--- a/source/frontend/commands/data-policy.js
+++ b/source/frontend/commands/data-policy.js
@@ -4,7 +4,7 @@ const { CommandWrapper } = require('../classes');
 const mainId = "data-policy";
 module.exports = new CommandWrapper(mainId, "Get a link to BountyBot's data policy page", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Link the user to the repo Data Policy wiki page (automatically updated) */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		interaction.reply({ content: "Here's a [link to the BountyBot Data Policy page](<https://github.com/Imaginary-Horizons-Productions/BountyBot/wiki/Data-Policy>).", flags: MessageFlags.Ephemeral });
 	}
 );

--- a/source/frontend/commands/evergreen/edit.js
+++ b/source/frontend/commands/evergreen/edit.js
@@ -6,7 +6,7 @@ const { textsHaveAutoModInfraction, bountiesToSelectOptions, buildBountyEmbed, t
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("edit", "Change the name, description, or image of an evergreen bounty",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const openBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
 		if (openBounties.length < 1) {
 			interaction.reply({ content: "This server doesn't seem to have any open evergreen bounties at the moment.", flags: MessageFlags.Ephemeral });
@@ -100,19 +100,18 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 				selectedBounty.save();
 
 				// update bounty board
-				const [company] = await logicLayer.companies.findOrCreateCompany(modalSubmission.guildId);
 				const allHunters = await logicLayer.hunters.findCompanyHunters(modalSubmission.guild.id);
-				const currentCompanyLevel = company.getLevel(allHunters);
-				if (company.bountyBoardId) {
-					const embeds = await Promise.all(openBounties.map(bounty => buildBountyEmbed(bounty, modalSubmission.guild, currentCompanyLevel, false, company, new Set())));
-					const bountyBoard = await modalSubmission.guild.channels.fetch(company.bountyBoardId);
-					bountyBoard.threads.fetch(company.evergreenThreadId).then(async thread => {
+				const currentCompanyLevel = origin.company.getLevel(allHunters);
+				if (origin.company.bountyBoardId) {
+					const embeds = await Promise.all(openBounties.map(bounty => buildBountyEmbed(bounty, modalSubmission.guild, currentCompanyLevel, false, origin.company, new Set())));
+					const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
+					bountyBoard.threads.fetch(origin.company.evergreenThreadId).then(async thread => {
 						const message = await thread.fetchStarterMessage();
 						message.edit({ embeds });
 					});
 				}
 
-				const bountyEmbed = await buildBountyEmbed(selectedBounty, modalSubmission.guild, currentCompanyLevel, false, company, new Set());
+				const bountyEmbed = await buildBountyEmbed(selectedBounty, modalSubmission.guild, currentCompanyLevel, false, origin.company, new Set());
 				modalSubmission.reply({ content: "Here's the embed for the newly edited evergreen bounty:", embeds: [bountyEmbed], flags: MessageFlags.Ephemeral });
 			});
 		}).catch(error => {

--- a/source/frontend/commands/evergreen/index.js
+++ b/source/frontend/commands/evergreen/index.js
@@ -15,8 +15,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"take-down.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Evergreen Bounties are not closed after completion; ideal for server-wide objectives", PermissionFlagsBits.ManageChannels, true, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer);
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/evergreen/showcase.js
+++ b/source/frontend/commands/evergreen/showcase.js
@@ -4,7 +4,7 @@ const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { bountiesToSelectOptions, buildBountyEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("showcase", "Show the embed for an evergreen bounty",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const existingBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
 		if (existingBounties.length < 1) {
 			interaction.reply({ content: "This server doesn't have any open evergreen bounties posted.", flags: MessageFlags.Ephemeral });
@@ -30,9 +30,8 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for an evergr
 					return collectedInteraction;
 				}
 
-				const [company] = await logicLayer.companies.findOrCreateCompany(collectedInteraction.guildId);
-				const currentCompanyLevel = company.getLevel(await logicLayer.hunters.findCompanyHunters(collectedInteraction.guild.id));
-				buildBountyEmbed(bounty, interaction.guild, currentCompanyLevel, false, company, new Set()).then(embed => {
+				const currentCompanyLevel = origin.company.getLevel(await logicLayer.hunters.findCompanyHunters(collectedInteraction.guild.id));
+				buildBountyEmbed(bounty, interaction.guild, currentCompanyLevel, false, origin.company, new Set()).then(embed => {
 					const payload = { embeds: [embed] };
 					const extraText = interaction.options.get("extra-text");
 					if (extraText) {

--- a/source/frontend/commands/feedback.js
+++ b/source/frontend/commands/feedback.js
@@ -6,7 +6,7 @@ const { testGuildId, feedbackChannelId, SKIP_INTERACTION_HANDLING } = require('.
 const mainId = "feedback";
 module.exports = new CommandWrapper(mainId, "Provide BountyBot feedback and get an invite to the test server", PermissionFlagsBits.SendMessages, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Open the modal associated with the feedback type to prompt more specific information */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		if (!testGuildId || !feedbackChannelId) {
 			interaction.reply({ content: "The test server is not yet configured to receive feedback, thanks for your patience.", flags: MessageFlags.Ephemeral });
 			return;

--- a/source/frontend/commands/festival/close.js
+++ b/source/frontend/commands/festival/close.js
@@ -2,20 +2,20 @@ const { SubcommandWrapper } = require("../../classes");
 const { sendAnnouncement, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("close", "End the festival, returning to normal XP",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, company]) {
-		company.update({ "festivalMultiplier": 1 });
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
+		origin.company.update({ "festivalMultiplier": 1 });
 		interaction.guild.members.fetchMe().then(bountyBot => {
 			bountyBot.setNickname(null);
 		})
-		interaction.reply(sendAnnouncement(company, { content: "The XP multiplier festival has ended. Hope you participate next time!" }));
+		interaction.reply(sendAnnouncement(origin.company, { content: "The XP multiplier festival has ended. Hope you participate next time!" }));
 		const embeds = [];
 		const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-		if (company.scoreboardIsSeasonal) {
+		if (origin.company.scoreboardIsSeasonal) {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-			embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
+			embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
 		} else {
-			embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
 		}
-		updateScoreboard(company, interaction.guild, embeds);
+		updateScoreboard(origin.company, interaction.guild, embeds);
 	}
 );

--- a/source/frontend/commands/festival/index.js
+++ b/source/frontend/commands/festival/index.js
@@ -12,10 +12,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 ]);
 module.exports = new CommandWrapper(mainId, "Manage a server-wide festival to multiply XP of bounty completions, toast reciepts, and crit toasts", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	/** Allow users to manage an XP multiplier festival */
-	(interaction, runMode) => {
-		logicLayer.companies.findOrCreateCompany(interaction.guild.id).then(([company]) => {
-			subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer, company);
-		});
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/festival/start.js
+++ b/source/frontend/commands/festival/start.js
@@ -3,13 +3,13 @@ const { SubcommandWrapper } = require("../../classes");
 const { sendAnnouncement, updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("start", "Start an XP multiplier festival",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer, company]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const multiplier = interaction.options.getNumber("multiplier");
 		if (!(multiplier >= 1)) {
 			interaction.reply({ content: `Multiplier must be greater than 1.`, flags: MessageFlags.Ephemeral })
 			return;
 		}
-		company.update({ "festivalMultiplier": multiplier });
+		origin.company.update({ "festivalMultiplier": multiplier });
 		interaction.guild.members.fetchMe().then(bountyBot => {
 			const multiplierTag = ` [XP x ${multiplier}]`;
 			const bountyBotName = bountyBot.nickname ?? bountyBot.displayName;
@@ -17,16 +17,16 @@ module.exports = new SubcommandWrapper("start", "Start an XP multiplier festival
 				bountyBot.setNickname(`${bountyBotName}${multiplierTag}`);
 			}
 		})
-		interaction.reply(sendAnnouncement(company, { content: `An XP multiplier festival has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
+		interaction.reply(sendAnnouncement(origin.company, { content: `An XP multiplier festival has started. Bounty and toast XP will be multiplied by ${multiplier}.` }));
 		const embeds = [];
 		const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-		if (company.scoreboardIsSeasonal) {
+		if (origin.company.scoreboardIsSeasonal) {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-			embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
+			embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
 		} else {
-			embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
 		}
-		updateScoreboard(company, interaction.guild, embeds);
+		updateScoreboard(origin.company, interaction.guild, embeds);
 	}
 ).setOptions(
 	{

--- a/source/frontend/commands/inventory.js
+++ b/source/frontend/commands/inventory.js
@@ -7,7 +7,7 @@ let logicLayer;
 
 const mainId = "inventory";
 module.exports = new CommandWrapper(mainId, "Show your inventory of usable items", PermissionFlagsBits.ViewChannel, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		logicLayer.items.getInventory(interaction.user.id).then(itemRows => {
 			let content = `Here are the items in your inventory (use them with ${commandMention("item")}):\n- `;
 			if (itemRows.length > 0) {

--- a/source/frontend/commands/item.js
+++ b/source/frontend/commands/item.js
@@ -11,7 +11,7 @@ const ITEM_COOLDOWNS = new Map();
 
 const mainId = "item";
 module.exports = new CommandWrapper(mainId, "Get details on a selected item and a button to use it", PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		const itemName = interaction.options.getString("item-name");
 		const itemRow = await logicLayer.items.findUserItemEntry(interaction.user.id, itemName);
 		const hasItem = itemRow !== null && itemRow.count > 0 || runMode !== "production";
@@ -72,7 +72,7 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 				setTimeout(() => timestamps.delete(collectedInteration.user.id), getItemCooldown(itemName));
 			}
 
-			return useItem(itemName, collectedInteration).then(shouldSkipDecrement => {
+			return useItem(itemName, collectedInteration, origin).then(shouldSkipDecrement => {
 				if (!shouldSkipDecrement && runMode === "production") {
 					itemRow.decrement("count");
 				}

--- a/source/frontend/commands/moderation/bountybot-ban.js
+++ b/source/frontend/commands/moderation/bountybot-ban.js
@@ -2,10 +2,15 @@ const { MessageFlags } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("bountybot-ban", "Toggle whether the provided user can interact with bounties or toasts",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const discordUser = interaction.options.getUser("user");
 		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
-		const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(discordUser.id, interaction.guild.id);
+		let hunter;
+		if (discordUser.id === origin.hunter.userId) {
+			hunter = origin.hunter;
+		} else {
+			hunter = (await logicLayer.hunters.findOrCreateBountyHunter(discordUser.id, interaction.guild.id)).hunter[0];
+		}
 		hunter.isBanned = !hunter.isBanned;
 		if (hunter.isBanned) {
 			hunter.hasBeenBanned = true;

--- a/source/frontend/commands/moderation/gp-penalty.js
+++ b/source/frontend/commands/moderation/gp-penalty.js
@@ -3,7 +3,7 @@ const { SubcommandWrapper } = require("../../classes");
 const { commandMention } = require("../../shared");
 
 module.exports = new SubcommandWrapper("gp-penalty", "Reduce the GP of the open Server Goal",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const penaltyValue = Math.abs(interaction.options.get("penalty", true).value);
 		const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guild.id);
 		if (!goal) {

--- a/source/frontend/commands/moderation/index.js
+++ b/source/frontend/commands/moderation/index.js
@@ -16,8 +16,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"xp-penalty.js"
 ]);
 module.exports = new CommandWrapper(mainId, "BountyBot moderation tools", PermissionFlagsBits.ManageRoles, false, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer);
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/moderation/revoke-goal-bonus.js
+++ b/source/frontend/commands/moderation/revoke-goal-bonus.js
@@ -2,9 +2,9 @@ const { MessageFlags, userMention } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("revoke-goal-bonus", "Revoke Goal contribution item find bonus",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const revokeOption = interaction.options.get("revokee", true);
-		const hunter = await logicLayer.hunters.findOneHunter(revokeOption.value, interaction.guild.id);
+		const hunter = revokeOption.value === origin.hunter.userId ? origin.hunter : await logicLayer.hunters.findOneHunter(revokeOption.value, interaction.guild.id);
 		if (!hunter) {
 			interaction.reply({ content: `${userMention(revokeOption.value)} hasn't interacted with BountyBot yet.`, flags: MessageFlags.Ephemeral });
 			return;

--- a/source/frontend/commands/moderation/season-disqualify.js
+++ b/source/frontend/commands/moderation/season-disqualify.js
@@ -3,7 +3,7 @@ const { SubcommandWrapper } = require("../../classes");
 const { syncRankRoles } = require("../../shared");
 
 module.exports = new SubcommandWrapper("season-disqualify", "Toggle disqualification from ranking for a bounty hunter in the current season",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const member = interaction.options.getMember("bounty-hunter");
 		await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 		const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);

--- a/source/frontend/commands/moderation/user-report.js
+++ b/source/frontend/commands/moderation/user-report.js
@@ -3,9 +3,9 @@ const { SubcommandWrapper } = require("../../classes");
 const { modStatsEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("user-report", "Get the BountyBot moderation stats for a user",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const member = interaction.options.getMember("user");
-		const hunter = await logicLayer.hunters.findOneHunter(member.id, interaction.guild.id);
+		const hunter = member.id === origin.hunter.userId ? origin.hunter : await logicLayer.hunters.findOneHunter(member.id, interaction.guild.id);
 		if (!hunter) {
 			interaction.reply({ content: `${member} has not interacted with BountyBot on this server.`, flags: MessageFlags.Ephemeral });
 			return;

--- a/source/frontend/commands/moderation/xp-penalty.js
+++ b/source/frontend/commands/moderation/xp-penalty.js
@@ -3,9 +3,9 @@ const { SubcommandWrapper } = require("../../classes");
 const { syncRankRoles } = require("../../shared");
 
 module.exports = new SubcommandWrapper("xp-penalty", "Reduce a bounty hunter's XP",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const member = interaction.options.getMember("bounty-hunter");
-		const hunter = await logicLayer.hunters.findOneHunter(member.id, interaction.guild.id);
+		const hunter = member.id === origin.hunter.userId ? origin.hunter : await logicLayer.hunters.findOneHunter(member.id, interaction.guild.id);
 		if (!hunter) {
 			interaction.reply({ content: `${member} hasn't interacted with BountyBot yet.`, flags: MessageFlags.Ephemeral });
 			return;

--- a/source/frontend/commands/premium.js
+++ b/source/frontend/commands/premium.js
@@ -5,7 +5,7 @@ const { ihpAuthorPayload, randomFooterTip } = require("../shared");
 
 const mainId = "premium";
 module.exports = new CommandWrapper(mainId, "List perks for supporting IHP development", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		fs.promises.stat(__filename).then(stats => {
 			interaction.reply({
 				embeds: [

--- a/source/frontend/commands/raffle/announce-upcoming.js
+++ b/source/frontend/commands/raffle/announce-upcoming.js
@@ -2,11 +2,10 @@ const { SubcommandWrapper } = require("../../classes");
 const { sendAnnouncement } = require("../../shared");
 
 module.exports = new SubcommandWrapper("announce-upcoming", "Announce an upcoming raffle",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
-		const company = await logicLayer.companies.findCompanyByPK(interaction.guild.id);
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const announcement = interaction.options.getString("announcement");
-		company.update({ nextRaffleString: announcement });
-		interaction.reply(sendAnnouncement(company, { content: announcement }));
+		origin.company.update({ nextRaffleString: announcement });
+		interaction.reply(sendAnnouncement(origin.company, { content: announcement }));
 	}
 ).setOptions(
 	{

--- a/source/frontend/commands/raffle/by-level.js
+++ b/source/frontend/commands/raffle/by-level.js
@@ -2,7 +2,7 @@ const { MessageFlags } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("by-level", "Select a user at or above a particular level",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const levelThreshold = interaction.options.getInteger("level");
 		const eligibleHunters = await logicLayer.hunters.findHuntersAtOrAboveLevel(interaction.guild.id, levelThreshold);
 		const eligibleMembers = await interaction.guild.members.fetch({ user: eligibleHunters.map(hunter => hunter.userId) });
@@ -13,9 +13,7 @@ module.exports = new SubcommandWrapper("by-level", "Select a user at or above a 
 		}
 		const winnerId = eligibleIds.at(Math.floor(Math.random() * eligibleIds.size));
 		interaction.reply(`The winner of this raffle is: <@${winnerId}>`);
-		logicLayer.companies.findCompanyByPK(interaction.guild.id).then(company => {
-			company.update("nextRaffleString", null);
-		});
+		origin.company.update("nextRaffleString", null);
 	}
 ).setOptions(
 	{

--- a/source/frontend/commands/raffle/by-rank.js
+++ b/source/frontend/commands/raffle/by-rank.js
@@ -4,7 +4,7 @@ const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { rankArrayToSelectOptions } = require("../../shared");
 
 module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a particular rank",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		if (ranks.length < 1) {
 			interaction.reply({ content: "This server doesn't have any ranks configured.", flags: MessageFlags.Ephemeral });
@@ -37,9 +37,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
 			collectedInteraction.update({ components: [] });
 			collectedInteraction.channel.send(`The winner of this raffle is: ${winner}`);
-			logicLayer.companies.findCompanyByPK(interaction.guild.id).then(company => {
-				company.update("nextRaffleString", null);
-			});
+			origin.company.update("nextRaffleString", null);
 		}).catch(error => {
 			if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {
 				return;

--- a/source/frontend/commands/raffle/index.js
+++ b/source/frontend/commands/raffle/index.js
@@ -12,8 +12,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"by-rank.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Randomly select a bounty hunter from a variety of pools", PermissionFlagsBits.ManageGuild, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
-	(interaction, runMode) => {
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer);
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/rank/add.js
+++ b/source/frontend/commands/rank/add.js
@@ -4,7 +4,7 @@ const { SubcommandWrapper } = require("../../classes");
 const { commandMention, syncRankRoles } = require("../../shared");
 
 module.exports = new SubcommandWrapper("add", "Add a seasonal rank for showing outstanding bounty hunters",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		const newThreshold = interaction.options.getNumber("variance-threshold");
 		const existingThresholds = ranks.map(rank => rank.threshold);

--- a/source/frontend/commands/rank/edit.js
+++ b/source/frontend/commands/rank/edit.js
@@ -3,7 +3,7 @@ const { SubcommandWrapper } = require("../../classes");
 const { syncRankRoles } = require("../../shared");
 
 module.exports = new SubcommandWrapper("edit", "Change the role or rankmoji for a seasonal rank",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const threshold = interaction.options.getNumber("variance-threshold");
 		const rank = await logicLayer.ranks.findOneRank(interaction.guild.id, threshold);
 		if (!rank) {

--- a/source/frontend/commands/rank/index.js
+++ b/source/frontend/commands/rank/index.js
@@ -12,8 +12,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"remove.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Seasonal Ranks distinguish bounty hunters who have above average season XP", PermissionFlagsBits.ManageRoles, true, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer);
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/rank/remove.js
+++ b/source/frontend/commands/rank/remove.js
@@ -5,7 +5,7 @@ const { rankArrayToSelectOptions, listifyEN, disabledSelectRow, syncRankRoles } 
 const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("remove", "Remove one or more existing seasonal ranks",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		const guildRoles = await interaction.guild.roles.fetch();
 		interaction.reply({

--- a/source/frontend/commands/reset/all-hunter-stats.js
+++ b/source/frontend/commands/reset/all-hunter-stats.js
@@ -3,22 +3,21 @@ const { SubcommandWrapper } = require("../../classes");
 const { updateScoreboard, seasonalScoreboardEmbed, overallScoreboardEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("all-hunter-stats", "IRREVERSIBLY reset all bounty hunter stats on this server",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		logicLayer.hunters.deleteCompanyHunters(interaction.guild.id);
 		interaction.reply({ content: "Resetting bounty hunter stats has begun.", flags: MessageFlags.Ephemeral });
-		const company = await logicLayer.companies.findCompanyByPK(interaction.guild.id);
 		const season = await logicLayer.seasons.findOneSeason(interaction.guild.id, "current");
 		if (season) {
 			await logicLayer.seasons.deleteSeasonParticipations(season.id);
 		}
 		const embeds = [];
 		const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-		if (company.scoreboardIsSeasonal) {
-			embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, new Map(), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
+		if (origin.company.scoreboardIsSeasonal) {
+			embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, new Map(), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
 		} else {
-			embeds.push(await overallScoreboardEmbed(company, interaction.guild, [], goalProgress));
+			embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, [], goalProgress));
 		}
-		updateScoreboard(company, interaction.guild, embeds);
+		updateScoreboard(origin.company, interaction.guild, embeds);
 		interaction.user.send(`Resetting bounty hunter stats on ${interaction.guild.name} has completed.`);
 	}
 );

--- a/source/frontend/commands/reset/index.js
+++ b/source/frontend/commands/reset/index.js
@@ -11,8 +11,8 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"server-settings.js"
 ]);
 module.exports = new CommandWrapper(mainId, "Reset all bounty hunter stats, bounties, or server configs", PermissionFlagsBits.ManageGuild, false, [InteractionContextType.Guild], 3000,
-	(interaction, runMode) => {
-		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, runMode, logicLayer);
+	(interaction, origin, runMode) => {
+		subcommandExecuteDictionary[interaction.options.getSubcommand()](interaction, origin, runMode, logicLayer);
 	}
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/commands/reset/server-settings.js
+++ b/source/frontend/commands/reset/server-settings.js
@@ -2,7 +2,7 @@ const { MessageFlags } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("server-settings", "IRREVERSIBLY return all server configs to default",
-	async function executeSubcommand(interaction, runMode, ...[logicLayer]) {
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		logicLayer.companies.resetCompanySettings(interaction.guild.id);
 		interaction.reply({ content: "Server settings have been reset.", flags: MessageFlags.Ephemeral });
 	}

--- a/source/frontend/commands/scoreboard.js
+++ b/source/frontend/commands/scoreboard.js
@@ -8,15 +8,14 @@ let logicLayer;
 const mainId = "scoreboard";
 module.exports = new CommandWrapper(mainId, "View the XP scoreboard", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** View the XP scoreboard */
-	async (interaction, runMode) => {
-		const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
+	async (interaction, origin, runMode) => {
 		const embeds = [];
 		const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
 		if (interaction.options.getString("scoreboard-type") === "season") {
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-			embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
+			embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, await logicLayer.seasons.getParticipationMap(season.id), await logicLayer.ranks.findAllRanks(interaction.guild.id), goalProgress));
 		} else {
-			embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
 		}
 		interaction.reply({ embeds, flags: MessageFlags.Ephemeral });
 	}

--- a/source/frontend/commands/season-end.js
+++ b/source/frontend/commands/season-end.js
@@ -10,22 +10,16 @@ let logicLayer;
 const mainId = "season-end";
 module.exports = new CommandWrapper(mainId, "Start a new season for this server, resetting ranks and placements", PermissionFlagsBits.ManageGuild, false, [InteractionContextType.Guild], 3000,
 	/** End the Company's current season and start a new one */
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		const guild = interaction.guild;
-		const company = await logicLayer.companies.findCompanyByPK(guild.id);
-		if (!company) {
-			interaction.reply({ content: "This server hasn't used BountyBot yet, so it doesn't have a season to end.", flags: MessageFlags.Ephemeral });
-			return;
-		}
-
 		const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-		const currentCompanyLevel = company.getLevel(allHunters);
+		const currentCompanyLevel = origin.company.getLevel(allHunters);
 		const currentLevelThreshold = Hunter.xpThreshold(currentCompanyLevel, COMPANY_XP_COEFFICIENT);
 		const nextLevelThreshold = Hunter.xpThreshold(currentCompanyLevel + 1, COMPANY_XP_COEFFICIENT);
 		const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
 		const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
 		const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
-		statsEmbed(company, guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(async embed => {
+		statsEmbed(origin.company, guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(async embed => {
 			const seasonBeforeEndingSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
 			if (seasonBeforeEndingSeason) {
 				seasonBeforeEndingSeason.isPreviousSeason = false;
@@ -69,17 +63,17 @@ module.exports = new CommandWrapper(mainId, "Start a new season for this server,
 			}
 			const embeds = [];
 			const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-			if (company.scoreboardIsSeasonal) {
-				embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, new Map(), ranks, goalProgress));
+			if (origin.company.scoreboardIsSeasonal) {
+				embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, new Map(), ranks, goalProgress));
 			} else {
-				embeds.push(await overallScoreboardEmbed(company, interaction.guild, allHunters, goalProgress));
+				embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, allHunters, goalProgress));
 			}
-			updateScoreboard(company, guild, embeds);
+			updateScoreboard(origin.company, guild, embeds);
 			let announcementText = "A new season has started, ranks and placements have been reset!";
 			if (shoutouts.length > 0) {
 				announcementText += `\n## Shoutouts\n- ${shoutouts.join("\n- ")}`;
 			}
-			interaction.reply(sendAnnouncement(company, { content: announcementText, embeds: [embed] }));
+			interaction.reply(sendAnnouncement(origin.company, { content: announcementText, embeds: [embed] }));
 		})
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/commands/seasonal-ranks.js
+++ b/source/frontend/commands/seasonal-ranks.js
@@ -7,7 +7,7 @@ let logicLayer;
 
 const mainId = "seasonal-ranks";
 module.exports = new CommandWrapper(mainId, "Look up this server's seasonal ranks", PermissionFlagsBits.ViewChannel, false, [InteractionContextType.Guild], 3000,
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		const ranks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		if (!ranks || !ranks.length) {
 			interaction.reply({ content: `Could not find any seasonal ranks. Please contact a server admin to make sure this isn't a mistake.`, flags: MessageFlags.Ephemeral });

--- a/source/frontend/commands/stats.js
+++ b/source/frontend/commands/stats.js
@@ -10,21 +10,20 @@ let logicLayer;
 const mainId = "stats";
 module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yourself or someone else", null, false, [InteractionContextType.Guild], 3000,
 	/** Get the BountyBot stats for yourself or someone else */
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		const target = interaction.options.getMember("bounty-hunter");
 		const guild = interaction.guild;
 		if (target) {
 			if (target.id === interaction.client.user.id) {
 				// BountyBot
-				const [company] = await logicLayer.companies.findOrCreateCompany(guild.id);
 				const allHunters = await logicLayer.hunters.findCompanyHunters(guild.id);
-				const currentCompanyLevel = company.getLevel(allHunters);
+				const currentCompanyLevel = origin.company.getLevel(allHunters);
 				const currentLevelThreshold = Hunter.xpThreshold(currentCompanyLevel, COMPANY_XP_COEFFICIENT);
 				const nextLevelThreshold = Hunter.xpThreshold(currentCompanyLevel + 1, COMPANY_XP_COEFFICIENT);
 				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
 				const lastSeason = await logicLayer.seasons.findOneSeason(guild.id, "previous");
 				const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
-				statsEmbed(company, guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
+				statsEmbed(origin.company, guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 					interaction.reply({
 						embeds: [embed],
 						flags: MessageFlags.Ephemeral
@@ -38,10 +37,9 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 						return;
 					}
 
-					const { xpCoefficient } = await logicLayer.companies.findCompanyByPK(guild.id);
-					const currentHunterLevel = hunter.getLevel(xpCoefficient);
-					const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, xpCoefficient);
-					const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, xpCoefficient);
+					const currentHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
+					const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, origin.company.xpCoefficient);
+					const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, origin.company.xpCoefficient);
 					const participations = await logicLayer.seasons.findHunterParticipations(hunter.userId, hunter.companyId);
 					const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
 					const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
@@ -73,51 +71,43 @@ module.exports = new CommandWrapper(mainId, "Get the BountyBot stats for yoursel
 			}
 		} else {
 			// Self
-			logicLayer.hunters.findOneHunter(interaction.user.id, guild.id).then(async hunter => {
-				if (!hunter) {
-					interaction.reply({ content: "You don't seem to have a profile with this server's BountyBot yet. It'll be created when you gain XP.", flags: MessageFlags.Ephemeral });
-					return;
-				}
+			const currentHunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+			const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, origin.company.xpCoefficient);
+			const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, origin.company.xpCoefficient);
+			const bountySlots = Hunter.getBountySlotCount(currentHunterLevel, origin.company.maxSimBounties);
+			const participations = await logicLayer.seasons.findHunterParticipations(origin.hunter.userId, origin.hunter.companyId);
+			const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
+			const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
+			const previousParticipations = currentParticipation === null ? participations : participations.slice(1);
+			const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
+			const rankName = ranks[currentParticipation.rankIndex]?.roleId ? `<@&${ranks[currentParticipation.rankIndex].roleId}>` : `Rank ${currentParticipation.rankIndex + 1}`;
+			const mostSecondedToast = await logicLayer.toasts.findMostSecondedToast(interaction.user.id, guild.id);
+			const nextRankXP = await logicLayer.seasons.nextRankXP(interaction.user.id, currentSeason, ranks);
 
-				const { xpCoefficient, maxSimBounties } = await logicLayer.companies.findCompanyByPK(guild.id);
-				const currentHunterLevel = hunter.getLevel(xpCoefficient);
-				const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, xpCoefficient);
-				const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, xpCoefficient);
-				const bountySlots = Hunter.getBountySlotCount(currentHunterLevel, maxSimBounties);
-				const participations = await logicLayer.seasons.findHunterParticipations(hunter.userId, hunter.companyId);
-				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(guild.id);
-				const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);
-				const previousParticipations = currentParticipation === null ? participations : participations.slice(1);
-				const ranks = await logicLayer.ranks.findAllRanks(interaction.guildId);
-				const rankName = ranks[currentParticipation.rankIndex]?.roleId ? `<@&${ranks[currentParticipation.rankIndex].roleId}>` : `Rank ${currentParticipation.rankIndex + 1}`;
-				const mostSecondedToast = await logicLayer.toasts.findMostSecondedToast(interaction.user.id, guild.id);
-				const nextRankXP = await logicLayer.seasons.nextRankXP(interaction.user.id, currentSeason, ranks);
-
-				interaction.reply({
-					embeds: [
-						new EmbedBuilder().setColor(Colors[hunter.profileColor])
-							.setAuthor(ihpAuthorPayload)
-							.setThumbnail(interaction.user.avatarURL())
-							.setTitle(`You are __Level ${currentHunterLevel}__ in ${guild.name}`)
-							.setDescription(
-								`${generateTextBar(hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)} *Next Level:* ${nextLevelThreshold - hunter.xp} XP\n\
+			interaction.reply({
+				embeds: [
+					new EmbedBuilder().setColor(Colors[origin.hunter.profileColor])
+						.setAuthor(ihpAuthorPayload)
+						.setThumbnail(interaction.user.avatarURL())
+						.setTitle(`You are __Level ${currentHunterLevel}__ in ${guild.name}`)
+						.setDescription(
+							`${generateTextBar(origin.hunter.xp - currentLevelThreshold, nextLevelThreshold - currentLevelThreshold, 11)} *Next Level:* ${nextLevelThreshold - origin.hunter.xp} XP\n\
 								You have earned *${currentParticipation?.xp ?? 0} XP* this season${currentParticipation.rankIndex != null ? ` which qualifies for ${rankName}` : ""}.${nextRankXP > 0 ? `You need ${nextRankXP} XP to reach the next rank.` : ""}\n\n\
 								You have ${bountySlots} bounty slot${bountySlots === 1 ? '' : 's'}!`
-							)
-							.addFields(
-								{ name: "Season Placements", value: `Currently: ${(currentParticipation?.placement ?? 0) === 0 ? "Unranked" : "#" + currentParticipation.placement}\n${previousParticipations.length > 0 ? `Previous Placements: ${previousParticipations.map(participation => `#${participation.placement}`).join(", ")}` : ""}`, inline: true },
-								{ name: "Total XP Earned", value: `${hunter.xp} XP`, inline: true },
-								{ name: "Most Seconded Toast", value: mostSecondedToast ? `"${mostSecondedToast.text}" with **${mostSecondedToast.secondings} secondings**` : "No toasts seconded yet..." },
-								{ name: "Bounty Stats", value: `Bounties Hunted: ${hunter.othersFinished} bount${hunter.othersFinished === 1 ? 'y' : 'ies'}\nBounty Postings: ${hunter.mineFinished} bount${hunter.mineFinished === 1 ? 'y' : 'ies'}`, inline: true },
-								{ name: "Toast Stats", value: `Toasts Raised: ${hunter.toastsRaised} toast${hunter.toastsRaised === 1 ? "" : "s"}\nToasts Seconded: ${hunter.toastsSeconded} toast${hunter.toastsSeconded === 1 ? "" : "s"}\nToasts Recieved: ${hunter.toastsReceived} toast${hunter.toastsReceived === 1 ? "" : "s"}`, inline: true },
-								{ name: "Upcoming Level-Up Rewards", value: [currentHunterLevel + 1, currentHunterLevel + 2, currentHunterLevel + 3].map(level => `Level ${level}\n- ${getHunterLevelUpRewards(level, maxSimBounties, true).join("\n- ")}`).join("\n") }
-							)
-							.setFooter(randomFooterTip())
-							.setTimestamp()
-					],
-					flags: MessageFlags.Ephemeral
-				});
-			})
+						)
+						.addFields(
+							{ name: "Season Placements", value: `Currently: ${(currentParticipation?.placement ?? 0) === 0 ? "Unranked" : "#" + currentParticipation.placement}\n${previousParticipations.length > 0 ? `Previous Placements: ${previousParticipations.map(participation => `#${participation.placement}`).join(", ")}` : ""}`, inline: true },
+							{ name: "Total XP Earned", value: `${origin.hunter.xp} XP`, inline: true },
+							{ name: "Most Seconded Toast", value: mostSecondedToast ? `"${mostSecondedToast.text}" with **${mostSecondedToast.secondings} secondings**` : "No toasts seconded yet..." },
+							{ name: "Bounty Stats", value: `Bounties Hunted: ${origin.hunter.othersFinished} bount${origin.hunter.othersFinished === 1 ? 'y' : 'ies'}\nBounty Postings: ${origin.hunter.mineFinished} bount${origin.hunter.mineFinished === 1 ? 'y' : 'ies'}`, inline: true },
+							{ name: "Toast Stats", value: `Toasts Raised: ${origin.hunter.toastsRaised} toast${origin.hunter.toastsRaised === 1 ? "" : "s"}\nToasts Seconded: ${origin.hunter.toastsSeconded} toast${origin.hunter.toastsSeconded === 1 ? "" : "s"}\nToasts Recieved: ${origin.hunter.toastsReceived} toast${origin.hunter.toastsReceived === 1 ? "" : "s"}`, inline: true },
+							{ name: "Upcoming Level-Up Rewards", value: [currentHunterLevel + 1, currentHunterLevel + 2, currentHunterLevel + 3].map(level => `Level ${level}\n- ${getHunterLevelUpRewards(level, origin.company.maxSimBounties, true).join("\n- ")}`).join("\n") }
+						)
+						.setFooter(randomFooterTip())
+						.setTimestamp()
+				],
+				flags: MessageFlags.Ephemeral
+			});
 		}
 	}
 ).setOptions(

--- a/source/frontend/commands/tutorial.js
+++ b/source/frontend/commands/tutorial.js
@@ -7,7 +7,7 @@ const { BOUNTYBOT_INVITE_URL } = require("../../constants");
 const mainId = "tutorial";
 module.exports = new CommandWrapper(mainId, "Get tips for starting with BountyBot", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Send the user a embed with tips to start using BountyBot */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		fs.promises.stat(__filename).then(stats => {
 			const embed = new EmbedBuilder().setColor(Colors.Blurple).setAuthor(ihpAuthorPayload)
 				.setThumbnail(interaction.client.user.avatarURL())

--- a/source/frontend/commands/version.js
+++ b/source/frontend/commands/version.js
@@ -5,7 +5,7 @@ const { buildVersionEmbed } = require('../shared');
 const mainId = "version";
 module.exports = new CommandWrapper(mainId, "Get the most recent changes or the full change log", null, false, [InteractionContextType.BotDM, InteractionContextType.Guild, InteractionContextType.PrivateChannel], 3000,
 	/** Send the user the most recent set of patch notes or full change log */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 		if (interaction.options.getString("notes-length") === "last-version") {
 			buildVersionEmbed(interaction.client.user.displayAvatarURL()).then(embed => {
 				interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/source/frontend/context_menus/BountyBot_Stats.js
+++ b/source/frontend/context_menus/BountyBot_Stats.js
@@ -9,19 +9,18 @@ let logicLayer;
 
 const mainId = "BountyBot Stats";
 module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionContextType.Guild], 3000,
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		const target = interaction.targetMember;
 		if (target.id == interaction.client.user.id) {
 			// BountyBot
-			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 			const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-			const currentCompanyLevel = company.getLevel(allHunters);
+			const currentCompanyLevel = origin.company.getLevel(allHunters);
 			const currentLevelThreshold = Hunter.xpThreshold(currentCompanyLevel, COMPANY_XP_COEFFICIENT);
 			const nextLevelThreshold = Hunter.xpThreshold(currentCompanyLevel + 1, COMPANY_XP_COEFFICIENT);
 			const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
 			const lastSeason = await logicLayer.seasons.findOneSeason(interaction.guild.id, "previous");
 			const participantCount = await logicLayer.seasons.getParticipantCount(currentSeason.id);
-			statsEmbed(company, interaction.guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
+			statsEmbed(origin.company, interaction.guild, allHunters, participantCount, currentLevelThreshold, nextLevelThreshold, currentSeason, lastSeason).then(embed => {
 				interaction.reply({
 					embeds: [embed],
 					flags: MessageFlags.Ephemeral
@@ -35,10 +34,9 @@ module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionCon
 					return;
 				}
 
-				const { xpCoefficient } = await logicLayer.companies.findCompanyByPK(interaction.guildId);
-				const currentHunterLevel = hunter.getLevel(xpCoefficient);
-				const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, xpCoefficient);
-				const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, xpCoefficient);
+				const currentHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
+				const currentLevelThreshold = Hunter.xpThreshold(currentHunterLevel, origin.company.xpCoefficient);
+				const nextLevelThreshold = Hunter.xpThreshold(currentHunterLevel + 1, origin.company.xpCoefficient);
 				const participations = await logicLayer.seasons.findHunterParticipations(hunter.userId, hunter.companyId);
 				const [currentSeason] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 				const currentParticipation = participations.find(participation => participation.seasonId === currentSeason.id);

--- a/source/frontend/context_menus/Raise_a_Toast.js
+++ b/source/frontend/context_menus/Raise_a_Toast.js
@@ -9,7 +9,7 @@ let logicLayer;
 const mainId = "Raise a Toast";
 module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMessages, false, [InteractionContextType.Guild], 3000,
 	/** Open a modal to receive toast text, then raise the toast to the user */
-	async (interaction, runMode) => {
+	async (interaction, origin, runMode) => {
 		if (interaction.targetId === interaction.user.id) {
 			interaction.reply({ content: "You cannot raise a toast to yourself.", flags: MessageFlags.Ephemeral });
 			return;
@@ -20,7 +20,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			return;
 		}
 
-		const [toastee] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.targetId, interaction.guildId);
+		const { hunter: [toastee] } = await logicLayer.hunters.findOrCreateBountyHunter(interaction.targetId, interaction.guildId);
 		if (toastee.isBanned) {
 			interaction.reply({ content: `${userMention(interaction.targetId)} cannot receive toasts because they are banned from interacting with BountyBot on this server.`, flags: MessageFlags.Ephemeral });
 			return;
@@ -46,17 +46,16 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 
 			const season = await logicLayer.seasons.incrementSeasonStat(modalSubmission.guild.id, "toastsRaised");
 			let hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
-			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guildId);
 
-			const previousCompanyLevel = company.getLevel(Object.values(hunterMap));
-			const { toastId, rewardedHunterIds, hunterResults, critValue } = await logicLayer.toasts.raiseToast(modalSubmission.guild, company, interaction.user.id, new Set([interaction.targetId]), hunterMap, season.id, toastText, null);
+			const previousCompanyLevel = origin.company.getLevel(Object.values(hunterMap));
+			const { toastId, rewardedHunterIds, hunterResults, critValue } = await logicLayer.toasts.raiseToast(modalSubmission.guild, origin.company, interaction.user.id, new Set([interaction.targetId]), hunterMap, season.id, toastText, null);
 			hunterMap = await reloadHunterMapSubset(hunterMap, rewardedHunterIds.concat(interaction.user.id));
-			const rewardTexts = formatHunterResultsToRewardTexts(hunterResults, hunterMap, company);
-			const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, Object.values(hunterMap), interaction.guild.name);
+			const rewardTexts = formatHunterResultsToRewardTexts(hunterResults, hunterMap, origin.company);
+			const companyLevelLine = buildCompanyLevelUpLine(origin.company, previousCompanyLevel, Object.values(hunterMap), interaction.guild.name);
 			if (companyLevelLine) {
 				rewardTexts.push(companyLevelLine);
 			}
-			const embeds = [generateToastEmbed(company.toastThumbnailURL, toastText, new Set([interaction.targetId]), modalSubmission.member)];
+			const embeds = [generateToastEmbed(origin.company.toastThumbnailURL, toastText, new Set([interaction.targetId]), modalSubmission.member)];
 
 			if (rewardedHunterIds.length > 0) {
 				const goalUpdate = await logicLayer.goals.progressGoal(modalSubmission.guild.id, "toasts", hunterMap[interaction.user.id], season);
@@ -84,16 +83,16 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 					const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
 					const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
 					syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
-					const rewardString = generateToastRewardString(rewardedHunterIds, formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch()), rewardTexts, interaction.member.toString(), company.festivalMultiplierString(), critValue);
+					const rewardString = generateToastRewardString(rewardedHunterIds, formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch()), rewardTexts, interaction.member.toString(), origin.company.festivalMultiplierString(), critValue);
 					sendToRewardsThread(response.resource.message, rewardString, "Rewards");
 					const embeds = [];
 					const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-					if (company.scoreboardIsSeasonal) {
-						embeds.push(await seasonalScoreboardEmbed(company, modalSubmission.guild, participationMap, descendingRanks, goalProgress));
+					if (origin.company.scoreboardIsSeasonal) {
+						embeds.push(await seasonalScoreboardEmbed(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress));
 					} else {
-						embeds.push(await overallScoreboardEmbed(company, modalSubmission.guild, await logicLayer.hunters.findCompanyHunters(modalSubmission.guild.id), goalProgress));
+						embeds.push(await overallScoreboardEmbed(origin.company, modalSubmission.guild, await logicLayer.hunters.findCompanyHunters(modalSubmission.guild.id), goalProgress));
 					}
-					updateScoreboard(company, modalSubmission.guild, embeds);
+					updateScoreboard(origin.company, modalSubmission.guild, embeds);
 				}
 			});
 		}).catch(error => {

--- a/source/frontend/context_menus/_message_context_menu_blueprint.js
+++ b/source/frontend/context_menus/_message_context_menu_blueprint.js
@@ -7,7 +7,7 @@ let logicLayer;
 const mainId = "";
 module.exports = new MessageContextMenuWrapper(mainId, null, false, [InteractionContextType.Guild], 3000,
 	/** Specs */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/context_menus/_user_context_menu_blueprint.js
+++ b/source/frontend/context_menus/_user_context_menu_blueprint.js
@@ -7,7 +7,7 @@ let logicLayer;
 const mainId = "";
 module.exports = new UserContextMenuWrapper(mainId, null, false, [InteractionContextType.Guild], 3000,
 	/** Specs */
-	(interaction, runMode) => {
+	(interaction, origin, runMode) => {
 
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/_itemDictionary.js
+++ b/source/frontend/items/_itemDictionary.js
@@ -1,5 +1,5 @@
 const { CommandInteraction } = require("discord.js");
-const { ItemTemplateSet, ItemTemplate } = require("../classes");
+const { ItemTemplateSet, ItemTemplate, InteractionOrigin } = require("../classes");
 
 /** @type {Record<string, ItemTemplate>} */
 const ITEMS = {};
@@ -47,10 +47,11 @@ exports.getItemCooldown = function (itemName) {
 /**
  * @param {string} itemName
  * @param {CommandInteraction} interaction
+ * @param {InteractionOrigin} origin
  * @returns {Promise<boolean>} whether to skip decrementing the item count
  */
-exports.useItem = function (itemName, interaction) {
-	return ITEMS[itemName].effect(interaction);
+exports.useItem = function (itemName, interaction, origin) {
+	return ITEMS[itemName].effect(interaction, origin);
 }
 
 exports.setLogic = function (logicBlob) {

--- a/source/frontend/items/_item_template.js
+++ b/source/frontend/items/_item_template.js
@@ -7,7 +7,7 @@ const itemName = "";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "description", 3000,
 		/** specs */
-		async (interaction) => {
+		async (interaction, origin) => {
 
 		})
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -10,7 +10,7 @@ let logicLayer;
 const itemName = "Bonus Bounty Showcase";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Showcase one of your bounties and increase its reward on a separate cooldown", timeConversion(1, "d", "ms"),
-		async (interaction) => {
+		async (interaction, origin) => {
 			const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 			if (openBounties.length < 1) {
 				interaction.reply({ content: "You don't have any open bounties on this server to showcase.", flags: MessageFlags.Ephemeral });
@@ -47,12 +47,10 @@ module.exports = new ItemTemplateSet(
 
 				bounty.increment("showcaseCount");
 				await bounty.reload();
-				const poster = await logicLayer.hunters.findOneHunter(collectedInteraction.user.id, collectedInteraction.guildId);
-				const company = await logicLayer.companies.findCompanyByPK(collectedInteraction.guild.id);
 				const hunterIdSet = await logicLayer.bounties.getHunterIdSet(collectedInteraction.values[0]);
-				const currentPosterLevel = poster.getLevel(company.xpCoefficient);
-				updatePosting(collectedInteraction.guild, company, bounty, currentPosterLevel, hunterIdSet);
-				return buildBountyEmbed(bounty, collectedInteraction.guild, currentPosterLevel, false, company, hunterIdSet).then(async embed => {
+				const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+				updatePosting(collectedInteraction.guild, origin.company, bounty, currentPosterLevel, hunterIdSet);
+				return buildBountyEmbed(bounty, collectedInteraction.guild, currentPosterLevel, false, origin.company, hunterIdSet).then(async embed => {
 					if (collectedInteraction.channel.archived) {
 						await collectedInteraction.channel.setArchived(false, "bounty showcased");
 					}

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -10,7 +10,7 @@ let logicLayer;
 const itemName = "Bounty Thumbnail";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Adds an image (via URL) to one of your open bounties!", 3000,
-		async (interaction) => {
+		async (interaction, origin) => {
 			const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 			if (openBounties.length < 1) {
 				interaction.reply({ content: "You don't have any open bounties on this server to add a thumbnail to.", flags: MessageFlags.Ephemeral });

--- a/source/frontend/items/colorizers.js
+++ b/source/frontend/items/colorizers.js
@@ -10,7 +10,7 @@ class Colorizer extends ItemTemplate {
 		const itemName = `${color} Profile Colorizer`;
 		super(itemName, `Changes the color of your stats profile embed to ${color.toLowerCase()}`, 3000,
 			/** Sets the user's Hunter profile to the specfied color in the used guild */
-			async (interaction) => {
+			async (interaction, origin) => {
 				await logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 				interaction.reply({ content: `Your profile color has been set to ${color === "Default" ? "black" : color} in this server.`, flags: MessageFlags.Ephemeral });
 			}

--- a/source/frontend/items/goal-initializer.js
+++ b/source/frontend/items/goal-initializer.js
@@ -8,8 +8,7 @@ let logicLayer;
 const itemName = "Goal Initializer";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Begin a Server Goal if there isn't already one running", 3000,
-		async (interaction) => {
-			const [company] = await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
+		async (interaction, origin) => {
 			const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guildId);
 			if (!!goal) {
 				interaction.reply({ content: "This server already has a Server Goal running.", flags: MessageFlags.Ephemeral });
@@ -21,9 +20,8 @@ module.exports = new ItemTemplateSet(
 			const previousSeason = await logicLayer.seasons.findOneSeason(interaction.guildId, "previous");
 			const activeHunters = previousSeason ? await logicLayer.seasons.getParticipantCount(previousSeason.id) : 0;
 			const requiredGP = Math.max(activeHunters * 20, 60);
-			await logicLayer.companies.findOrCreateCompany(interaction.guild.id);
 			await logicLayer.goals.createGoal(interaction.guildId, goalType, requiredGP);
-			interaction.channel.send(sendAnnouncement(company, { content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));
+			interaction.channel.send(sendAnnouncement(origin.company, { content: `${interaction.member} has started a Server Goal! This time **${goalType} are worth double GP**!` }));
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/loot-box.js
+++ b/source/frontend/items/loot-box.js
@@ -8,11 +8,10 @@ let logicLayer;
 const itemName = "Loot Box";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Unboxes into 2 random items!", 3000,
-		async (interaction) => {
-			const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
+		async (interaction, origin) => {
 			const rolledItems = [];
 			for (let i = 0; i < 2; i++) {
-				const [itemRow] = await logicLayer.items.rollItemForHunter(1, hunter);
+				const [itemRow] = await logicLayer.items.rollItemForHunter(1, origin.hunter);
 				if (itemRow) {
 					rolledItems.push(`a ${bold(itemRow.itemName)}`);
 				}

--- a/source/frontend/items/progress-in-a-can.js
+++ b/source/frontend/items/progress-in-a-can.js
@@ -8,15 +8,14 @@ let logicLayer;
 const itemName = "Progress-in-a-Can";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Add a contribution to the currently running Server Goal", 3000,
-		async (interaction) => {
+		async (interaction, origin) => {
 			const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guild.id);
 			if (!goal) {
 				interaction.reply({ content: "There isn't currently a Server Goal running.", flags: MessageFlags.Ephemeral });
 				return true;
 			}
-			const hunter = await logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id);
 			const season = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-			const progressData = await logicLayer.goals.progressGoal(interaction.guildId, goal.type, hunter, season);
+			const progressData = await logicLayer.goals.progressGoal(interaction.guildId, goal.type, origin.hunter, season);
 			const resultPayload = { content: `${userMention(interaction.user.id)}'s Progress-in-a-Can contributed ${progressData.gpContributed} GP the Server Goal!` };
 			if (progressData.goalCompleted) {
 				resultPayload.embeds = [generateCompletionEmbed(progressData.contributorIds)];

--- a/source/frontend/items/unidentified-item.js
+++ b/source/frontend/items/unidentified-item.js
@@ -8,9 +8,8 @@ let logicLayer;
 const itemName = "Unidentified Item";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Rolls as a random item!", 3000,
-		async (interaction) => {
-			const [hunter] = await logicLayer.hunters.findOrCreateBountyHunter(interaction.user.id, interaction.guild.id);
-			const [itemRow] = await logicLayer.items.rollItemForHunter(1, hunter);
+		async (interaction, origin) => {
+			const [itemRow] = await logicLayer.items.rollItemForHunter(1, origin.hunter);
 			interaction.reply({ content: `The unidentified item was a ${bold(itemRow.itemName)}! Use it with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
 		}
 	)

--- a/source/frontend/items/xp-boost-epic.js
+++ b/source/frontend/items/xp-boost-epic.js
@@ -8,49 +8,46 @@ const itemName = "Epic XP Boost";
 const xpValue = 25;
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-		async (interaction) => {
-			logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
-				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-				logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
-				const company = await logicLayer.companies.findCompanyByPK(interaction.guildId);
-				const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-				const previousCompanyLevel = company.getLevel(allHunters);
-				const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
-				await hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
-				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-				const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
-				syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
-				const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
-				let content = `${interaction.member} used an ${itemName} and gained ${xpValue} XP.`;
-				const hunterLevelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
-				if (hunterLevelLine) {
-					additionalRewards.push(hunterLevelLine);
-				}
-				const reloadedHunters = await Promise.all(allHunters.map(hunter => {
-					if (hunter.userId === interaction.user.id) {
-						return hunter.reload();
-					} else {
-						return hunter;
-					}
-				}))
-				const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
-				if (companyLevelLine) {
-					additionalRewards.push(companyLevelLine);
-				}
-				if (additionalRewards.length > 0) {
-					content += `\n- ${additionalRewards.join("\n- ")}`;
-				}
-				interaction.reply({ content });
-				const embeds = [];
-				const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-				if (company.scoreboardIsSeasonal) {
-					embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, participationMap, descendingRanks, goalProgress));
+		async (interaction, origin) => {
+			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
+			const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
+			const previousCompanyLevel = origin.company.getLevel(allHunters);
+			const previousHunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+			await origin.hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
+			const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+			const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+			const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
+			syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
+			const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
+			let content = `${interaction.member} used an ${itemName} and gained ${xpValue} XP.`;
+			const hunterLevelLine = buildHunterLevelUpLine(origin.hunter, previousHunterLevel, origin.company.xpCoefficient, origin.company.maxSimBounties);
+			if (hunterLevelLine) {
+				additionalRewards.push(hunterLevelLine);
+			}
+			const reloadedHunters = await Promise.all(allHunters.map(hunter => {
+				if (hunter.userId === interaction.user.id) {
+					return hunter.reload();
 				} else {
-					embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+					return hunter;
 				}
-				updateScoreboard(company, interaction.guild, embeds);
-			})
+			}))
+			const companyLevelLine = buildCompanyLevelUpLine(origin.company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
+			if (companyLevelLine) {
+				additionalRewards.push(companyLevelLine);
+			}
+			if (additionalRewards.length > 0) {
+				content += `\n- ${additionalRewards.join("\n- ")}`;
+			}
+			interaction.reply({ content });
+			const embeds = [];
+			const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
+			if (origin.company.scoreboardIsSeasonal) {
+				embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, participationMap, descendingRanks, goalProgress));
+			} else {
+				embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			}
+			updateScoreboard(origin.company, interaction.guild, embeds);
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/xp-boost-legendary.js
+++ b/source/frontend/items/xp-boost-legendary.js
@@ -8,49 +8,46 @@ const itemName = "Legendary XP Boost";
 const xpValue = 75;
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-		async (interaction) => {
-			logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
-				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-				logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
-				const company = await logicLayer.companies.findCompanyByPK(interaction.guildId);
-				const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-				const previousCompanyLevel = company.getLevel(allHunters);
-				const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
-				await hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
-				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-				const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
-				syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
-				const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
-				let content = `${interaction.member} used a ${itemName} and gained ${xpValue} XP.`;
-				const hunterLevelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
-				if (hunterLevelLine) {
-					additionalRewards.push(hunterLevelLine);
-				}
-				const reloadedHunters = await Promise.all(allHunters.map(hunter => {
-					if (hunter.userId === interaction.user.id) {
-						return hunter.reload();
-					} else {
-						return hunter;
-					}
-				}))
-				const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
-				if (companyLevelLine) {
-					additionalRewards.push(companyLevelLine);
-				}
-				if (additionalRewards.length > 0) {
-					content += `\n- ${additionalRewards.join("\n- ")}`;
-				}
-				interaction.reply({ content });
-				const embeds = [];
-				const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-				if (company.scoreboardIsSeasonal) {
-					embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, participationMap, descendingRanks, goalProgress));
+		async (interaction, origin) => {
+			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
+			const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
+			const previousCompanyLevel = origin.company.getLevel(allHunters);
+			const previousHunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+			await origin.hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
+			const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+			const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+			const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
+			syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
+			const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
+			let content = `${interaction.member} used a ${itemName} and gained ${xpValue} XP.`;
+			const hunterLevelLine = buildHunterLevelUpLine(origin.hunter, previousHunterLevel, origin.company.xpCoefficient, origin.company.maxSimBounties);
+			if (hunterLevelLine) {
+				additionalRewards.push(hunterLevelLine);
+			}
+			const reloadedHunters = await Promise.all(allHunters.map(hunter => {
+				if (hunter.userId === interaction.user.id) {
+					return hunter.reload();
 				} else {
-					embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+					return hunter;
 				}
-				updateScoreboard(company, interaction.guild, embeds);
-			})
+			}))
+			const companyLevelLine = buildCompanyLevelUpLine(origin.company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
+			if (companyLevelLine) {
+				additionalRewards.push(companyLevelLine);
+			}
+			if (additionalRewards.length > 0) {
+				content += `\n- ${additionalRewards.join("\n- ")}`;
+			}
+			interaction.reply({ content });
+			const embeds = [];
+			const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
+			if (origin.company.scoreboardIsSeasonal) {
+				embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, participationMap, descendingRanks, goalProgress));
+			} else {
+				embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			}
+			updateScoreboard(origin.company, interaction.guild, embeds);
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/xp-boost.js
+++ b/source/frontend/items/xp-boost.js
@@ -8,49 +8,46 @@ const itemName = "XP Boost";
 const xpValue = 5;
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, `Gain ${xpValue} XP in the used server (unaffected by festivals)`, 60000,
-		async (interaction) => {
-			logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
-				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
-				logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
-				const company = await logicLayer.companies.findCompanyByPK(interaction.guildId);
-				const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
-				const previousCompanyLevel = company.getLevel(allHunters);
-				const previousHunterLevel = hunter.getLevel(company.xpCoefficient);
-				await hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
-				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-				const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
-				syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
-				const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
-				let content = `${interaction.member} used an ${itemName} and gained ${xpValue} XP.`;
-				const hunterLevelLine = buildHunterLevelUpLine(hunter, previousHunterLevel, company.xpCoefficient, company.maxSimBounties);
-				if (hunterLevelLine) {
-					additionalRewards.push(hunterLevelLine);
-				}
-				const reloadedHunters = await Promise.all(allHunters.map(hunter => {
-					if (hunter.userId === interaction.user.id) {
-						return hunter.reload();
-					} else {
-						return hunter;
-					}
-				}))
-				const companyLevelLine = buildCompanyLevelUpLine(company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
-				if (companyLevelLine) {
-					additionalRewards.push(companyLevelLine);
-				}
-				if (additionalRewards.length > 0) {
-					content += `\n- ${additionalRewards.join("\n- ")}`;
-				}
-				interaction.reply({ content });
-				const embeds = [];
-				const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
-				if (company.scoreboardIsSeasonal) {
-					embeds.push(await seasonalScoreboardEmbed(company, interaction.guild, participationMap, descendingRanks, goalProgress));
+		async (interaction, origin) => {
+			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
+			logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, xpValue);
+			const allHunters = await logicLayer.hunters.findCompanyHunters(interaction.guild.id);
+			const previousCompanyLevel = origin.company.getLevel(allHunters);
+			const previousHunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+			await origin.hunter.increment({ xp: xpValue }).then(hunter => hunter.reload());
+			const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+			const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+			const seasonUpdates = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks);
+			syncRankRoles(seasonUpdates, descendingRanks, interaction.guild.members);
+			const additionalRewards = formatSeasonResultsToRewardTexts(seasonUpdates, descendingRanks, await interaction.guild.roles.fetch());
+			let content = `${interaction.member} used an ${itemName} and gained ${xpValue} XP.`;
+			const hunterLevelLine = buildHunterLevelUpLine(origin.hunter, previousHunterLevel, origin.company.xpCoefficient, origin.company.maxSimBounties);
+			if (hunterLevelLine) {
+				additionalRewards.push(hunterLevelLine);
+			}
+			const reloadedHunters = await Promise.all(allHunters.map(hunter => {
+				if (hunter.userId === interaction.user.id) {
+					return hunter.reload();
 				} else {
-					embeds.push(await overallScoreboardEmbed(company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+					return hunter;
 				}
-				updateScoreboard(company, interaction.guild, embeds);
-			})
+			}))
+			const companyLevelLine = buildCompanyLevelUpLine(origin.company, previousCompanyLevel, reloadedHunters, interaction.guild.name);
+			if (companyLevelLine) {
+				additionalRewards.push(companyLevelLine);
+			}
+			if (additionalRewards.length > 0) {
+				content += `\n- ${additionalRewards.join("\n- ")}`;
+			}
+			interaction.reply({ content });
+			const embeds = [];
+			const goalProgress = await logicLayer.goals.findLatestGoalProgress(interaction.guild.id);
+			if (origin.company.scoreboardIsSeasonal) {
+				embeds.push(await seasonalScoreboardEmbed(origin.company, interaction.guild, participationMap, descendingRanks, goalProgress));
+			} else {
+				embeds.push(await overallScoreboardEmbed(origin.company, interaction.guild, await logicLayer.hunters.findCompanyHunters(interaction.guild.id), goalProgress));
+			}
+			updateScoreboard(origin.company, interaction.guild, embeds);
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/logic/hunters.js
+++ b/source/logic/hunters.js
@@ -1,5 +1,5 @@
 const { Sequelize, Op } = require("sequelize");
-const { Hunter } = require("../database/models");
+const { Hunter, User } = require("../database/models");
 
 /** @type {Sequelize} */
 let db;
@@ -16,11 +16,13 @@ function setDB(database) {
  * Requires that the Company housing the Hunter exists
  * @param {string} userId
  * @param {string} companyId
- * @returns {Promise<[Hunter, boolean]>}
+ * @returns {Promise<{ user: [User, boolean], hunter: [Hunter, boolean] }>}
  */
 async function findOrCreateBountyHunter(userId, companyId) {
-	await db.models.User.findOrCreate({ where: { id: userId } });
-	return db.models.Hunter.findOrCreate({ where: { userId, companyId } });
+	return {
+		user: await db.models.User.findOrCreate({ where: { id: userId } }),
+		hunter: await db.models.Hunter.findOrCreate({ where: { userId, companyId } })
+	}
 }
 
 /** *Queries directly for a Hunter*


### PR DESCRIPTION
Summary
-------
- pass Hunter and Company from `InteractionCreate` validations to frontend execute functions
- remove rest syntax for Subcommand execute arguments (all arbitrary data being passed through there was stuff in origin)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)

Issue
-----
Closes #494