### PR TITLE
`/bounty swap` improvements

### DIFF
--- a/source/frontend/commands/bounty/swap.js
+++ b/source/frontend/commands/bounty/swap.js
@@ -29,7 +29,8 @@ module.exports = new SubcommandWrapper("swap", "Move one of your bounties to ano
 				collector.on("collect", async (collectedInteraction) => {
 					let previousBounty = openBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
 					if (collectedInteraction.customId.endsWith("bounty")) {
-						const bountySlotCount = Hunter.getBountySlotCount(origin.hunter.getLevel(origin.company.xpCoefficient), origin.company.maxSimBounties);
+						const startingPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+						const bountySlotCount = Hunter.getBountySlotCount(startingPosterLevel, origin.company.maxSimBounties);
 						if (bountySlotCount < 2) {
 							collectedInteraction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: MessageFlags.Ephemeral });
 							return;
@@ -44,7 +45,7 @@ module.exports = new SubcommandWrapper("swap", "Move one of your bounties to ano
 									{
 										emoji: getNumberEmoji(i),
 										label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-										description: `XP Reward: ${Bounty.calculateCompleterReward(origin.hunter.getLevel(origin.company.xpCoefficient), i, existingBounty?.showcaseCount ?? 0)}`,
+										description: `XP Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, i, existingBounty?.showcaseCount ?? 0)}`,
 										value: i.toString()
 									}
 								)

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -59,15 +59,6 @@ function findOpenBounties(userId, companyId) {
 	return db.models.Bounty.findAll({ where: { userId, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
 }
 
-/** *Find a Hunter's Bounties in the slotNumbers*
- * @param {string} userId
- * @param {string} companyId
- * @param {number[]} slotNumbers
- */
-function bulkFindOpenBounties(userId, companyId, slotNumbers) {
-	return db.models.Bounty.findAll({ where: { userId, companyId, slotNumber: { [Op.in]: slotNumbers }, state: "open" } });
-}
-
 /** @param {string} companyId */
 function findEvergreenBounties(companyId) {
 	return db.models.Bounty.findAll({ where: { isEvergreen: true, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
@@ -204,7 +195,6 @@ module.exports = {
 	bulkCreateCompletions,
 	findBounty,
 	findOpenBounties,
-	bulkFindOpenBounties,
 	findEvergreenBounties,
 	findBountyCompletions,
 	getHunterIdSet,


### PR DESCRIPTION
Summary
-------
Some of the functions being moved or replicated in #419 are old enough to benefit from being refactored. I'm going to split the actual refactors out to separate PRs so that #419's PR can be mostly structural.

Here are the changes for `/bounty swap`:
- add validation for source bounty being completed before slot is selected
- expand destination bounty validation to include destination bounty being completed before slot is selected
- reduce duplicate fetches (allowing the deprecation of `logicLayer.bounties.bulkFindOpenBounties()`)
- switch to `Model.update()` over set and save
- use formating function instead of literal markdown
- avoid recalculating poster level for each bounty when generating slot options

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] added/expanded validations are needed
- [x] stale bounty detection skips logic if bounty was completed before destination slot was selected
- [x] swaps with open bounties still work
- [x] if bounty in selected slot is completed before slot is selected, bounty in destination slot is not modified