### PR TITLE
#498 pt3: crash fixes in showcase flows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@
 ### Premium Features
 - Added premium commands `/festival start-gp` and `/festival close-gp` for toggling times where gp contributions are multiplied (old festival commands renamed to `/festival start-xp` and `/festival close-xp`)
 - Added the `nickname` option to `/config-premium` to allow bot managers to set a nickname for BountyBot that won't get cleared by toggling festivals on or off
-### Bug Fixes
+### Other Changes
+- The completing a bounty via the select in the bounty board can now add turn-ins like the slash command
 - Fixed Goal Point contributions not showing up in reward messages
 ### Known Issues
 - When editing a bounty, not submitting a description, image, or timestamp pair, always deletes those data from the bounty (this will be fixed with modal checkboxes in the future)

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,71 +1,107 @@
-const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
+const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, reloadHunterMapSubset, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		const slotNumber = interaction.options.getInteger("bounty-slot");
-		const bounty = await logicLayer.bounties.findBounty({ userId: interaction.user.id, slotNumber, companyId: interaction.guild.id });
-		if (!bounty) {
-			interaction.reply({ content: "You don't have a bounty in the `bounty-slot` provided.", flags: MessageFlags.Ephemeral });
+		const openBounties = await logicLayer.bounties.findOpenBounties(origin.user.id, origin.company.id);
+		if (openBounties.length < 1) {
+			interaction.reply({ content: "You don't appear to have any open bounties in this server.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const labelIdBountyId = "bounty-id";
+		const labelIdBountyHunters = "hunters";
+		const maxHunters = 10;
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Mark your Bounty Complete!")
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBounties(openBounties))
+					),
+				new LabelBuilder().setLabel("Extra Turn-Ins")
+					.setUserSelectMenuComponent(
+						new UserSelectMenuBuilder().setCustomId(labelIdBountyHunters)
+							.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+							.setMaxValues(maxHunters)
+							.setRequired(false)
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
+
+		const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (bounty?.state !== "open") {
+			modalSubmission.reply({ content: "Your selected bounty no longer appears to be open.", flags: MessageFlags.Ephemeral });
 			return;
 		}
 
 		// disallow completion within 5 minutes of creating bounty
 		if (runMode === "production" && new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {
-			interaction.reply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can ${commandMention("bounty add-completers")} so you won't forget instead.`, flags: MessageFlags.Ephemeral });
+			modalSubmission.reply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can ${commandMention("bounty record-turn-ins")} so you won't forget instead.`, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
+		// Early-out if no completers
 		const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
-		const hunterCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
-		for (const optionKey of ["first-bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
-			const guildMember = interaction.options.getMember(optionKey);
-			if (guildMember) {
-				if (guildMember?.id !== interaction.user.id && !hunterCollection.has(guildMember.id)) {
-					hunterCollection.set(guildMember.id, guildMember);
-				}
-			}
-		}
-
+		const memberCollection = await modalSubmission.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
 		const validatedHunters = new Map();
-		for (const [memberId, member] of hunterCollection) {
+		for (const [memberId, member] of memberCollection) {
 			if (runMode !== "production" || !member.user.bot) {
-				const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
+				const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
 				if (!hunter.isBanned) {
 					validatedHunters.set(memberId, hunter);
 				}
 			}
 		}
 
+		const extraTurnIns = modalSubmission.fields.getSelectedMembers(labelIdBountyHunters);
+		if (extraTurnIns !== null) {
+			for (const [memberId, member] of extraTurnIns) {
+				if (runMode !== "production" || !(member.user.bot || validatedHunters.has(memberId))) {
+					const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
+					if (!hunter.isBanned) {
+						validatedHunters.set(memberId, hunter);
+					}
+				}
+			}
+		}
 		if (validatedHunters.size < 1) {
-			interaction.reply({ content: `No bounty hunters have turn-ins recorded for this bounty. If you'd like to close your bounty without distributng rewards, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+			modalSubmission.reply({ content: `There aren't any eligible pending turn-ins for this bounty. If you'd like to close your bounty without paying out rewards, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
 			return;
 		}
 
-		await interaction.deferReply();
+		await modalSubmission.deferReply();
 
 		const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 
-		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
+		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
 
 		const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 		const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, origin.hunter, validatedHunters, season, origin.company);
 		const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", origin.hunter, season);
-		companyReceipt.guildName = interaction.guild.name;
-		hunterMap = await reloadHunterMapSubset(hunterMap, [...validatedHunters.keys(), origin.hunter.userId]);
+		companyReceipt.guildName = modalSubmission.guild.name;
+		hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
 		const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 		if (previousCompanyLevel < currentCompanyLevel) {
 			companyReceipt.levelUp = currentCompanyLevel;
 		}
-		const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+		const descendingRanks = await logicLayer.ranks.findAllRanks(origin.company.id);
 		const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await interaction.guild.roles.fetch());
-		syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
+		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
+		syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
 		consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
-		const content = rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties);
+		const rewardMessageContent = rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties);
 
 		const acknowledgeOptions = { content: `${userMention(bounty.userId)}'s bounty, ` };
 		if (goalProgress.goalCompleted) {
@@ -73,70 +109,33 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		}
 
 		if (origin.company.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
+			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
+			modalSubmission.editReply(acknowledgeOptions);
+			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
 			bountyBoard.threads.fetch(bounty.postingId).then(async thread => {
 				await unarchiveAndUnlockThread(thread, "bounty complete");
 				thread.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-				thread.send({ content, flags: MessageFlags.SuppressNotifications });
+				thread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
 				return thread.fetchStarterMessage();
 			}).then(async posting => {
 				posting.edit({
-					embeds: [bountyEmbed(bounty, interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(interaction.guild.scheduledEvents), goalProgress)],
+					embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
 					components: []
 				}).then(() => {
 					posting.channel.setArchived(true, "bounty completed");
 				});
 			});
-			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
-			interaction.editReply(acknowledgeOptions);
 		} else {
 			acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
-			interaction.editReply(acknowledgeOptions).then(message => {
-				sendRewardMessage(message, content, `${bounty.title} Rewards`);
+			modalSubmission.editReply(acknowledgeOptions).then(message => {
+				sendRewardMessage(message, rewardMessageContent, `${bounty.title} Rewards`);
 			})
 		}
 
 		if (origin.company.scoreboardIsSeasonal) {
-			refreshReferenceChannelScoreboardSeasonal(origin.company, interaction.guild, participationMap, descendingRanks, goalProgress);
+			refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
 		} else {
-			refreshReferenceChannelScoreboardOverall(origin.company, interaction.guild, hunterMap, goalProgress);
+			refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
 		}
-	}
-).setOptions(
-	{
-		type: "Integer",
-		name: "bounty-slot",
-		description: "The slot number of your bounty",
-		required: true
-	},
-	{
-		type: "User",
-		name: "first-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "second-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "third-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fourth-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fifth-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
-		required: false
 	}
 );

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -17,7 +17,6 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to edit...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/bounty/post.js
+++ b/source/frontend/commands/bounty/post.js
@@ -35,7 +35,6 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("XP awarded depends on slot used...")
-						.setMaxValues(1)
 						.setOptions(slotOptions)
 				)
 			],

--- a/source/frontend/commands/bounty/record-turn-ins.js
+++ b/source/frontend/commands/bounty/record-turn-ins.js
@@ -32,7 +32,7 @@ module.exports = new SubcommandWrapper("record-turn-ins", "Record turn-ins of on
 					)
 			);
 		await interaction.showModal(modal);
-		const modalSubmission = await interaction.awaitModalSubmit({ filter: interaction => interaction.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
 			.catch(butIgnoreInteractionCollectorErrors);
 		if (!modalSubmission) {
 			return;

--- a/source/frontend/commands/bounty/revoke-turn-ins.js
+++ b/source/frontend/commands/bounty/revoke-turn-ins.js
@@ -32,7 +32,7 @@ module.exports = new SubcommandWrapper("revoke-turn-ins", "Revoke the turn-ins o
 					)
 			);
 		await interaction.showModal(modal);
-		const modalSubmission = await interaction.awaitModalSubmit({ filter: interaction => interaction.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
 			.catch(butIgnoreInteractionCollectorErrors);
 		if (!modalSubmission) {
 			return;

--- a/source/frontend/commands/bounty/showcase.js
+++ b/source/frontend/commands/bounty/showcase.js
@@ -38,7 +38,7 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for one of yo
 					)
 			);
 		await interaction.showModal(modal);
-		const modalSubmission = await interaction.awaitModalSubmit({ filter: interaction => interaction.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
 			.catch(butIgnoreInteractionCollectorErrors);
 		if (!modalSubmission) {
 			return;

--- a/source/frontend/commands/bounty/swap.js
+++ b/source/frontend/commands/bounty/swap.js
@@ -1,98 +1,96 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, bold } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, bold, ModalBuilder, LabelBuilder, TextDisplayBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty, Hunter } = require("../../../database/models");
-const { emojiFromNumber, selectOptionsFromBounties, refreshBountyThreadStarterMessage, addLogMessageToBountyThread, addCompanyAnnouncementPrefix, disabledSelectRow } = require("../../shared");
+const { emojiFromNumber, refreshBountyThreadStarterMessage, addLogMessageToBountyThread, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { timeConversion } = require("../../../shared");
+const { SelectMenuLimits } = require("@sapphire/discord.js-utilities");
 
 module.exports = new SubcommandWrapper("swap", "Move one of your bounties to another slot to change its reward",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id).then(openBounties => {
-			if (openBounties.length < 1) {
-				interaction.reply({ content: "You don't seem to have any open bounties at the moment.", flags: MessageFlags.Ephemeral });
-				return;
+		const startingPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+		const bountySlotCount = Hunter.getBountySlotCount(startingPosterLevel, origin.company.maxSimBounties);
+		if (bountySlotCount < 2) {
+			interaction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const openBounties = await logicLayer.bounties.mapOpenBountiesBySlotNumber(origin.user.id, origin.company.id);
+		if (openBounties.size < 1) {
+			interaction.reply({ content: "You don't seem to have any open bounties at the moment.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const slotOptions = [];
+		for (let i = 0; i < bountySlotCount; i++) {
+			const slotNumber = i + 1;
+			const matchingBounty = openBounties.get(slotNumber);
+			const option = { emoji: emojiFromNumber(slotNumber), label: `Slot ${slotNumber} (Base Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, slotNumber, 0)} XP)`, value: slotNumber.toString() };
+			if (matchingBounty) {
+				option.description = truncateTextToLength(`Swap With: ${matchingBounty.title}`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption);
 			}
+			slotOptions.push(option);
+		}
 
-			interaction.reply({
-				content: "Swapping a bounty to another slot will change the XP reward for that bounty.",
-				components: [
-					new ActionRowBuilder().addComponents(
-						new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}bounty`)
-							.setPlaceholder("Select a bounty to swap...")
-							.setMaxValues(1)
-							.setOptions(selectOptionsFromBounties(openBounties))
+		const labelIdBountyId = "bounty-id";
+		const labelIdSlot = "slot";
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Swap Bounty Rewards")
+			.addTextDisplayComponents(new TextDisplayBuilder().setContent("Swapping a bounty to another slot will change the XP reward for that bounty."))
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBountiesWithBaseRewardAsDescription(openBounties, startingPosterLevel))
+					),
+				new LabelBuilder().setLabel("Bounty Slot")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdSlot)
+							.setPlaceholder("Select a bounty slot...")
+							.setOptions(slotOptions)
 					)
-				],
-				flags: MessageFlags.Ephemeral,
-				withResponse: true
-			}).then(response => {
-				const collector = response.resource.message.createMessageComponentCollector({ max: 2 });
-				let previousBounty;
-				collector.on("collect", async (collectedInteraction) => {
-					if (collectedInteraction.customId.endsWith("bounty")) {
-						previousBounty = openBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
-						const startingPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-						const bountySlotCount = Hunter.getBountySlotCount(startingPosterLevel, origin.company.maxSimBounties);
-						if (bountySlotCount < 2) {
-							collectedInteraction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: MessageFlags.Ephemeral });
-							return;
-						}
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
 
-						const existingBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guildId);
-						const slotOptions = [];
-						for (let i = 1; i <= bountySlotCount; i++) {
-							if (i != previousBounty.slotNumber) {
-								const existingBounty = existingBounties.find(bounty => bounty.slotNumber == i);
-								slotOptions.push(
-									{
-										emoji: emojiFromNumber(i),
-										label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-										description: `XP Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, i, existingBounty?.showcaseCount ?? 0)}`,
-										value: i.toString()
-									}
-								)
-							}
-						}
+		let sourceBounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (sourceBounty?.state !== "open") {
+			modalSubmission.reply({ content: "The selected bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-						collectedInteraction.update({
-							content: "If there is a bounty in the destination slot, it'll be swapped to the old bounty's slot.",
-							components: [
-								disabledSelectRow(`Selected Bounty: ${previousBounty.title}`),
-								new ActionRowBuilder().addComponents(
-									new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
-										.setPlaceholder("Select a slot to swap the bounty to...")
-										.setMaxValues(1)
-										.setOptions(slotOptions)
-								)
-							],
-							flags: MessageFlags.Ephemeral
-						})
-					} else {
-						await previousBounty.reload();
-						if (previousBounty.state !== "open") {
-							collectedInteraction.update({ content: "The selected bounty appears to already have been completed.", components: [] });
-						} else {
-							const hunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-							const sourceSlot = previousBounty.slotNumber;
-							const destinationSlot = parseInt(collectedInteraction.values[0]);
-							let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id });
+		const destinationSlot = Number(modalSubmission.fields.getStringSelectValues(labelIdSlot)[0]);
+		if (sourceBounty.slotNumber === destinationSlot) {
+			modalSubmission.reply({ content: `${bold(sourceBounty.title)} is already in slot ${destinationSlot}.`, flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-							previousBounty = await previousBounty.update({ slotNumber: destinationSlot });
+		await origin.company.reload();
+		const currentPosterLevel = (await origin.hunter.reload()).getLevel(origin.company.xpCoefficient);
+		if (destinationSlot > Hunter.getBountySlotCount(currentPosterLevel, origin.company.maxSimBounties)) {
+			modalSubmission.reply({ content: "You no longer have the bounty slot you are trying to swap into.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-              refreshBountyThreadStarterMessage(interaction.guild, origin.company, previousBounty, await previousBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, hunterLevel, await logicLayer.bounties.getHunterIdSet(previousBounty.id));
-							addLogMessageToBountyThread(interaction.guild, origin.company, previousBounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${Bounty.calculateCompleterReward(hunterLevel, destinationSlot, previousBounty.showcaseCount)} XP.`);
+		const sourceSlot = sourceBounty.slotNumber;
+		let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
+		const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, sourceBounty.showcaseCount);
 
-							if (destinationBounty?.state === "open") {
-								destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-								refreshBountyThreadStarterMessage(interaction.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, hunterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-								addLogMessageToBountyThread(interaction.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(hunterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
-							}
+		sourceBounty = await sourceBounty.update({ slotNumber: destinationSlot });
+		refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, sourceBounty, await sourceBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(sourceBounty.id));
+		addLogMessageToBountyThread(modalSubmission.guild, origin.company, sourceBounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`);
 
-							interaction.channel.send(addCompanyAnnouncementPrefix(origin.company, { content: `${interaction.member}'s bounty, ${bold(previousBounty.title)} is now worth ${Bounty.calculateCompleterReward(hunterLevel, destinationSlot, previousBounty.showcaseCount)} XP.` }));
-							interaction.deleteReply();
-						}
-					}
-				})
-			})
-		})
+		if (destinationBounty) {
+			destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
+			refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
+			addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+		}
+
+		modalSubmission.reply(addCompanyAnnouncementPrefix(origin.company, { content: `${modalSubmission.member}'s bounty, ${bold(sourceBounty.title)} is now worth ${destinationRewardValue} XP.` }));
 	}
 );

--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -5,48 +5,49 @@ const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("take-down", "Take down one of your bounties without awarding XP (forfeit posting XP)",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id).then(openBounties => {
-			interaction.reply({
-				content: `If you'd like to change the title, description, image, or time of your bounty, you can use ${commandMention("bounty edit")} instead.`,
-				components: [
-					new ActionRowBuilder().addComponents(
-						new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
-							.setPlaceholder("Select a bounty to take down...")
-							.setMaxValues(1)
-							.setOptions(selectOptionsFromBounties(openBounties))
-					)
-				],
-				flags: MessageFlags.Ephemeral,
-				withResponse: true
-			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
-				const [bountyId] = collectedInteraction.values;
-				const bounty = await logicLayer.bounties.findBounty(bountyId);
-				bounty.state = "deleted";
-				bounty.save();
-				logicLayer.bounties.deleteBountyCompletions(bountyId);
-				if (origin.company.bountyBoardId) {
-					const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
-					const postingThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
-					if (postingThread) {
-						postingThread.delete("Bounty taken down by poster");
-					}
-				}
-				bounty.destroy();
+		const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
+		if (openBounties.length < 1) {
+			interaction.reply({ content: "You don't have any open bounties to take down.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-				origin.hunter.decrement("xp");
-				const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-				await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
-				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await collectedInteraction.guild.roles.fetch());
-				syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-
-				collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
-			}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
-				// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
-				if (interaction.channel) {
-					interaction.deleteReply();
+		interaction.reply({
+			content: `If you'd like to change the title, description, image, or time of your bounty, you can use ${commandMention("bounty edit")} instead.`,
+			components: [
+				new ActionRowBuilder().addComponents(
+					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+						.setPlaceholder("Select a bounty to take down...")
+						.setOptions(selectOptionsFromBounties(openBounties))
+				)
+			],
+			flags: MessageFlags.Ephemeral,
+			withResponse: true
+		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
+			const [bountyId] = collectedInteraction.values;
+			const bounty = await logicLayer.bounties.findBounty(bountyId);
+			logicLayer.bounties.deleteBountyCompletions(bountyId);
+			if (origin.company.bountyBoardId && bounty.postingId) {
+				const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
+				const postingThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
+				if (postingThread) {
+					postingThread.delete("Bounty taken down by poster");
 				}
-			})
+			}
+			bounty.destroy();
+
+			origin.hunter.decrement("xp");
+			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
+			await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
+			const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+			const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await collectedInteraction.guild.roles.fetch());
+			syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
+
+			collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
+		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
+			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
+			if (interaction.channel) {
+				interaction.deleteReply();
+			}
 		})
 	}
 );

--- a/source/frontend/commands/evergreen/complete.js
+++ b/source/frontend/commands/evergreen/complete.js
@@ -1,144 +1,135 @@
-const { MessageFlags, ActionRowBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder } = require("discord.js");
+const { MessageFlags, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty, Company } = require("../../../database/models");
-const { bountyEmbed, goalCompletionEmbed, disabledSelectRow, selectOptionsFromBounties, sendRewardMessage, syncRankRoles, refreshEvergreenBountiesThread, commandMention, reloadHunterMapSubset, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require("../../shared");
-const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../../constants");
+const { bountyEmbed, goalCompletionEmbed, selectOptionsFromBounties, sendRewardMessage, syncRankRoles, refreshEvergreenBountiesThread, commandMention, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("complete", "Distribute rewards for turn-ins of an evergreen bounty to up to 5 bounty hunters",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		const evergreenBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
+		const evergreenBounties = await logicLayer.bounties.findEvergreenBounties(origin.company.id);
 		if (evergreenBounties.length < 1) {
 			interaction.reply({ content: `This server doesn't currently have any evergreen bounties. Post one with ${commandMention("evergreen post")}?`, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
-		interaction.reply({
-			content: "Select an evergreen bounty and some bounty hunters to distribute its rewards to.",
-			components: [
-				new ActionRowBuilder().addComponents(
-					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}bounty`)
-						.setPlaceholder("Select bounty...")
-						.setOptions(selectOptionsFromBounties(evergreenBounties))
-				),
-				disabledSelectRow("Select bounty hunters...")
-			],
-			flags: MessageFlags.Ephemeral,
+		const labelIdBountyId = "bounty-id";
+		const labelIdBountyHunters = "bounty-hunters";
+		const maxHunters = 10;
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Payout an Evergreen Bounty")
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select an evergreen bounty...")
+							.setOptions(selectOptionsFromBounties(evergreenBounties))
+					),
+				new LabelBuilder().setLabel("Bounty Hunters")
+					.setUserSelectMenuComponent(
+						new UserSelectMenuBuilder().setCustomId(labelIdBountyHunters)
+							.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+							.setMaxValues(maxHunters)
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
+
+		const bountyId = modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0];
+		const bounty = await logicLayer.bounties.findBounty(bountyId);
+		const validatedHunters = new Map();
+		for (const [memberId, guildMember] of modalSubmission.fields.getSelectedMembers(labelIdBountyHunters)) {
+			const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
+			if (runMode !== "production" || (!guildMember.user.bot && !hunter.isBanned)) {
+				validatedHunters.set(memberId, hunter);
+			}
+		}
+
+		if (validatedHunters.size < 1) {
+			modalSubmission.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: MessageFlags.Ephemeral })
+			return;
+		}
+
+		const season = await logicLayer.seasons.incrementSeasonStat(origin.company.id, "bountiesCompleted");
+
+		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+		const companyReceipt = { guildName: modalSubmission.guild.name };
+		const hunterReceipts = new Map();
+
+		const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+		// Evergreen bounties are not eligible for showcase bonuses
+		const bountyBaseValue = Bounty.calculateCompleterReward(previousCompanyLevel, bounty.slotNumber, 0);
+		const bountyValue = Math.floor(bountyBaseValue * origin.company.xpFestivalMultiplier);
+		await logicLayer.bounties.bulkCreateCompletions(bountyId, origin.company.id, [...validatedHunters.keys()], bountyValue);
+
+		const xpMultiplierString = origin.company.festivalMultiplierString("xp");
+		const goalProgress = {
+			totalGP: 0,
+			goalCompleted: false,
+			currentGP: 0,
+			requiredGP: 0
+		};
+		const finalContributorIds = new Set(validatedHunters.keys());
+		for (const userId of validatedHunters.keys()) {
+			const hunterReceipt = { xp: bountyBaseValue, xpMultiplier: xpMultiplierString };
+			let hunter = await logicLayer.hunters.findOneHunter(userId, origin.company.id);
+			const previousHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
+			hunter = await hunter.increment({ othersFinished: 1, xp: bountyValue }).then(hunter => hunter.reload());
+			const currentHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
+			if (currentHunterLevel > previousHunterLevel) {
+				hunterReceipt.levelUp = { achievedLevel: currentHunterLevel, previousLevel: previousHunterLevel };
+			}
+			hunterReceipts.set(userId, hunterReceipt);
+			logicLayer.seasons.changeSeasonXP(userId, origin.company.id, season.id, bountyValue);
+			const { goalProgress: { gpContributed, goalCompleted, contributorIds, currentGP, requiredGP } } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunter, season);
+			goalProgress.totalGP += gpContributed;
+			goalProgress.goalCompleted ||= goalCompleted;
+			goalProgress.currentGP = currentGP;
+			goalProgress.requiredGP = requiredGP;
+			contributorIds.forEach(id => finalContributorIds.add(id));
+		}
+
+		hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+		const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+		if (previousCompanyLevel < currentCompanyLevel) {
+			companyReceipt.levelUp = currentCompanyLevel;
+		}
+		const announcementPayload = {
+			embeds: [bountyEmbed(bounty, modalSubmission.guild.members.me, currentCompanyLevel, false, origin.company, finalContributorIds, null, goalProgress)],
 			withResponse: true
-		}).then(response => response.resource.message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms") })).then(collector => {
-			let bounty;
-			collector.on("collect", async collectedInteraction => {
-				const [_, stepId] = collectedInteraction.customId.split(SAFE_DELIMITER);
-				switch (stepId) {
-					case "bounty":
-						bounty = evergreenBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
-						collectedInteraction.update({
-							components: [
-								disabledSelectRow(`Selected Bounty: ${bounty.title}`),
-								new ActionRowBuilder().addComponents(
-									new UserSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}hunters`)
-										.setPlaceholder("Select bounty hunters...")
-										.setMaxValues(5)
-								)
-							]
-						});
-						break;
-					case "hunters":
-						const validatedHunters = new Map();
-						for (const [memberId, guildMember] of collectedInteraction.members) {
-							const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, guildMember.guild.id);
-							if (runMode !== "production" || (!guildMember.user.bot && !hunter.isBanned)) {
-								validatedHunters.set(memberId, hunter);
-							}
-						}
-
-						if (validatedHunters.size < 1) {
-							collectedInteraction.reply({ content: "No valid bounty hunters received. Bots cannot be credited for bounty completion.", flags: MessageFlags.Ephemeral })
-							return;
-						}
-
-						const season = await logicLayer.seasons.incrementSeasonStat(collectedInteraction.guild.id, "bountiesCompleted");
-
-						let hunterMap = await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id);
-						const companyReceipt = { guildName: collectedInteraction.guild.name };
-						const hunterReceipts = new Map();
-
-						const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-						// Evergreen bounties are not eligible for showcase bonuses
-						const bountyBaseValue = Bounty.calculateCompleterReward(previousCompanyLevel, bounty.slotNumber, 0);
-						const bountyValue = Math.floor(bountyBaseValue * origin.company.xpFestivalMultiplier);
-						await logicLayer.bounties.bulkCreateCompletions(bounty.id, collectedInteraction.guild.id, [...validatedHunters.keys()], bountyValue);
-
-						const xpMultiplierString = origin.company.festivalMultiplierString("xp");
-						const goalProgress = {
-							totalGP: 0,
-							goalCompleted: false,
-							currentGP: 0,
-							requiredGP: 0
-						};
-						const finalContributorIds = new Set(validatedHunters.keys());
-						for (const userId of validatedHunters.keys()) {
-							const hunterReceipt = { xp: bountyBaseValue, xpMultiplier: xpMultiplierString };
-							let hunter = await logicLayer.hunters.findOneHunter(userId, collectedInteraction.guild.id);
-							const previousHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
-							hunter = await hunter.increment({ othersFinished: 1, xp: bountyValue }).then(hunter => hunter.reload());
-							const currentHunterLevel = hunter.getLevel(origin.company.xpCoefficient);
-							if (currentHunterLevel > previousHunterLevel) {
-								hunterReceipt.levelUp = { achievedLevel: currentHunterLevel, previousLevel: previousHunterLevel };
-							}
-							hunterReceipts.set(userId, hunterReceipt);
-							logicLayer.seasons.changeSeasonXP(userId, collectedInteraction.guildId, season.id, bountyValue);
-							const { goalProgress: { gpContributed, goalCompleted, contributorIds, currentGP, requiredGP } } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunter, season);
-							goalProgress.totalGP += gpContributed;
-							goalProgress.goalCompleted ||= goalCompleted;
-							goalProgress.currentGP = currentGP;
-							goalProgress.requiredGP = requiredGP;
-							contributorIds.forEach(id => finalContributorIds.add(id));
-						}
-
-						hunterMap = await reloadHunterMapSubset(hunterMap, Array.from(finalContributorIds));
-						const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-						if (previousCompanyLevel < currentCompanyLevel) {
-							companyReceipt.levelUp = currentCompanyLevel;
-						}
-						const announcementPayload = {
-							embeds: [bountyEmbed(bounty, collectedInteraction.guild.members.me, currentCompanyLevel, false, origin.company, finalContributorIds, goalProgress)],
-							withResponse: true
-						};
-						if (goalProgress.totalGP > 0) {
-							companyReceipt.gp = goalProgress.totalGP;
-							companyReceipt.gpMultiplier = origin.company.festivalMultiplierString("gp");
-						}
-						if (goalProgress.goalCompleted) {
-							announcementPayload.embeds.push(goalCompletionEmbed([...finalContributorIds.keys()]));
-						}
-						await collectedInteraction.update({ components: [] });
-						interaction.deleteReply();
-						const message = await collectedInteraction.channel.send(announcementPayload);
-						const descendingRanks = await logicLayer.ranks.findAllRanks(collectedInteraction.guild.id);
-						const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-						const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await collectedInteraction.guild.roles.fetch());
-						syncRankRoles(seasonalHunterReceipts, descendingRanks, collectedInteraction.guild.members);
-						consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
-						sendRewardMessage(message, rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties), `${bounty.title} Rewards`);
-						if (origin.company.scoreboardIsSeasonal) {
-							refreshReferenceChannelScoreboardSeasonal(origin.company, collectedInteraction.guild, participationMap, descendingRanks, goalProgress);
-						} else {
-							refreshReferenceChannelScoreboardOverall(origin.company, collectedInteraction.guild, hunterMap, goalProgress);
-						}
-						if (origin.company.bountyBoardId) {
-							const hunterIdMap = {};
-							for (const bounty of evergreenBounties) {
-								hunterIdMap[bounty.id] = await logicLayer.bounties.getHunterIdSet(bounty.id);
-							}
-							const bountyBoard = await collectedInteraction.guild.channels.fetch(origin.company.bountyBoardId);
-							refreshEvergreenBountiesThread(bountyBoard, evergreenBounties, origin.company, currentCompanyLevel, collectedInteraction.guild.members.me, hunterIdMap);
-						} else if (!collectedInteraction.member.manageable) {
-							collectedInteraction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: MessageFlags.Ephemeral });
-						}
-						break;
-				}
-			})
-		})
+		};
+		if (goalProgress.totalGP > 0) {
+			companyReceipt.gp = goalProgress.totalGP;
+			companyReceipt.gpMultiplier = origin.company.festivalMultiplierString("gp");
+		}
+		if (goalProgress.goalCompleted) {
+			announcementPayload.embeds.push(goalCompletionEmbed([...finalContributorIds.keys()]));
+		}
+		const response = await modalSubmission.reply(announcementPayload);
+		const descendingRanks = await logicLayer.ranks.findAllRanks(origin.company.id);
+		const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
+		syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
+		consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
+		sendRewardMessage(response.resource.message, rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties), `${bounty.title} Rewards`);
+		if (origin.company.scoreboardIsSeasonal) {
+			refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
+		} else {
+			refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
+		}
+		if (origin.company.bountyBoardId) {
+			const hunterIdMap = {};
+			for (const bounty of evergreenBounties) {
+				hunterIdMap[bounty.id] = await logicLayer.bounties.getHunterIdSet(bounty.id);
+			}
+			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
+			refreshEvergreenBountiesThread(bountyBoard, evergreenBounties, origin.company, currentCompanyLevel, modalSubmission.guild.members.me, hunterIdMap);
+		} else if (!modalSubmission.member.manageable) {
+			modalSubmission.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: MessageFlags.Ephemeral });
+		}
 	}
 );

