### PR TITLE
#540 & #534: update Discord.js to v14.23.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,9 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "BountyBot",
 			"dependencies": {
 				"@sapphire/discord.js-utilities": "7.3.3",
-				"discord.js": "14.21.0",
+				"discord.js": "14.23.2",
 				"node-cron": "3.0.3",
 				"sequelize": "6.37.7",
 				"sequelize-cli": "6.6.3",
@@ -15,14 +14,14 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
-			"integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.12.2.tgz",
+			"integrity": "sha512-AugKmrgRJOHXEyMkABH/hXpAmIBKbYokCEl9VAM4Kh6FvkdobQ+Zhv7AR6K+y5hS7+VQ7gKXPYCe1JQmV07H1g==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.6.1",
 				"@discordjs/util": "^1.1.1",
 				"@sapphire/shapeshift": "^4.0.0",
-				"discord-api-types": "^0.38.1",
+				"discord-api-types": "^0.38.26",
 				"fast-deep-equal": "^3.1.3",
 				"ts-mixer": "^6.0.4",
 				"tslib": "^2.6.3"
@@ -57,16 +56,16 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
-			"integrity": "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+			"integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
 				"@discordjs/util": "^1.1.1",
 				"@sapphire/async-queue": "^1.5.3",
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "^0.38.1",
+				"discord-api-types": "^0.38.16",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
 				"undici": "6.21.3"
@@ -802,26 +801,26 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.38.8",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.8.tgz",
-			"integrity": "sha512-xuRXPD44FcbKHrQK15FS1HFlMRNJtsaZou/SVws18vQ7zHqmlxyDktMkZpyvD6gE2ctGOVYC/jUyoMMAyBWfcw==",
+			"version": "0.38.29",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.29.tgz",
+			"integrity": "sha512-+5BfrjLJN1hrrcK0MxDQli6NSv5lQH7Y3/qaOfk9+k7itex8RkA/UcevVMMLe8B4IKIawr4ITBTb2fBB2vDORg==",
 			"workspaces": [
 				"scripts/actions/documentation"
 			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.21.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.21.0.tgz",
-			"integrity": "sha512-U5w41cEmcnSfwKYlLv5RJjB8Joa+QJyRwIJz5i/eg+v2Qvv6EYpCRhN9I2Rlf0900LuqSDg8edakUATrDZQncQ==",
+			"version": "14.23.2",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.23.2.tgz",
+			"integrity": "sha512-tU2NFr823X3TXEc8KyR/4m296KLxPai4nirN3q9kHCpY4TKj96n9lHZnyLzRNMui8EbL07jg9hgH2PWWfKMGIg==",
 			"dependencies": {
-				"@discordjs/builders": "^1.11.2",
+				"@discordjs/builders": "^1.12.1",
 				"@discordjs/collection": "1.5.3",
 				"@discordjs/formatters": "^0.6.1",
-				"@discordjs/rest": "^2.5.1",
+				"@discordjs/rest": "^2.6.0",
 				"@discordjs/util": "^1.1.1",
 				"@discordjs/ws": "^1.2.3",
 				"@sapphire/snowflake": "3.5.3",
-				"discord-api-types": "^0.38.1",
+				"discord-api-types": "^0.38.29",
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
 				"magic-bytes.js": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"@sapphire/discord.js-utilities": "7.3.3",
-		"discord.js": "14.21.0",
+		"discord.js": "14.23.2",
 		"node-cron": "3.0.3",
 		"sequelize": "6.37.7",
 		"sequelize-cli": "6.6.3",


### PR DESCRIPTION
Summary
-------
- update Discord.js to v14.23.2 (support for new modal components!)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] refactors listed in change notes unused by us
- [x] did some end to end testing and implemented a feature with new modal components when installing in Prophets of the Labyrinth

Issue
-----
Closes #540, Closes #534