### PR TITLE
#553: use select menu in Record Bounty Turn-In context menu modal

### DIFF
--- a/source/frontend/context_menus/Record_Bounty_Turn-In.js
+++ b/source/frontend/context_menus/Record_Bounty_Turn-In.js
@@ -47,7 +47,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 		return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modalId, time: 300000 }).then(async modalSubmission => {
 			const [bountyId] = modalSubmission.fields.getStringSelectValues("bounty-id");
 			const bounty = await logicLayer.bounties.findBounty(bountyId);
-			if (bounty.state !== "open") {
+			if (bounty?.state !== "open") {
 				modalSubmission.reply({ content: "The bounty you selected no longer appears to be open.", flags: MessageFlags.Ephemeral });
 				return;
 			}


### PR DESCRIPTION
Summary
-------
- use select menu in Record Bounty Turn-In context menu modal

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] no regressions found in Record Bounty Turn-In critical path

Issue
-----
Closes #553