--- a/source/frontend/commands/evergreen/edit.js
+++ b/source/frontend/commands/evergreen/edit.js
@@ -18,7 +18,6 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to edit...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/evergreen/post.js
+++ b/source/frontend/commands/evergreen/post.js
@@ -1,4 +1,4 @@
-const { ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags, LabelBuilder } = require("discord.js");
+const { ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags, LabelBuilder, FileUploadBuilder } = require("discord.js");
 const { EmbedLimits } = require("@sapphire/discord.js-utilities");
 const { SubcommandWrapper } = require("../../classes");
 const { SKIP_INTERACTION_HANDLING, MAX_EVERGREEN_SLOTS } = require("../../../constants");
@@ -22,37 +22,36 @@ module.exports = new SubcommandWrapper("post", `Post an evergreen bounty, limit 
 			return;
 		}
 
-		const titleId = "title";
-		const descriptionId = "description";
-		const imageId = "image";
+		const labelIdTitle = "title";
+		const labelIdDescription = "description";
+		const labelIdImage = "image";
 		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 			.setTitle("New Evergreen Bounty")
 			.addLabelComponents(
 				new LabelBuilder().setLabel("Title")
 					.setTextInputComponent(
-						new TextInputBuilder().setCustomId(titleId)
+						new TextInputBuilder().setCustomId(labelIdTitle)
 							.setStyle(TextInputStyle.Short)
 							.setPlaceholder("Discord markdown allowed...")
 							.setMaxLength(EmbedLimits.MaximumTitleLength)
 					),
 				new LabelBuilder().setLabel("Description")
 					.setTextInputComponent(
-						new TextInputBuilder().setCustomId(descriptionId)
+						new TextInputBuilder().setCustomId(labelIdDescription)
 							.setStyle(TextInputStyle.Paragraph)
 							.setPlaceholder("Bounties with clear instructions are easier to complete...")
 					),
 				new LabelBuilder().setLabel("Image")
-					.setTextInputComponent(
-						new TextInputBuilder().setCustomId(imageId)
+					.setFileUploadComponent(
+						new FileUploadBuilder().setCustomId(labelIdImage)
 							.setRequired(false)
-							.setStyle(TextInputStyle.Short)
 					)
 			);
 		interaction.showModal(modal);
 
 		return interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") }).then(async interaction => {
-			const title = interaction.fields.getTextInputValue(titleId);
-			const description = interaction.fields.getTextInputValue(descriptionId);
+			const title = interaction.fields.getTextInputValue(labelIdTitle);
+			const description = interaction.fields.getTextInputValue(labelIdDescription);
 
 			const autoModInfraction = await textsHaveAutoModInfraction(interaction.channel, interaction.member, [title, description], "evergreen post");
 			if (autoModInfraction == null) {
@@ -74,7 +73,7 @@ module.exports = new SubcommandWrapper("post", `Post an evergreen bounty, limit 
 				rawBounty.description = description;
 			}
 
