### PR TITLE
avoid foreign key error on deleteHunterBountiesAndCompletionsFromCompany

### DIFF
--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -195,14 +195,15 @@ async function deleteCompanyBounties(companyId) {
  * @param {string} companyId
  */
 async function deleteHunterBountiesAndCompletionsFromCompany(userId, companyId) {
-	await db.models.Completion.destroy({ where: { userId, companyId } });
 	const bountyPostingIds = [];
 	for (const bounty of await db.models.Bounty.findAll({ where: { userId, companyId } })) {
+		await db.models.Completion.destroy({ where: { bountyId: bounty.id } });
 		if (bounty.postingId) {
 			bountyPostingIds.push(bounty.postingId);
 		}
+		await bounty.destroy();
 	}
-	await db.models.Bounty.destroy({ where: { userId, companyId } });
+	await db.models.Completion.destroy({ where: { userId, companyId } });
 	return bountyPostingIds;
 }
 


### PR DESCRIPTION
Summary
-------
- make sure to delete completions belonging to deleted hunter's bounties before deleting bounty