### PR TITLE
update Discord.js to v14.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,9 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "BountyBot",
 			"dependencies": {
 				"@sapphire/discord.js-utilities": "7.3.3",
-				"discord.js": "14.19.3",
+				"discord.js": "14.20.0",
 				"sequelize": "6.37.7",
 				"sequelize-cli": "6.6.3",
 				"sqlite3": "5.1.7"
@@ -56,9 +55,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.0.tgz",
-			"integrity": "sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
+			"integrity": "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
 				"@discordjs/util": "^1.1.1",
@@ -68,7 +67,7 @@
 				"discord-api-types": "^0.38.1",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
-				"undici": "6.21.1"
+				"undici": "6.21.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -100,12 +99,12 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.2.tgz",
-			"integrity": "sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+			"integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
-				"@discordjs/rest": "^2.5.0",
+				"@discordjs/rest": "^2.5.1",
 				"@discordjs/util": "^1.1.0",
 				"@sapphire/async-queue": "^1.5.2",
 				"@types/ws": "^8.5.10",
@@ -809,23 +808,23 @@
 			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.19.3",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.19.3.tgz",
-			"integrity": "sha512-lncTRk0k+8Q5D3nThnODBR8fR8x2fM798o8Vsr40Krx0DjPwpZCuxxTcFMrXMQVOqM1QB9wqWgaXPg3TbmlHqA==",
+			"version": "14.20.0",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.20.0.tgz",
+			"integrity": "sha512-5fRTptK2vpuz+bTuAEUQLSo/3AgCSLHl6Mm9+/ofb+8cbbnjWllhtaqRBq7XcpzlBnfNEugKv8HvCwcOtIHpCg==",
 			"dependencies": {
 				"@discordjs/builders": "^1.11.2",
 				"@discordjs/collection": "1.5.3",
 				"@discordjs/formatters": "^0.6.1",
-				"@discordjs/rest": "^2.5.0",
+				"@discordjs/rest": "^2.5.1",
 				"@discordjs/util": "^1.1.1",
-				"@discordjs/ws": "^1.2.2",
+				"@discordjs/ws": "^1.2.3",
 				"@sapphire/snowflake": "3.5.3",
 				"discord-api-types": "^0.38.1",
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
-				"undici": "6.21.1"
+				"undici": "6.21.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2572,9 +2571,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.21.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-			"integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+			"version": "6.21.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
 			"engines": {
 				"node": ">=18.17"
 			}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"@sapphire/discord.js-utilities": "7.3.3",
-		"discord.js": "14.19.3",
+		"discord.js": "14.20.0",
 		"sequelize": "6.37.7",
 		"sequelize-cli": "6.6.3",
 		"sqlite3": "5.1.7"


### PR DESCRIPTION
Summary
-------
- update to Discord.js v14.20.0
   - resolves vulnerability, stay up to date

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] discord.js change notes don't contain things that look like breakages