-			const imageFileCollection = interaction.fields.getUploadedFiles(imageId);
+			const imageFileCollection = interaction.fields.getUploadedFiles(labelIdImage);
 			if (imageFileCollection) {
 				const firstAttachment = imageFileCollection.first();
 				if (firstAttachment) {

--- a/source/frontend/commands/evergreen/showcase.js
+++ b/source/frontend/commands/evergreen/showcase.js
@@ -1,8 +1,9 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, PermissionFlagsBits } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, PermissionFlagsBits, ModalBuilder, TextDisplayBuilder, LabelBuilder, TextInputBuilder, TextInputStyle } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { selectOptionsFromBounties, bountyEmbed, butIgnoreInteractionCollectorErrors } = require("../../shared");
 const { Company } = require("../../../database/models");
+const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("showcase", "Show the embed for an evergreen bounty",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -12,50 +13,50 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for an evergr
 			return;
 		}
 
-		interaction.reply({
-			content: "Unlike normal bounty showcases, an evergreen showcase does not increase the reward of the showcased bounty and is not rate-limited.",
-			components: [
-				new ActionRowBuilder().addComponents(
-					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
-						.setPlaceholder("Select a bounty to showcase...")
-						.setMaxValues(1)
-						.setOptions(selectOptionsFromBounties(existingBounties))
-				)
-			],
-			flags: MessageFlags.Ephemeral,
-			withResponse: true
-		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(collectedInteraction => {
-			return existingBounties.find(bounty => bounty.id === collectedInteraction.values[0]).reload().then(async bounty => {
-				if (bounty?.state !== "open") {
-					return collectedInteraction;
-				}
+		const labelIdBountyId = "bounty-id";
+		const labelIdCustomMessage = "custom-message";
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Showcase an Evergreen Bounty")
+			.addTextDisplayComponents(
+				new TextDisplayBuilder().setContent("Unlike normal bounty showcases, an evergreen showcase does not increase the reward of the showcased bounty and is not rate-limited.")
+			)
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBounties(existingBounties))
+					),
+				new LabelBuilder().setLabel("Custom Message")
+					.setTextInputComponent(
+						new TextInputBuilder().setCustomId(labelIdCustomMessage)
+							.setStyle(TextInputStyle.Paragraph)
+							.setPlaceholder("Add a custom message to the showcase...")
+							.setRequired(false)
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
 
-				const currentCompanyLevel = Company.getLevel(origin.company.getXP(await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id)));
-				const payload = { embeds: [bountyEmbed(bounty, interaction.guild, currentCompanyLevel, false, origin.company, new Set())] };
-				const extraText = interaction.options.get("extra-text");
-				if (extraText) {
-					payload.content = extraText.value;
-				}
-				if (!interaction.memberPermissions?.has(PermissionFlagsBits.MentionEveryone)) {
-					payload.allowedMentions = { parse: [] };
-				}
-				collectedInteraction.channel.send(payload);
-				return collectedInteraction;
-			});
-		}).then(interactionToAcknowledge => {
-			return interactionToAcknowledge.update({ components: [] });
-		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
-			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
-			if (interaction.channel) {
-				interaction.deleteReply();
-			}
-		})
-	}
-).setOptions(
-	{
-		type: "String",
-		name: "extra-text",
-		description: "Text to show in the showcase message",
-		required: false
+		const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (bounty?.state !== "open") {
+			modalSubmission.reply({ content: "The bounty you selected appears to have been taken-down before the showcase could resolve.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const currentCompanyLevel = Company.getLevel(origin.company.getXP(await logicLayer.hunters.getCompanyHunterMap(origin.company.id)));
+		const payload = { embeds: [bountyEmbed(bounty, modalSubmission.guild.members.me, currentCompanyLevel, false, origin.company, new Set())] };
+		const extraText = modalSubmission.fields.getTextInputValue(labelIdCustomMessage);
+		if (extraText) {
+			payload.content = extraText;
+		}
+		if (!modalSubmission.memberPermissions?.has(PermissionFlagsBits.MentionEveryone)) {
+			payload.allowedMentions = { parse: [] };
+		}
+		modalSubmission.reply(payload);
 	}
 );

--- a/source/frontend/commands/evergreen/swap.js
+++ b/source/frontend/commands/evergreen/swap.js
@@ -1,99 +1,82 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, ModalBuilder, LabelBuilder, TextDisplayBuilder, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { emojiFromNumber, selectOptionsFromBounties, disabledSelectRow, refreshEvergreenBountiesThread } = require("../../shared");
-const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require("../../../constants");
+const { selectOptionsFromBounties, refreshEvergreenBountiesThread, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { Bounty, Company } = require("../../../database/models");
+const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("swap", "Swap the rewards of two evergreen bounties",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		const existingBounties = await logicLayer.bounties.findEvergreenBounties(interaction.guild.id);
+		const existingBounties = await logicLayer.bounties.findEvergreenBounties(origin.company.id);
 		if (existingBounties.length < 2) {
 			interaction.reply({ content: "There must be at least 2 evergreen bounties for this server to swap.", flags: MessageFlags.Ephemeral });
 			return;
 		}
 
-		interaction.reply({
-			content: "Swapping a bounty to another slot will change the XP reward for that bounty.",
-			components: [
-				new ActionRowBuilder().addComponents(
-					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}evergreen`)
-						.setPlaceholder("Select a bounty to swap...")
-						.setMaxValues(1)
-						.setOptions(selectOptionsFromBounties(existingBounties))
-				)
-			],
-			flags: MessageFlags.Ephemeral,
-			withResponse: true
-		}).then(response => {
-			const collector = response.resource.message.createMessageComponentCollector({ max: 2 });
-			collector.on("collect", async (collectedInteraction) => {
-				if (collectedInteraction.customId.endsWith("evergreen")) {
-					logicLayer.hunters.findOneHunter(interaction.user.id, interaction.guild.id).then(async hunter => {
-						await Promise.all(existingBounties.map(bounty => bounty.reload()));
-						const previousBounty = existingBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
-						const previousBountySlot = previousBounty.slotNumber;
-						const slotOptions = [];
-						for (const bounty of existingBounties) {
-							if (bounty.slotNumber != previousBountySlot) {
-								slotOptions.push(
-									{
-										emoji: emojiFromNumber(bounty.slotNumber),
-										label: `Slot ${bounty.slotNumber}: ${bounty.title}`,
-										// Evergreen bounties are not eligible for showcase bonuses
-										description: `XP Reward: ${Bounty.calculateCompleterReward(hunter.getLevel(origin.company.xpCoefficient), bounty.slotNumber, 0)}`,
-										value: bounty.id
-									}
-								);
-							}
-						}
+		const labelIdSourceBountyId = "first-bounty-id";
+		const labelIdDestinationBountyId = "second-bounty-id";
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Swap Evergreen Bounty Rewards")
+			.addTextDisplayComponents(new TextDisplayBuilder().setContent("Swapping a bounty to another slot will change the XP reward for that bounty."))
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty 1")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdSourceBountyId)
+							.setPlaceholder("Select an evergreen bounty...")
+							.setOptions(selectOptionsFromBounties(existingBounties))
+					),
+				new LabelBuilder().setLabel("Bounty 2")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdDestinationBountyId)
+							.setPlaceholder("Select an evergreen bounty...")
+							.setOptions(selectOptionsFromBounties(existingBounties))
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
 
-						collectedInteraction.update({
-							components: [
-								disabledSelectRow(`Selected Bounty: ${previousBounty.title}`),
-								new ActionRowBuilder().addComponents(
-									new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}${SAFE_DELIMITER}${previousBounty.id}`)
-										.setPlaceholder("Select a bounty to swap with...")
-										.setMaxValues(1)
-										.setOptions(slotOptions)
-								)
-							],
-							flags: MessageFlags.Ephemeral
-						})
-					})
-				} else {
-					const sourceBountyId = collectedInteraction.customId.split(SAFE_DELIMITER)[1];
+		const [sourceBountyId] = modalSubmission.fields.getStringSelectValues(labelIdSourceBountyId);
+		const [destinationBountyId] = modalSubmission.fields.getStringSelectValues(labelIdDestinationBountyId);
+		if (sourceBountyId === destinationBountyId) {
+			modalSubmission.reply({ content: "It appears you've selected the same bounty twice.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-					const sourceBounty = existingBounties.find(bounty => bounty.id === sourceBountyId);
-					const sourceSlot = sourceBounty.slotNumber;
-					const destinationBounty = existingBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
-					const destinationSlot = destinationBounty.slotNumber;
-					sourceBounty.slotNumber = destinationSlot;
-					await sourceBounty.save();
+		const sourceBounty = await logicLayer.bounties.findBounty(sourceBountyId);
+		if (!sourceBounty) {
+			modalSubmission.reply({ content: "The first bounty you selected appears to have been taken down before the swap could be resolved.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+		const sourceSlot = sourceBounty.slotNumber;
 
-					destinationBounty.slotNumber = sourceSlot;
-					await destinationBounty.save();
+		const destinationBounty = await logicLayer.bounties.findBounty(destinationBountyId);
+		if (!sourceBounty) {
+			modalSubmission.reply({ content: "The second bounty you selected appears to have been taken down before the swap could be resolved.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+		const destinationSlot = destinationBounty.slotNumber;
 
-					const currentCompanyLevel = Company.getLevel(origin.company.getXP(await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id)));
-					if (origin.company.bountyBoardId) {
-						const hunterIdMap = {};
-						for (const bounty of existingBounties) {
-							hunterIdMap[bounty.id] = await logicLayer.bounties.getHunterIdSet(bounty.id);
-						}
-						collectedInteraction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
-							refreshEvergreenBountiesThread(bountyBoard, existingBounties, origin.company, currentCompanyLevel, interaction.guild.members.me, hunterIdMap);
-						})
-					} else if (!collectedInteraction.member.manageable) {
-						interaction.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: MessageFlags.Ephemeral });
-					}
+		await sourceBounty.update({ slotNumber: destinationSlot });
+		await destinationBounty.update({ slotNumber: sourceSlot });
 
-					// Evergreen bounties are not eligible for showcase bonuses
-					interaction.channel.send(`Some evergreen bounties have been swapped, **${sourceBounty.title}** is now worth ${Bounty.calculateCompleterReward(currentCompanyLevel, destinationSlot, 0)} XP and **${destinationBounty.title}** is now worth ${Bounty.calculateCompleterReward(currentCompanyLevel, sourceSlot, 0)} XP.`);
-				}
+		const currentCompanyLevel = Company.getLevel(origin.company.getXP(await logicLayer.hunters.getCompanyHunterMap(origin.company.id)));
+		// Evergreen bounties are not eligible for showcase bonuses
+		modalSubmission.reply(`Some evergreen bounties have been swapped, ${bold(sourceBounty.title)} is now worth ${Bounty.calculateCompleterReward(currentCompanyLevel, destinationSlot, 0)} XP and ${bold(destinationBounty.title)} is now worth ${Bounty.calculateCompleterReward(currentCompanyLevel, sourceSlot, 0)} XP.`);
+
+		if (origin.company.bountyBoardId) {
+			const hunterIdMap = {};
+			for (const bounty of existingBounties) {
+				hunterIdMap[bounty.id] = await logicLayer.bounties.getHunterIdSet(bounty.id);
+			}
+			modalSubmission.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
+				refreshEvergreenBountiesThread(bountyBoard, existingBounties, origin.company, currentCompanyLevel, modalSubmission.guild.members.me, hunterIdMap);
 			})
-
-			collector.on("end", () => {
-				interaction.deleteReply();
-			})
-		})
+		} else if (!modalSubmission.member.manageable) {
+			modalSubmission.followUp({ content: `Looks like your server doesn't have a bounty board channel. Make one with ${commandMention("create-default bounty-board-forum")}?`, flags: MessageFlags.Ephemeral });
+		}
 	}
 );

