### PR TITLE
SillySalamndr/issue377

### DIFF
--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -12,9 +12,16 @@ function setDB(database) {
 
 /** *Find the Secondings of specified seconder for the purposes of Crit Toast and Rewarded Toast tracking*
  * @param {string} seconderId
- */
-function findRecentSecondings(seconderId) {
-	return db.models.Seconding.findAll({ where: { seconderId, createdAt: { [Op.gt]: dateInPast({ d: 2 }) } } });
+ * @param {object} recency How far in the past to look for recent secondings. By default, 2 days.
+ * @param {number} recency.w An amount of time to look back in weeks.
+ * @param {number} recency.d An amount of time to look back in days.
+ * @param {number} recency.h An amount of time to look back in hours.
+ * @param {number} recency.m An amount of time to look back in minues.
+ * @param {number} recency.s An amount of time to look back in seconds.
+ * @param {number} recency.ms An amount of time to look back in milliseconds.
+*/
+function findRecentSecondings(seconderId, recency = { d: 2 }) {
+	return db.models.Seconding.findAll({ where: { seconderId, createdAt: { [Op.gt]: dateInPast(recency) } } });
 }
 
 /** *Get the ids of the rewarded Recipients on the sender's last 5 Toasts*

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -12,7 +12,7 @@ function setDB(database) {
 
 /** *Find the Secondings of specified seconder for the purposes of Crit Toast and Rewarded Toast tracking*
  * @param {string} seconderId
- * @param {object} recency How far in the past to look for recent secondings. By default, 2 days.
+ * @param {object} recency How far in the past to look for recent secondings. Defaults to 2 days.
  * @param {number} recency.w An amount of time to look back in weeks.
  * @param {number} recency.d An amount of time to look back in days.
  * @param {number} recency.h An amount of time to look back in hours.


### PR DESCRIPTION
Fixes #377

Summary
-------
`findRecentSecondings` was made more generically applicable by allowing for the function to take in the amount of time in the past to limit by. Most all of the work in this task comes from additions to the JSDoc. There should be no functional changes from this task.

I apologize for not having a thorough test before making this pull request; I need to have a second user so that it is possible to have someone hit the seconding button.

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [ ] TODO: Group test to hit this function via toast + seconding

Issue
-----
Closes #377
