### PR TITLE
#439: improve reply messages for raffles

### DIFF
--- a/migrations/20250626235952-addCustomizableRaffleThumbnail.js
+++ b/migrations/20250626235952-addCustomizableRaffleThumbnail.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		const tableDescription = await queryInterface.describeTable("Company");
+		if (!("raffleThumbnailURL" in tableDescription)) {
+			await queryInterface.addColumn("Company", "raffleThumbnailURL", Sequelize.STRING);
+		}
+	},
+	async down(queryInterface, Sequelize) {
+		const tableDescription = await queryInterface.describeTable("Company");
+		if ("raffleThumbnailURL" in tableDescription) {
+			await queryInterface.sequelize.query("ALTER TABLE Company DROP COLUMN raffleThumbnailURL");
+		}
+	}
+};

--- a/source/database/models/companies/Company.js
+++ b/source/database/models/companies/Company.js
@@ -102,7 +102,10 @@ function initModel(sequelize) {
 			type: DataTypes.STRING
 		},
 		toastThumbnailURL: {
-			type: DataTypes.STRING
+			type: DataTypes.STRING,
+			get() {
+				return this.getDataValue("toastThumbnailURL") ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png';
+			}
 		},
 		openBountyThumbnailURL: {
 			type: DataTypes.STRING,
@@ -132,6 +135,12 @@ function initModel(sequelize) {
 			type: DataTypes.STRING,
 			get() {
 				return this.getDataValue("goalCompletionThumbnailURL") ?? "https://cdn.discordapp.com/attachments/673600843630510123/1309260766318166117/trophy-cup.png?ex=6740ef9b&is=673f9e1b&hm=218e19ede07dcf85a75ecfb3dde26f28adfe96eb7b91e89de11b650f5c598966&";
+			}
+		},
+		raffleThumbnailURL: {
+			type: DataTypes.STRING,
+			get() {
+				return this.getDataValue("raffleThumbnailURL") ?? "https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&";
 			}
 		}
 	}, {

--- a/source/frontend/commands/config-premium.js
+++ b/source/frontend/commands/config-premium.js
@@ -95,6 +95,17 @@ module.exports = new CommandWrapper(mainId, "Configure premium BountyBot setting
 			}
 		}
 