--- a/source/frontend/commands/evergreen/take-down.js
+++ b/source/frontend/commands/evergreen/take-down.js
@@ -13,7 +13,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to take down...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/moderation/take-down.js
+++ b/source/frontend/commands/moderation/take-down.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, userMention, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors } = require("../../shared");
@@ -18,7 +18,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}${poster.id}`)
 						.setPlaceholder("Select a bounty to take down...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],
@@ -29,14 +28,12 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 			const [bountyId] = collectedInteraction.values;
 			openBounties.find(bounty => bounty.id === bountyId).reload().then(async bounty => {
 				logicLayer.bounties.deleteBountyCompletions(bountyId);
-				bounty.state = "deleted";
-				bounty.save();
+				bounty.update({ state: "deleted" });
 				if (origin.company.bountyBoardId) {
 					const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
 					const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 					postingThread.delete("Bounty taken down by moderator");
 				}
-				bounty.destroy();
 
 				let poster;
 				if (posterId === origin.hunter.userId) {
@@ -50,7 +47,7 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await interaction.guild.roles.fetch());
 				syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-				collectedInteraction.reply({ content: `<@${posterId}>'s bounty **${bounty.title}** has been taken down by ${interaction.member}.` });
+				collectedInteraction.reply({ content: `${userMention(posterId)}'s bounty ${bold(bounty.title)} has been taken down by ${interaction.member}.` });
 			});
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
 			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply

