### PR TITLE
#566: validate that rank roles are manageable by BountyBot

### DIFF
--- a/source/frontend/commands/rank/edit.js
+++ b/source/frontend/commands/rank/edit.js
@@ -1,4 +1,4 @@
-const { MessageFlags } = require("discord.js");
+const { MessageFlags, unorderedList } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { syncRankRoles } = require("../../shared");
 
@@ -12,22 +12,39 @@ module.exports = new SubcommandWrapper("edit", "Change the role or rankmoji for 
 		}
 
 		const updateOptions = {};
-
-		const newRole = interaction.options.getRole("role");
-		if (newRole) {
-			updateOptions.roleId = newRole.id;
-		}
+		let response = "The seasonal rank ";
+		const errors = [];
 
 		const newRankmoji = interaction.options.getString("rankmoji");
 		if (newRankmoji) {
 			updateOptions.rankmoji = newRankmoji;
+			response += `${newRankmoji} `;
 		}
+
+		response += `at ${threshold} standard deviations above mean season xp was updated`;
+
+		const newRole = interaction.options.getRole("role");
+		if (newRole) {
+			const bountybotGuildMember = await interaction.guild.members.fetchMe();
+			if (interaction.guild.roles.comparePositions(bountybotGuildMember.roles.highest, newRole) > 0) {
+				updateOptions.roleId = newRole.id;
+				response += ` to give the role ${newRole}`;
+			} else {
+				errors.push(`Did not assign ${newRole} to the rank. ${bountybotGuildMember} would not be able to add or remove the role from bounty hunters (none of ${bountybotGuildMember}'s roles are above it).`);
+			}
+		}
+
+		response += ".";
+		if (errors.length > 0) {
+			response += ` However, the following errors were encountered:\n${unorderedList(errors)}`;
+		}
+
 		rank.update(updateOptions);
 		const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
 		const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await interaction.guild.roles.fetch());
 		syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-		interaction.reply({ content: `The seasonal rank ${newRankmoji ? `${newRankmoji} ` : ""}at ${threshold} standard deviations above mean season xp was updated${newRole ? ` to give the role ${newRole}` : ""}.`, flags: MessageFlags.Ephemeral });
+		interaction.reply({ content: response, flags: MessageFlags.Ephemeral });
 	}
 ).setOptions(
 	{


### PR DESCRIPTION
Summary
-------
- validate that rank roles are manageable by BountyBot

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] adding a rank with an unmanageable role provides an error message and doesn't add the role
- [x] adding a rank with a manageable role still works

Issue
-----
Closes #566