### PR TITLE
Interim fix for item cooldown:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 config
 saves
-db.sqlite
-db_base.sqlite
+*.sqlite

--- a/source/index.js
+++ b/source/index.js
@@ -189,17 +189,19 @@ dAPIClient.on(Events.InteractionCreate, async interaction => {
 	//#endregion
 
 	// #region General Cooldown Management
-	const commandTime = new Date();
-	const { isOnGeneralCooldown, isOnCommandCooldown, cooldownTimestamp, lastCommandName } = await logicBlob.cooldowns.checkCooldownState(interaction.user.id, mainId, commandTime);
-	if (isOnGeneralCooldown) {
-		interaction.reply({ content: `Please wait, you are on BountyBot cooldown from using \`${lastCommandName}\` recently. Try again ${discordTimestamp(Math.floor(cooldownTimestamp.getTime() / 1000), TimestampStyles.RelativeTime)}.`, flags: [MessageFlags.Ephemeral] });
-		return;
+	if (!interaction.isAutocomplete()) { // Only run cooldowns on valid command types
+		const commandTime = new Date();
+		const { isOnGeneralCooldown, isOnCommandCooldown, cooldownTimestamp, lastCommandName } = await logicBlob.cooldowns.checkCooldownState(interaction.user.id, mainId, commandTime);
+		if (isOnGeneralCooldown) {
+			interaction.reply({ content: `Please wait, you are on BountyBot cooldown from using \`${lastCommandName}\` recently. Try again ${discordTimestamp(Math.floor(cooldownTimestamp.getTime() / 1000), TimestampStyles.RelativeTime)}.`, flags: [MessageFlags.Ephemeral] });
+			return;
+		}
+		if (isOnCommandCooldown) {
+			interaction.reply({ content: `Please wait, \`/${mainId}\` is on cooldown. It can be used again ${discordTimestamp(Math.floor(cooldownTimestamp.getTime() / 1000), TimestampStyles.RelativeTime)}.`, flags: [MessageFlags.Ephemeral] });
+			return;
+		}
+		logicBlob.cooldowns.updateCooldowns(interaction.user.id, mainId, commandTime, cooldownMap[mainId]);
 	}
-	if (isOnCommandCooldown) {
-		interaction.reply({ content: `Please wait, \`/${mainId}\` is on cooldown. It can be used again ${discordTimestamp(Math.floor(cooldownTimestamp.getTime() / 1000), TimestampStyles.RelativeTime)}.`, flags: [MessageFlags.Ephemeral] });
-		return;
-	}
-	logicBlob.cooldowns.updateCooldowns(interaction.user.id, mainId, commandTime, cooldownMap[mainId]);
 	//#endregion
 
 	//#region Command execution


### PR DESCRIPTION
- Item cooldowns now only check for non-autocomplete interactions
- gitignore now ignores all SQLite database files

Summary
-------
Items revealed an issue where users could autocomplete too quickly and run into a cooldown without actually firing a command. This fix naively ignores autocomplete commands as part of the cooldown system, since we aren't wanting looking at the autocomplete options to count as using the command for the cooldown system's purposes.

We may want to revisit this in the future to try to reduce spam from a malicious actor trying to crash the bot (or drive up costs) by repeatedly firing new autocomplete fetches, but that case seems difficult to produce at this time.

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] item commands now work if the user quickly tab/autocompletes the field


Issue
-----
No associated issue, as this was part of the pre-2.10 test effort. See discussion #548