+		const raffleThumbnailURL = interaction.options.getString("raffle-thumbnail-url");
+		if (raffleThumbnailURL) {
+			try {
+				new URL(raffleThumbnailURL);
+				updatePayload.raffleThumbnailURL = raffleThumbnailURL;
+				content += `\n- The server bonuses thumbnail was set to <${raffleThumbnailURL}>.`;
+			} catch (error) {
+				errors.push(error.message);
+			}
+		}
+
 		origin.company.update(updatePayload);
 		if (errors.length > 0) {
 			content += `\n\nThe following errors were encountered:\n- ${errors.join("\n- ")}`;
@@ -117,37 +128,43 @@ module.exports = new CommandWrapper(mainId, "Configure premium BountyBot setting
 	{
 		type: "String",
 		name: "toast-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of toasts",
+		description: "Set a url pointing to an image to use as thumbnail on toasts",
 		required: false
 	},
 	{
 		type: "String",
 		name: "open-bounty-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of open bounties",
+		description: "Set a url pointing to an image to use as thumbnail on open bounties",
 		required: false
 	},
 	{
 		type: "String",
 		name: "completed-bounty-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of completed bounties",
+		description: "Set a url pointing to an image to use as thumbnail on completed bounties",
 		required: false
 	},
 	{
 		type: "String",
 		name: "deleted-bounty-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of deleted bounties",
+		description: "Set a url pointing to an image to use as thumbnail on deleted bounties",
 		required: false
 	},
 	{
 		type: "String",
 		name: "scoreboard-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of the scoreboard",
+		description: "Set a url pointing to an image to use as thumbnail on the scoreboard",
 		required: false
 	},
 	{
 		type: "String",
 		name: "goal-completion-thumbnail-url",
-		description: "Configure the image shown in the thumbnail of the server goal completion message",
+		description: "Set a url pointing to an image to use as thumbnail in server goal completion messages",
+		required: false
+	},
+	{
+		type: "String",
+		name: "raffle-thumbnail-url",
+		description: "Set a url pointing to an image to use as thumbnail in raffle winner messages",
 		required: false
 	}
 );

--- a/source/frontend/commands/raffle/by-level.js
+++ b/source/frontend/commands/raffle/by-level.js
@@ -1,18 +1,30 @@
-const { MessageFlags } = require("discord.js");
+const { MessageFlags, Colors, userMention, EmbedBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("by-level", "Select a user at or above a particular level",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
 		const levelThreshold = interaction.options.getInteger("level");
-		const eligibleHunters = await logicLayer.hunters.findHuntersAtOrAboveLevel(interaction.guild.id, levelThreshold);
-		const eligibleMembers = await interaction.guild.members.fetch({ user: eligibleHunters.map(hunter => hunter.userId) });
-		const eligibleIds = eligibleMembers.filter(member => member.manageable).map(member => member.id);
-		if (eligibleIds.size < 1) {
+		const eligibleHunters = await logicLayer.hunters.findHuntersAtOrAboveLevel(origin.company, levelThreshold);
+		const eligibleMembers = (await interaction.guild.members.fetch({ user: eligibleHunters.map(hunter => hunter.userId) })).filter(member => member.manageable);
+		if (eligibleMembers.size < 1) {
 			interaction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above level ${levelThreshold}).`, flags: MessageFlags.Ephemeral });
 			return;
 		}
-		const winnerId = eligibleIds.at(Math.floor(Math.random() * eligibleIds.size));
-		interaction.reply(`The winner of this raffle is: <@${winnerId}>`);
+		const eligibleIds = eligibleMembers.map(member => member.id);
+		const winnerId = eligibleIds.at(Math.floor(Math.random() * eligibleIds.length));
+		const embed = new EmbedBuilder().setColor(Colors[eligibleHunters.find(hunter => hunter.userId === winnerId).profileColor])
+			.setAuthor({ name: interaction.guild.name, iconURL: interaction.guild.iconURL() })
+			.setTitle("Raffle Results")
+			//TODONOW customizable thumbnail
+			.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&")
+			.setDescription(`The winner of this raffle is: ${userMention(winnerId)}`)
+			.addFields({ name: "Qualifications", value: `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})` })
+			.setTimestamp();
+
+		if (interaction.guild.bannerURL()) {
+			embed.setImage(interaction.guild.bannerURL());
+		}
+		interaction.reply({ embeds: [embed] });
 		origin.company.update("nextRaffleString", null);
 	}
 ).setOptions(

--- a/source/frontend/commands/raffle/by-level.js
+++ b/source/frontend/commands/raffle/by-level.js
@@ -1,4 +1,4 @@
-const { MessageFlags, Colors, userMention, EmbedBuilder } = require("discord.js");
+const { MessageFlags, Colors, EmbedBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 
 module.exports = new SubcommandWrapper("by-level", "Select a user at or above a particular level",
@@ -10,14 +10,13 @@ module.exports = new SubcommandWrapper("by-level", "Select a user at or above a 
 			interaction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above level ${levelThreshold}).`, flags: MessageFlags.Ephemeral });
 			return;
 		}
-		const eligibleIds = eligibleMembers.map(member => member.id);
-		const winnerId = eligibleIds.at(Math.floor(Math.random() * eligibleIds.length));
-		const embed = new EmbedBuilder().setColor(Colors[eligibleHunters.find(hunter => hunter.userId === winnerId).profileColor])
+		const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
+		const embed = new EmbedBuilder().setColor(Colors[eligibleHunters.find(hunter => hunter.userId === winner.id).profileColor])
 			.setAuthor({ name: interaction.guild.name, iconURL: interaction.guild.iconURL() })
 			.setTitle("Raffle Results")
 			//TODONOW customizable thumbnail
 			.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&")
-			.setDescription(`The winner of this raffle is: ${userMention(winnerId)}`)
+			.setDescription(`The winner of this raffle is: ${winner}`)
 			.addFields({ name: "Qualifications", value: `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})` })
 			.setTimestamp();
 