--- a/source/frontend/commands/toast.js
+++ b/source/frontend/commands/toast.js
@@ -1,6 +1,6 @@
 const { PermissionFlagsBits, InteractionContextType, MessageFlags, userMention, unorderedList } = require('discord.js');
 const { CommandWrapper } = require('../classes');
-const { textsHaveAutoModInfraction, sentenceListEN, toastEmbed, secondingButtonRow, goalCompletionEmbed, sendRewardMessage, reloadHunterMapSubset, syncRankRoles, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require('../shared');
+const { textsHaveAutoModInfraction, sentenceListEN, toastEmbed, secondingButtonRow, goalCompletionEmbed, sendRewardMessage, syncRankRoles, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require('../shared');
 const { Company } = require('../../database/models');
 
 /** @type {typeof import("../../logic")} */
@@ -79,7 +79,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 			companyReceipt = results.companyReceipt;
 			goalProgress = results.goalProgress;
 
-			hunterMap = await reloadHunterMapSubset(hunterMap, Array.from(hunterReceipts.keys()));
+			hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
 			const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 			if (previousCompanyLevel < currentCompanyLevel) {
 				companyReceipt.levelUp = currentCompanyLevel;

--- a/source/frontend/context_menus/Raise_a_Toast.js
+++ b/source/frontend/context_menus/Raise_a_Toast.js
@@ -1,7 +1,7 @@
 const { InteractionContextType, PermissionFlagsBits, ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags, userMention, LabelBuilder } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { textsHaveAutoModInfraction, toastEmbed, secondingButtonRow, goalCompletionEmbed, sendRewardMessage, reloadHunterMapSubset, syncRankRoles, butIgnoreInteractionCollectorErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require('../shared');
+const { textsHaveAutoModInfraction, toastEmbed, secondingButtonRow, goalCompletionEmbed, sendRewardMessage, syncRankRoles, butIgnoreInteractionCollectorErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require('../shared');
 const { Company } = require('../../database/models');
 const { timeConversion } = require('../../shared');
 
@@ -61,7 +61,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				companyReceipt = results.companyReceipt;
 				goalProgress = results.goalProgress;
 
-				hunterMap = await reloadHunterMapSubset(hunterMap, Array.from(hunterReceipts.keys()));
+				hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
 				const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 				if (previousCompanyLevel < currentCompanyLevel) {
 					companyReceipt.levelUp = currentCompanyLevel;

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -2,8 +2,9 @@ const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, us
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, reloadHunterMapSubset, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, disabledSelectRow, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, butIgnoreUnknownChannelErrors } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
+const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -44,7 +45,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 							)
 					);
 				await interaction.showModal(modal);
-				const modalSubmission = await interaction.awaitModalSubmit({ filter: interaction => interaction.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
 					.catch(butIgnoreInteractionCollectorErrors);
 				if (!modalSubmission) {
 					return;
@@ -83,7 +84,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 							)
 					);
 				await interaction.showModal(modal);
-				const modalSubmission = await interaction.awaitModalSubmit({ filter: interaction => interaction.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
 					.catch(butIgnoreInteractionCollectorErrors);
 				if (!modalSubmission) {
 					return;
@@ -119,7 +120,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 							.setChannelSelectMenuComponent(
 								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
 									.setPlaceholder("Select a channel...")
-									.setChannelTypes(ChannelType.GuildText, ChannelType.PrivateThread, ChannelType.PublicThread)
+									.setChannelTypes(ChannelType.GuildText)
 							)
 					);
 				await interaction.showModal(modal);
@@ -167,80 +168,103 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				// Early-out if no completers
 				const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
 				const memberCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
 				const validatedHunters = new Map();
+				const pendingTurnInDisplayNames = [];
 				for (const [memberId, member] of memberCollection) {
 					if (runMode !== "production" || !member.user.bot) {
-						const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
+						const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
 						if (!hunter.isBanned) {
 							validatedHunters.set(memberId, hunter);
+							pendingTurnInDisplayNames.push(member.displayName);
 						}
 					}
 				}
 
-				if (validatedHunters.size < 1) {
-					interaction.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+				const labelIdChannel = "channel";
+				const labelIdBountyHunters = "bounty-hunters";
+				const maxHunters = 10;
+				const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					.setTitle("Mark your Bounty Complete!")
+					.addTextDisplayComponents(new TextDisplayBuilder().setContent(`Pending Turn-Ins: ${pendingTurnInDisplayNames.length > 0 ? sentenceListEN(pendingTurnInDisplayNames) : "None yet!"}`))
+					.addLabelComponents(
+						new LabelBuilder().setLabel("Channel")
+							.setChannelSelectMenuComponent(
+								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
+									.setPlaceholder("Select a channel...")
+									.setChannelTypes(ChannelType.GuildText)
+							),
+						new LabelBuilder().setLabel("Extra Turn-Ins")
+							.setUserSelectMenuComponent(
+								new UserSelectMenuBuilder().setCustomId(labelIdBountyHunters)
+									.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+									.setMaxValues(maxHunters)
+									.setRequired(false)
+							)
+					);
+				await interaction.showModal(modal);
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+					.catch(butIgnoreInteractionCollectorErrors);
+				if (!modalSubmission) {
 					return;
 				}
 
-				interaction.reply({
-					content: `Which channel should the bounty's completion be announced in?\n\nPending Turn-Ins: ${sentenceListEN(Array.from(validatedHunters.keys()).map(id => userMention(id)))}`,
-					components: [
-						new ActionRowBuilder().addComponents(
-							new ChannelSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
-								.setPlaceholder("Select channel...")
-								.setChannelTypes(ChannelType.GuildText)
-						)
-					],
-					flags: MessageFlags.Ephemeral,
-					withResponse: true
-				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
-					await collectedInteraction.deferReply({ flags: MessageFlags.SuppressNotifications });
-					const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
+				// Early-out if no completers
+				const extraTurnIns = modalSubmission.fields.getSelectedMembers(labelIdBountyHunters);
+				if (extraTurnIns !== null) {
+					for (const [memberId, member] of extraTurnIns) {
+						if (runMode !== "production" || !(member.user.bot || validatedHunters.has(memberId))) {
+							const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
+							if (!hunter.isBanned) {
+								validatedHunters.set(memberId, hunter);
+							}
+						}
+					}
+				}
+				if (validatedHunters.size < 1) {
+					modalSubmission.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+					return;
+				}
 
-					let hunterMap = await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id);
-					const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-					const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, hunterMap.get(bounty.userId), validatedHunters, season, origin.company);
-					const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunterMap.get(bounty.userId), season);
-					companyReceipt.guildName = collectedInteraction.guild.name;
+				await modalSubmission.deferReply({ flags: MessageFlags.SuppressNotifications });
+				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 
-					hunterMap = await reloadHunterMapSubset(hunterMap, [...validatedHunters.keys(), bounty.userId]);
-					const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-					if (previousCompanyLevel < currentCompanyLevel) {
-						companyReceipt.levelUp = currentCompanyLevel;
-					}
-					const descendingRanks = await logicLayer.ranks.findAllRanks(collectedInteraction.guild.id);
-					const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-					const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await collectedInteraction.guild.roles.fetch());
-					syncRankRoles(seasonalHunterReceipts, descendingRanks, collectedInteraction.guild.members);
+				let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+				const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+				const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, hunterMap.get(bounty.userId), validatedHunters, season, origin.company);
+				const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunterMap.get(bounty.userId), season);
+				companyReceipt.guildName = modalSubmission.guild.name;
 
-					await unarchiveAndUnlockThread(collectedInteraction.channel, "bounty complete");
-					collectedInteraction.channel.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-					consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
-					await collectedInteraction.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
-					interaction.message.edit({
-						embeds: [bountyEmbed(bounty, collectedInteraction.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys(), goalProgress), await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents))],
-						components: []
-					});
-					collectedInteraction.channel.setArchived(true, "bounty completed");
-					const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${interaction.channel}, was completed!` };
-					if (goalProgress.goalCompleted) {
-						announcementOptions.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
-					}
-					collectedInteraction.channels.first().send(announcementOptions).catch(butIgnoreMissingPermissionErrors);
-					if (origin.company.scoreboardIsSeasonal) {
-						refreshReferenceChannelScoreboardSeasonal(origin.company, collectedInteraction.guild, participationMap, descendingRanks, goalProgress);
-					} else {
-						refreshReferenceChannelScoreboardOverall(origin.company, collectedInteraction.guild, hunterMap, goalProgress);
-					}
-				}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
-					// If the bounty thread was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
-					if (interaction.channel) {
-						interaction.deleteReply();
-					}
+				hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+				const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+				if (previousCompanyLevel < currentCompanyLevel) {
+					companyReceipt.levelUp = currentCompanyLevel;
+				}
+				const descendingRanks = await logicLayer.ranks.findAllRanks(origin.company.id);
+				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
+				syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
+
+				await unarchiveAndUnlockThread(modalSubmission.channel, "bounty complete");
+				modalSubmission.channel.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
+				consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
+				await modalSubmission.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
+				await modalSubmission.message.edit({
+					embeds: [bountyEmbed(bounty, modalSubmission.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys()), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
+					components: []
 				});
+				modalSubmission.channel.setArchived(true, "bounty completed");
+				const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${modalSubmission.channel}, was completed!` };
+				if (goalProgress.goalCompleted) {
+					announcementOptions.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
+				}
+				modalSubmission.fields.getSelectedChannels(labelIdChannel).first().send(announcementOptions).catch(butIgnoreMissingPermissionErrors);
+				if (origin.company.scoreboardIsSeasonal) {
+					refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
+				} else {
+					refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
+				}
 			} break;
 			case "edit": {
 				const { modal, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), false, interaction.id);
