### PR TITLE
#601: Item attempting to increment column that no longer exists.

### DIFF
--- a/source/logic/items.js
+++ b/source/logic/items.js
@@ -102,13 +102,7 @@ async function rollItemForHunter(dropRate, hunter) {
 	}
 	if (!droppedItem) return [null, false];
 
-	return db.models.Item.findOrCreate({ where: { userId: hunter.userId, itemName: droppedItem } }).then((result) => {
-		const [itemRow, itemWasCreated] = result;
-		if (!itemWasCreated) {
-			itemRow.increment("count");
-		}
-		return result;
-	});
+	return [ await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true ];
 }
 
 /** *Finds the count of the specified Items of User*


### PR DESCRIPTION
Summary
-------
- Now uses `create` over `findOrCreate`
- Maintains the previous functionality of returning an array pseudo-tuple to also return whether the item is created.

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Bot no longer crashes when giving a user a second item of a particular type

Issue
-----
Closes #601