--- a/source/frontend/commands/raffle/by-level.js
+++ b/source/frontend/commands/raffle/by-level.js
@@ -1,5 +1,6 @@
-const { MessageFlags, Colors, EmbedBuilder } = require("discord.js");
+const { MessageFlags } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
+const { raffleResultEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("by-level", "Select a user at or above a particular level",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -11,19 +12,7 @@ module.exports = new SubcommandWrapper("by-level", "Select a user at or above a 
 			return;
 		}
 		const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
-		const embed = new EmbedBuilder().setColor(Colors[eligibleHunters.find(hunter => hunter.userId === winner.id).profileColor])
-			.setAuthor({ name: interaction.guild.name, iconURL: interaction.guild.iconURL() })
-			.setTitle("Raffle Results")
-			//TODONOW customizable thumbnail
-			.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&")
-			.setDescription(`The winner of this raffle is: ${winner}`)
-			.addFields({ name: "Qualifications", value: `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})` })
-			.setTimestamp();
-
-		if (interaction.guild.bannerURL()) {
-			embed.setImage(interaction.guild.bannerURL());
-		}
-		interaction.reply({ embeds: [embed] });
+		interaction.reply({ embeds: [raffleResultEmbed(eligibleHunters.find(hunter => hunter.userId === winner.id).profileColor, interaction.guild, winner, `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
 		origin.company.update("nextRaffleString", null);
 	}
 ).setOptions(

--- a/source/frontend/commands/raffle/by-level.js
+++ b/source/frontend/commands/raffle/by-level.js
@@ -12,7 +12,7 @@ module.exports = new SubcommandWrapper("by-level", "Select a user at or above a 
 			return;
 		}
 		const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
-		interaction.reply({ embeds: [raffleResultEmbed(eligibleHunters.find(hunter => hunter.userId === winner.id).profileColor, interaction.guild, winner, `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
+		interaction.reply({ embeds: [raffleResultEmbed(eligibleHunters.find(hunter => hunter.userId === winner.id).profileColor, interaction.guild, origin.company.raffleThumbnailURL, winner, `Level ${levelThreshold} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
 		origin.company.update("nextRaffleString", null);
 	}
 ).setOptions(

--- a/source/frontend/commands/raffle/by-rank.js
+++ b/source/frontend/commands/raffle/by-rank.js
@@ -36,7 +36,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			}
 			const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
 			collectedInteraction.update({ components: [] });
-			collectedInteraction.channel.send(`The winner of this raffle is: ${winner}`);
+			collectedInteraction.channel.send(`The winner of this raffle is: ${winner}`); //TODONOW response embed
 			origin.company.update("nextRaffleString", null);
 		}).catch(error => {
 			if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {

--- a/source/frontend/commands/raffle/by-rank.js
+++ b/source/frontend/commands/raffle/by-rank.js
@@ -1,7 +1,7 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, DiscordjsErrorCodes } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, DiscordjsErrorCodes, roleMention } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
-const { rankArrayToSelectOptions } = require("../../shared");
+const { rankArrayToSelectOptions, raffleResultEmbed } = require("../../shared");
 
 module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a particular rank",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -10,13 +10,14 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			interaction.reply({ content: "This server doesn't have any ranks configured.", flags: MessageFlags.Ephemeral });
 			return;
 		}
+		const roles = await interaction.guild.roles.fetch();
 		interaction.reply({
 			content: "Select a rank to be the eligibility threshold for this raffle:",
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a rank...")
-						.addOptions(rankArrayToSelectOptions(ranks, await interaction.guild.roles.fetch()))
+						.addOptions(rankArrayToSelectOptions(ranks, roles))
 				)
 			],
 			flags: MessageFlags.Ephemeral,
@@ -27,16 +28,16 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			const reloadedRanks = await Promise.all(ranks.map(rank => rank.reload()));
 			const rankIndex = reloadedRanks.findIndex(rank => rank.threshold === threshold);
 			const rank = reloadedRanks[rankIndex];
-			const qualifiedHunterIds = await logicLayer.hunters.findHunterIdsAtOrAboveRank(interaction.guildId, rankIndex);
-			const unvalidatedMembers = await interaction.guild.members.fetch({ user: qualifiedHunterIds });
+			const hunterMap = await logicLayer.hunters.createHunterMapAtOrAboveRank(interaction.guildId, rankIndex);
+			const unvalidatedMembers = await interaction.guild.members.fetch({ user: [...hunterMap.keys()] });
 			const eligibleMembers = unvalidatedMembers.filter(member => member.manageable);
 			if (eligibleMembers.size < 1) {
-				collectedInteraction.reply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above the rank ${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${threshold + 1}`}).`, flags: MessageFlags.Ephemeral });
+				collectedInteraction.editReply({ content: `There wouldn't be any eligible bounty hunters for this raffle (at or above the rank ${rank.roleId ? `<@&${rank.roleId}>` : `Rank ${threshold + 1}`}).`, components: [] });
 				return;
 			}
 			const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
-			collectedInteraction.update({ components: [] });
-			collectedInteraction.channel.send(`The winner of this raffle is: ${winner}`); //TODONOW response embed
+			collectedInteraction.editReply({ components: [] });
+			collectedInteraction.channel.send({ embeds: [raffleResultEmbed(hunterMap.get(winner.id).profileColor, collectedInteraction.guild, winner, `Rank ${rank.roleId ? roleMention(rank.roleId) : `Rank ${ranks.reduce((checkedRank, matchingIndex, index) => rank.threshold === checkedRank.threshold ? index : matchingIndex, 0) + 1}`} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
 			origin.company.update("nextRaffleString", null);
 		}).catch(error => {
 			if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {
@@ -45,7 +46,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 
 			if (error.name === "SequelizeInstanceError") {
 				interaction.user.send({ content: "A raffle by ranks could not be started because there was an error with finding the rank you selected. Please try again." });
-			} else if (Object.values(error.rawError.errors.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
+			} else if (error.rawError && Object.values(error.rawError.errors.components).some(row => Object.values(row.components).some(component => Object.values(component.options).some(option => option.emoji.name._errors.some(error => error.code == "BUTTON_COMPONENT_INVALID_EMOJI"))))) {
 				interaction.user.send({ content: "A raffle by ranks could not be started because this server has a rank with a non-emoji as a rankmoji.", flags: MessageFlags.Ephemeral });
 			} else {
 				console.error(error);

--- a/source/frontend/commands/raffle/by-rank.js
+++ b/source/frontend/commands/raffle/by-rank.js
@@ -37,7 +37,7 @@ module.exports = new SubcommandWrapper("by-rank", "Select a user at or above a p
 			}
 			const winner = eligibleMembers.at(Math.floor(Math.random() * eligibleMembers.size));
 			collectedInteraction.editReply({ components: [] });
-			collectedInteraction.channel.send({ embeds: [raffleResultEmbed(hunterMap.get(winner.id).profileColor, collectedInteraction.guild, winner, `Rank ${rank.roleId ? roleMention(rank.roleId) : `Rank ${ranks.reduce((checkedRank, matchingIndex, index) => rank.threshold === checkedRank.threshold ? index : matchingIndex, 0) + 1}`} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
+			collectedInteraction.channel.send({ embeds: [raffleResultEmbed(hunterMap.get(winner.id).profileColor, collectedInteraction.guild, origin.company.raffleThumbnailURL, winner, `Rank ${rank.roleId ? roleMention(rank.roleId) : `Rank ${ranks.reduce((checkedRank, matchingIndex, index) => rank.threshold === checkedRank.threshold ? index : matchingIndex, 0) + 1}`} or higher (${eligibleMembers.size} eligible entrant${eligibleMembers.size === 1 ? "" : "s"})`)] });
 			origin.company.update("nextRaffleString", null);
 		}).catch(error => {
 			if (error.code === DiscordjsErrorCodes.InteractionCollectorError) {

--- a/source/frontend/shared/messageParts.js
+++ b/source/frontend/shared/messageParts.js
@@ -444,6 +444,28 @@ async function statsEmbed(company, guild, allHunters, participantCount, currentL
 }
 
 /**
+ * @param {keyof Colors} profileColor
+ * @param {Guild} guild
+ * @param {GuildMember} winner
+ * @param {string} qualificationText
+ */
+function raffleResultEmbed(profileColor, guild, winner, qualificationText) {
+	const embed = new EmbedBuilder().setColor(Colors[profileColor])
+		.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
+		.setTitle("Raffle Results")
+		//TODONOW customizable thumbnail
+		.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&")
+		.setDescription(`The winner of this raffle is: ${winner}`)
+		.addFields({ name: "Qualifications", value: qualificationText })
+		.setTimestamp();
+
+	if (guild.bannerURL()) {
+		embed.setImage(guild.bannerURL());
+	}
+	return embed;
+}
+
+/**
  * @param {number} level
  * @param {number} maxSlots
  * @param {boolean} futureReward
@@ -659,6 +681,7 @@ module.exports = {
 	seasonalScoreboardEmbed,
 	overallScoreboardEmbed,
 	statsEmbed,
+	raffleResultEmbed,
 	getHunterLevelUpRewards,
 	buildHunterLevelUpLine,
 	modStatsEmbed,

--- a/source/frontend/shared/messageParts.js
+++ b/source/frontend/shared/messageParts.js
@@ -446,15 +446,15 @@ async function statsEmbed(company, guild, allHunters, participantCount, currentL
 /**
  * @param {keyof Colors} profileColor
  * @param {Guild} guild
+ * @param {string} thumbnailURL
  * @param {GuildMember} winner
  * @param {string} qualificationText
  */
-function raffleResultEmbed(profileColor, guild, winner, qualificationText) {
+function raffleResultEmbed(profileColor, guild, thumbnailURL, winner, qualificationText) {
 	const embed = new EmbedBuilder().setColor(Colors[profileColor])
 		.setAuthor({ name: guild.name, iconURL: guild.iconURL() })
 		.setTitle("Raffle Results")
-		//TODONOW customizable thumbnail
-		.setThumbnail("https://cdn.discordapp.com/attachments/545684759276421120/1387920759870984283/ticket.png?ex=685f196f&is=685dc7ef&hm=a8e49b311c5c8854b0fc68ef9d2cf00aead714a0d21438b1b9fa2089f8e7a3de&")
+		.setThumbnail(thumbnailURL)
 		.setDescription(`The winner of this raffle is: ${winner}`)
 		.addFields({ name: "Qualifications", value: qualificationText })
 		.setTimestamp();
@@ -538,14 +538,14 @@ function modStatsEmbed(hunter, guild, member, dqCount, lastFiveBounties) {
 }
 
 /**
- * @param {string?} thumbnailURL
+ * @param {string} thumbnailURL
  * @param {string} toastText
  * @param {Set<string>} recipientIdSet
  * @param {GuildMember} senderMember
  */
 function generateToastEmbed(thumbnailURL, toastText, recipientIdSet, senderMember) {
 	return new EmbedBuilder().setColor("e5b271")
-		.setThumbnail(thumbnailURL ?? 'https://cdn.discordapp.com/attachments/545684759276421120/751876927723143178/glass-celebration.png')
+		.setThumbnail(thumbnailURL)
 		.setTitle(toastText)
 		.setDescription(`A toast to ${listifyEN([...recipientIdSet.values()].map(id => userMention(id)))}!`)
 		.setFooter({ text: senderMember.displayName, iconURL: senderMember.user.avatarURL() });

--- a/source/logic/companies.js
+++ b/source/logic/companies.js
@@ -39,7 +39,8 @@ function resetCompanySettings(id) {
 			openBountyThumbnailURL: null,
 			completedBountyThumbnailURL: null,
 			scoreboardThumbnailURL: null,
-			goalCompletionThumbnailURL: null
+			goalCompletionThumbnailURL: null,
+			raffleThumbnailURL: null
 		},
 		{ where: { id } }
 	);

--- a/source/logic/hunters.js
+++ b/source/logic/hunters.js
@@ -1,5 +1,5 @@
 const { Sequelize, Op } = require("sequelize");
-const { Hunter, User } = require("../database/models");
+const { Hunter, User, Company } = require("../database/models");
 
 /** @type {Sequelize} */
 let db;
@@ -85,11 +85,11 @@ function findCompanyHuntersByDescendingXP(companyId) {
 }
 
 /** *Find all Hunters in the specified Company at or above the level threshold*
- * @param {string} companyId
+ * @param {Company} company
  * @param {number} levelThreshold
  */
-function findHuntersAtOrAboveLevel(companyId, levelThreshold) {
-	return db.models.Hunter.findAll({ where: { companyId, level: { [Op.gte]: levelThreshold } } });
+async function findHuntersAtOrAboveLevel(company, levelThreshold) {
+	return (await db.models.Hunter.findAll({ where: { companyId: company.id } })).filter(hunter => hunter.getLevel(company.xpCoefficient) >= levelThreshold);
 }
 
 /** *Sets a Hunter's Profile Color*


### PR DESCRIPTION
Summary
-------
- improve reply messages for raffles

After trying out containers for the reply messages, embeds looked better and had more formatting capabilities for text. Sending a "is typing" indicator was deemed to be gimmicky and breaking of UX convention.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] /raffle by-level announces raffle winner in new style
- [x] /raffle by-rank announces raffle winner in new style
- [x] migration up adds custom raffle thumbnail column
- [x] migration down removes custom raffle thumbnail column

Issue
-----
Closes #439