@@ -269,9 +293,11 @@ module.exports = new SelectWrapper(mainId, 3000,
 						return;
 					}
 
+					await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
 					const updatePayload = { editCount: bounty.editCount + 1 };
 					if (title) {
 						updatePayload.title = title;
+						modalSubmission.channel.edit({ name: bounty.title });
 					}
 
 					updatePayload.description = description;
@@ -305,18 +331,8 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 					// update bounty board
 					const embeds = [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event)];
-					if (origin.company.bountyBoardId) {
-						interaction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
-							return bountyBoard.threads.fetch(bounty.postingId);
-						}).then(async thread => {
-							await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-							thread.edit({ name: bounty.title });
-							thread.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
-							return thread.fetchStarterMessage();
-						}).then(posting => {
-							posting.edit({ embeds });
-						})
-					}
+					modalSubmission.channel.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
+					interaction.message.edit({ embeds });
 
 					modalSubmission.reply({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds, flags: MessageFlags.Ephemeral });
 				});
@@ -329,82 +345,88 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
+				const openBounties = await logicLayer.bounties.mapOpenBountiesBySlotNumber(origin.user.id, origin.company.id);
 				const slotOptions = [];
-				for (let i = 1; i <= bountySlotCount; i++) {
-					if (i !== bounty.slotNumber) {
-						const existingBounty = openBounties.find(checkedBounty => checkedBounty.slotNumber === i);
-						slotOptions.push(
-							{
-								emoji: emojiFromNumber(i),
-								label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-								description: `XP Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, i, existingBounty?.showcaseCount ?? 0)}`,
-								value: i.toString()
-							}
-						)
+				for (let i = 0; i < bountySlotCount; i++) {
+					const slotNumber = i + 1;
+					if (slotNumber !== bounty.slotNumber) {
+						const matchingBounty = openBounties.get(slotNumber);
+						const option = { emoji: emojiFromNumber(slotNumber), label: `Slot ${slotNumber} (Base Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, slotNumber, 0)} XP)`, value: slotNumber.toString() };
+						if (matchingBounty) {
+							option.description = truncateTextToLength(`Swap With: ${matchingBounty.title}`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption);
+						}
+						slotOptions.push(option);
 					}
 				}
-				const channelSelectPlaceholder = "Select a channel to announce the swap in...";
-				interaction.reply({
-					content: "Swapping this bounty to another slot will change its XP reward.",
-					components: [
-						new ActionRowBuilder().addComponents(
-							new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}destination`)
-								.setPlaceholder("Select a slot to swap the bounty to...")
-								.setMaxValues(1)
-								.setOptions(slotOptions)
-						),
-						disabledSelectRow(channelSelectPlaceholder)
-					],
-					flags: MessageFlags.Ephemeral,
-					withResponse: true
-				}).then(response => {
-					const sourceSlot = bounty.slotNumber;
-					let destinationSlot;
-					const collector = response.resource.message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms"), max: 2 });
-					collector.on("collect", async collectedInteraction => {
-						const [_, stepId] = collectedInteraction.customId.split(SKIP_INTERACTION_HANDLING)
-						if (stepId === "destination") {
-							destinationSlot = parseInt(collectedInteraction.values[0]);
-							collectedInteraction.update({
-								components: [
-									disabledSelectRow(`Destination Slot: ${destinationSlot}`),
-									new ActionRowBuilder().addComponents(
-										new ChannelSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}channel`)
-											.setPlaceholder(channelSelectPlaceholder)
-											.addChannelTypes(ChannelType.GuildText, ChannelType.AnnouncementThread, ChannelType.PrivateThread, ChannelType.PublicThread)
-									)
-								]
-							})
+
+				const labelIdSlot = "slot";
+				const labelIdChannel = "channel";
+				const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					.setTitle("Move Bounty Slots")
+					.addTextDisplayComponents(new TextDisplayBuilder().setContent("Swapping this bounty to another slot will change its Base XP Reward."))
+					.addLabelComponents(
+						new LabelBuilder().setLabel("Bounty Slot")
+							.setStringSelectMenuComponent(
+								new StringSelectMenuBuilder().setCustomId(labelIdSlot)
+									.setPlaceholder("Select a bounty slot...")
+									.setOptions(slotOptions)
+							),
+						new LabelBuilder().setLabel("Announcement Channel")
+							.setChannelSelectMenuComponent(
+								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
+									.setPlaceholder("Select a channel...")
+									.setChannelTypes(ChannelType.GuildText)
+							)
+					);
+				await interaction.showModal(modal);
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+					.catch(butIgnoreInteractionCollectorErrors);
+				if (!modalSubmission) {
+					return;
+				}
+
+				/** Unnecessary Validations
+				 * - "bounty existence", "posting thread existence"; if a bounty thread (or the bounty, which cascades the delete to the thread) is deleted while its modal is open, the modal does not submit
+				 * - "same slot"; slot filtered out of options before input
+				 */
+				await bounty.reload();
+				if (bounty.state !== "open") {
+					modalSubmission.reply({ content: "This bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
+					return;
+				}
+
+				const destinationSlot = Number(modalSubmission.fields.getStringSelectValues(labelIdSlot)[0]);
+
+				await origin.company.reload();
+				const currentPosterLevel = (await origin.hunter.reload()).getLevel(origin.company.xpCoefficient);
+				if (destinationSlot > Hunter.getBountySlotCount(currentPosterLevel, origin.company.maxSimBounties)) {
+					modalSubmission.reply({ content: "You no longer have the bounty slot you are trying to swap into.", flags: MessageFlags.Ephemeral });
+					return;
+				}
+
+				const sourceSlot = bounty.slotNumber;
+				let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
+				const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, bounty.showcaseCount);
+
+				bounty = await bounty.update({ slotNumber: destinationSlot });
+				refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(bounty.id));
+				modalSubmission.reply({ content: `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.` });
+
+				if (destinationBounty) {
+					destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
+					refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
+					addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+				}
+
+				const channel = modalSubmission.fields.getSelectedChannels(labelIdChannel).first();
+				channel.send(addCompanyAnnouncementPrefix(origin.company, { content: `${modalSubmission.member}'s bounty, ${bold(bounty.title)} is now worth ${destinationRewardValue} XP.` }))
+					.catch(error => {
+						if (isMissingPermissionError) {
+							modalSubmission.followUp({ content: `Your bounty swap could not be announced in ${channel} because ${modalSubmission.client.user} doesn't have permission to view or send messages in that channel.`, flags: MessageFlags.Ephemeral });
 						} else {
-							await bounty.reload();
-							if (bounty.state !== "open") {
-								collectedInteraction.followUp({ content: "The selected bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
-								return;
-							}
-
-							let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id });
-							const posterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-							const destinationRewardValue = Bounty.calculateCompleterReward(posterLevel, destinationSlot, bounty.showcaseCount);
-
-							bounty = await bounty.update({ slotNumber: destinationSlot });
-
-							refreshBountyThreadStarterMessage(interaction.guild, origin.company, bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, posterLevel, await logicLayer.bounties.getHunterIdSet(bounty.id));
-							addLogMessageToBountyThread(interaction.guild, origin.company, bounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`);
-
-							if (destinationBounty?.state === "open") {
-								destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-								refreshBountyThreadStarterMessage(interaction.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, posterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-								addLogMessageToBountyThread(interaction.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(posterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
-							}
-
-							collectedInteraction.channels.first().send(addCompanyAnnouncementPrefix(origin.company, { content: `${interaction.member}'s bounty, ${bold(bounty.title)} is now worth ${destinationRewardValue} XP.` }));
-							collectedInteraction.update({ components: [] }).then(() => {
-								interaction.deleteReply();
-							})
+							console.error(error);
 						}
-					})
-				})
+					});
 			} break;
 			case "takedown": {
 				interaction.reply({
@@ -420,9 +442,6 @@ module.exports = new SelectWrapper(mainId, 3000,
 					flags: MessageFlags.Ephemeral,
 					withResponse: true
 				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
-					await bounty.reload();
-					bounty.state = "deleted";
-					bounty.save();
 					logicLayer.bounties.deleteBountyCompletions(bountyId);
 					bounty.destroy();
 

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -4,7 +4,7 @@ const { Bounty, Rank, Company, Participation, Hunter, Season, Completion, Toast 
 const { Role, Collection, AttachmentBuilder, ActionRowBuilder, UserSelectMenuBuilder, userMention, EmbedBuilder, Guild, StringSelectMenuBuilder, underline, italic, Colors, MessageFlags, GuildMember, ButtonBuilder, ButtonStyle, GuildScheduledEventPrivacyLevel, GuildScheduledEventEntityType, ModalBuilder, LabelBuilder, TextInputBuilder, TextInputStyle, bold, FileUploadBuilder, GuildScheduledEvent } = require("discord.js");
 const { SKIP_INTERACTION_HANDLING, bountyBotIconURL, discordIconURL, SAFE_DELIMITER, COMPANY_XP_COEFFICIENT } = require("../../constants");
 const { emojiFromNumber, sentenceListEN, fillableTextBar, randomCongratulatoryPhrase } = require("./stringConstructors");
-const { descendingByProperty, timeConversion } = require("../../shared");
+const { descendingByProperty, timeConversion, discordTimestamp, ascendingByProperty } = require("../../shared");
 
 /** @file Discord API (dAPI) Serializers - changes our data into the shapes dAPI wants */
 
@@ -164,6 +164,20 @@ function selectOptionsFromBounties(bounties) {
 		}
 		return optionPayload;
 	}).slice(0, SelectMenuLimits.MaximumOptionsLength);
+}
+
+/**
+ * @param {Map<number, Bounty>} bountyMap
+ * @param {number} posterLevel
+ */
+function selectOptionsFromBountiesWithBaseRewardAsDescription(bountyMap, posterLevel) {
+	// Since the bounty entries are tuples of [slotNumber, bounty], sorting by "property 0" sorts by slotNumber
+	return Array.from(bountyMap.entries()).sort(ascendingByProperty(0)).map(([slotNumber, bounty]) => ({
+		emoji: emojiFromNumber(slotNumber),
+		label: bounty.title,
+		description: truncateTextToLength(`Base Reward: ${Bounty.calculateCompleterReward(posterLevel, slotNumber, 0)} XP`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption),
+		value: bounty.id
+	})).slice(0, SelectMenuLimits.MaximumOptionsLength);
 }
 
 /**
@@ -493,10 +507,11 @@ function bountyEmbed(bounty, posterGuildMember, posterLevel, shouldOmitRewardsFi
 	}
 	if (hunterIdSet.size > 0) {
 		const completersFieldText = sentenceListEN(Array.from(hunterIdSet.values().map(id => userMention(id))));
+		const turnInFieldName = bounty.state === "open" ? "Pending Turn-Ins:" : "Turned-In By:";
 		if (completersFieldText.length <= EmbedLimits.MaximumFieldValueLength) {
-			fields.push({ name: "Turned in by:", value: completersFieldText });
+			fields.push({ name: turnInFieldName, value: completersFieldText });
 		} else {
-			fields.push({ name: "Turned in by:", value: "Too many to display!" });
+			fields.push({ name: turnInFieldName, value: "Too many to display!" });
 		}
 	}
 	if (goalProgress?.goalCompleted) {
@@ -629,6 +644,7 @@ module.exports = {
 	bountyControlPanelSelectRow,
 	bountyScheduledEventPayload,
 	selectOptionsFromBounties,
+	selectOptionsFromBountiesWithBaseRewardAsDescription,
 	selectOptionsFromRanks,
 	editBountyModalAndSubmissionOptions,
 	latestVersionChangesEmbed,

--- a/source/frontend/shared/storeManagement.js
+++ b/source/frontend/shared/storeManagement.js
@@ -1,16 +1,3 @@
-const { Hunter } = require("../../database/models");
-
-/** Reloads a subset of a map of a Company's Hunters
- * @param {Map<string, Hunter>} hunterMap
- * @param {string[]} reloadIds
- */
-async function reloadHunterMapSubset(hunterMap, reloadIds) {
-	for (const id of reloadIds) {
-		hunterMap.set(id, await hunterMap.get(id).reload());
-	}
-	return hunterMap;
-}
-
 /** In place, updates the object value in `originalMap` with the objects for each id in an `addedMap`
  * @param {Map<string, {}>} originalMap
  * @param {...Map<string, {}>} addedMaps
@@ -27,6 +14,5 @@ function consolidateHunterReceipts(originalMap, ...addedMaps) {
 }
 
 module.exports = {
-	reloadHunterMapSubset,
 	consolidateHunterReceipts
 };

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -59,6 +59,19 @@ function findOpenBounties(userId, companyId) {
 	return db.models.Bounty.findAll({ where: { userId, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
 }
 
+/**
+ * @param {string} userId
+ * @param {string} companyId
+ * @returns {Promise<Map<number, Bounty>>} a Map of the hunter's bounties with slotNumber as key
+ */
+async function mapOpenBountiesBySlotNumber(userId, companyId) {
+	const bountyMap = new Map();
+	for (const bounty of await db.models.Bounty.findAll({ where: { userId, companyId, state: "open" } })) {
+		bountyMap.set(bounty.slotNumber, bounty);
+	}
+	return bountyMap;
+}
+
 /** @param {string} companyId */
 function findEvergreenBounties(companyId) {
 	return db.models.Bounty.findAll({ where: { isEvergreen: true, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
@@ -228,6 +241,7 @@ module.exports = {
 	bulkCreateCompletions,
 	findBounty,
 	findOpenBounties,
+	mapOpenBountiesBySlotNumber,
 	findEvergreenBounties,
 	findBountyCompletions,
 	getHunterIdSet,

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -63,18 +63,20 @@ const GOAL_POINT_MAP = {
  */
 async function progressGoal(company, progressType, hunter, season) {
 	const contributorIds = [];
-	let gpDisplay = 0, gpEarned = 0, gpMultiplierString = "", goalCompleted = false, currentGP = 0, requiredGP = 0;
+	const companyReceipt = {};
+	let gpDisplay = 0, gpEarned = 0, goalCompleted = false, currentGP = 0, requiredGP = 0;
 	const goal = await db.models.Goal.findOne({ where: { companyId: company.id, state: "ongoing" }, order: [["createdAt", "DESC"]] });
 	if (goal) {
 		requiredGP = goal.requiredGP;
-		gpDisplay += GOAL_POINT_MAP[progressType];
+		gpDisplay = GOAL_POINT_MAP[progressType];
 		if (goal.type === progressType) {
 			gpDisplay *= 2;
 		}
 		gpEarned = gpDisplay;
+		companyReceipt.gp = gpDisplay;
 		if (company.gpFestivalMultiplier > 1) {
 			gpEarned *= company.gpFestivalMultiplier;
-			gpMultiplierString = company.festivalMultiplierString("gp");
+			companyReceipt.gpMultiplier = company.festivalMultiplierString("gp");
 		}
 		await createGoalContribution(goal.id, hunter.userId, gpEarned);
 		hunter.increment("goalContributions");
@@ -92,10 +94,7 @@ async function progressGoal(company, progressType, hunter, season) {
 		}
 	}
 	return {
-		companyReceipt: {
-			gp: gpDisplay,
-			gpMultiplier: gpMultiplierString
-		},
+		companyReceipt,
 		goalProgress: {
 			gpContributed: gpEarned,
 			goalCompleted,

--- a/source/logic/seasons.js
+++ b/source/logic/seasons.js
@@ -223,8 +223,8 @@ async function changeSeasonXP(userId, companyId, seasonId, xp) {
  * @param {string} companyId
  * @param {string} stat
  */
-async function incrementSeasonStat(guildId, stat) {
-	const [season] = await findOrCreateCurrentSeason(guildId);
+async function incrementSeasonStat(companyId, stat) {
+	const [season] = await findOrCreateCurrentSeason(companyId);
 	return season.increment(stat);
 }
 


### PR DESCRIPTION
Summary
-------
- refactor showcase flows to use modals instead of message components
- fix unknown channel error on edit bounty thread crash in showcase slash flow
- early out of control panel record/revoke turn-in if bounty isn't open

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] showcase flows complete critical path

Issue
-----
#498