### PR TITLE
fix `/bounty take-down` crash if user has no bounties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@
 ### Premium Features
 - Added premium commands `/festival start-gp` and `/festival close-gp` for toggling times where gp contributions are multiplied (old festival commands renamed to `/festival start-xp` and `/festival close-xp`)
 - Added the `nickname` option to `/config-premium` to allow bot managers to set a nickname for BountyBot that won't get cleared by toggling festivals on or off
-### Bug Fixes
+### Other Changes
+- The completing a bounty via the select in the bounty board can now add turn-ins like the slash command
 - Fixed Goal Point contributions not showing up in reward messages
 ### Known Issues
 - When editing a bounty, not submitting a description, image, or timestamp pair, always deletes those data from the bounty (this will be fixed with modal checkboxes in the future)

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,71 +1,107 @@
-const { MessageFlags, userMention, channelMention, bold } = require("discord.js");
+const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("complete", "Close one of your open bounties, distributing rewards to hunters who turned it in",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		const slotNumber = interaction.options.getInteger("bounty-slot");
-		const bounty = await logicLayer.bounties.findBounty({ userId: interaction.user.id, slotNumber, companyId: interaction.guild.id });
-		if (!bounty) {
-			interaction.reply({ content: "You don't have a bounty in the `bounty-slot` provided.", flags: MessageFlags.Ephemeral });
+		const openBounties = await logicLayer.bounties.findOpenBounties(origin.user.id, origin.company.id);
+		if (openBounties.length < 1) {
+			interaction.reply({ content: "You don't appear to have any open bounties in this server.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const labelIdBountyId = "bounty-id";
+		const labelIdBountyHunters = "hunters";
+		const maxHunters = 10;
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Mark your Bounty Complete!")
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBounties(openBounties))
+					),
+				new LabelBuilder().setLabel("Extra Turn-Ins")
+					.setUserSelectMenuComponent(
+						new UserSelectMenuBuilder().setCustomId(labelIdBountyHunters)
+							.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+							.setMaxValues(maxHunters)
+							.setRequired(false)
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
+
+		const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (bounty?.state !== "open") {
+			modalSubmission.reply({ content: "Your selected bounty no longer appears to be open.", flags: MessageFlags.Ephemeral });
 			return;
 		}
 
 		// disallow completion within 5 minutes of creating bounty
 		if (runMode === "production" && new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {
-			interaction.reply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can ${commandMention("bounty add-completers")} so you won't forget instead.`, flags: MessageFlags.Ephemeral });
+			modalSubmission.reply({ content: `Bounties cannot be completed within 5 minutes of their posting. You can ${commandMention("bounty record-turn-ins")} so you won't forget instead.`, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
+		// Early-out if no completers
 		const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
-		const hunterCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
-		for (const optionKey of ["first-bounty-hunter", "second-bounty-hunter", "third-bounty-hunter", "fourth-bounty-hunter", "fifth-bounty-hunter"]) {
-			const guildMember = interaction.options.getMember(optionKey);
-			if (guildMember) {
-				if (guildMember?.id !== interaction.user.id && !hunterCollection.has(guildMember.id)) {
-					hunterCollection.set(guildMember.id, guildMember);
-				}
-			}
-		}
-
+		const memberCollection = await modalSubmission.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
 		const validatedHunters = new Map();
-		for (const [memberId, member] of hunterCollection) {
+		for (const [memberId, member] of memberCollection) {
 			if (runMode !== "production" || !member.user.bot) {
-				const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
+				const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
 				if (!hunter.isBanned) {
 					validatedHunters.set(memberId, hunter);
 				}
 			}
 		}
 
+		const extraTurnIns = modalSubmission.fields.getSelectedMembers(labelIdBountyHunters);
+		if (extraTurnIns !== null) {
+			for (const [memberId, member] of extraTurnIns) {
+				if (runMode !== "production" || !(member.user.bot || validatedHunters.has(memberId))) {
+					const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
+					if (!hunter.isBanned) {
+						validatedHunters.set(memberId, hunter);
+					}
+				}
+			}
+		}
 		if (validatedHunters.size < 1) {
-			interaction.reply({ content: `No bounty hunters have turn-ins recorded for this bounty. If you'd like to close your bounty without distributng rewards, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+			modalSubmission.reply({ content: `There aren't any eligible pending turn-ins for this bounty. If you'd like to close your bounty without paying out rewards, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
 			return;
 		}
 
-		await interaction.deferReply();
+		await modalSubmission.deferReply();
 
 		const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 
-		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
+		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
 
 		const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 		const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, origin.hunter, validatedHunters, season, origin.company);
 		const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", origin.hunter, season);
-		companyReceipt.guildName = interaction.guild.name;
-		hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
+		companyReceipt.guildName = modalSubmission.guild.name;
+		hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
 		const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
 		if (previousCompanyLevel < currentCompanyLevel) {
 			companyReceipt.levelUp = currentCompanyLevel;
 		}
-		const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
+		const descendingRanks = await logicLayer.ranks.findAllRanks(origin.company.id);
 		const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await interaction.guild.roles.fetch());
-		syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
+		const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
+		syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
 		consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
-		const content = rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties);
+		const rewardMessageContent = rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties);
 
 		const acknowledgeOptions = { content: `${userMention(bounty.userId)}'s bounty, ` };
 		if (goalProgress.goalCompleted) {
@@ -73,70 +109,33 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		}
 
 		if (origin.company.bountyBoardId) {
-			const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
+			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
+			modalSubmission.editReply(acknowledgeOptions);
+			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
 			bountyBoard.threads.fetch(bounty.postingId).then(async thread => {
 				await unarchiveAndUnlockThread(thread, "bounty complete");
 				thread.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-				thread.send({ content, flags: MessageFlags.SuppressNotifications });
+				thread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
 				return thread.fetchStarterMessage();
 			}).then(async posting => {
 				posting.edit({
-					embeds: [bountyEmbed(bounty, interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(interaction.guild.scheduledEvents), goalProgress)],
+					embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
 					components: []
 				}).then(() => {
 					posting.channel.setArchived(true, "bounty completed");
 				});
 			});
-			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
-			interaction.editReply(acknowledgeOptions);
 		} else {
 			acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
-			interaction.editReply(acknowledgeOptions).then(message => {
-				sendRewardMessage(message, content, `${bounty.title} Rewards`);
+			modalSubmission.editReply(acknowledgeOptions).then(message => {
+				sendRewardMessage(message, rewardMessageContent, `${bounty.title} Rewards`);
 			})
 		}
 
 		if (origin.company.scoreboardIsSeasonal) {
-			refreshReferenceChannelScoreboardSeasonal(origin.company, interaction.guild, participationMap, descendingRanks, goalProgress);
+			refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
 		} else {
-			refreshReferenceChannelScoreboardOverall(origin.company, interaction.guild, hunterMap, goalProgress);
+			refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
 		}
-	}
-).setOptions(
-	{
-		type: "Integer",
-		name: "bounty-slot",
-		description: "The slot number of your bounty",
-		required: true
-	},
-	{
-		type: "User",
-		name: "first-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "second-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "third-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fourth-bounty-hunter",
-		description: "A bounty hunter who turned in the bounty",
-		required: false
-	},
-	{
-		type: "User",
-		name: "fifth-bounty-hunter",
-		description: "A bounty hunter who completed the bounty",
-		required: false
 	}
 );

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -17,7 +17,6 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to edit...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/bounty/post.js
+++ b/source/frontend/commands/bounty/post.js
@@ -35,7 +35,6 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("XP awarded depends on slot used...")
-						.setMaxValues(1)
 						.setOptions(slotOptions)
 				)
 			],

--- a/source/frontend/commands/bounty/swap.js
+++ b/source/frontend/commands/bounty/swap.js
@@ -1,98 +1,96 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, bold } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, bold, ModalBuilder, LabelBuilder, TextDisplayBuilder } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty, Hunter } = require("../../../database/models");
-const { emojiFromNumber, selectOptionsFromBounties, refreshBountyThreadStarterMessage, addLogMessageToBountyThread, addCompanyAnnouncementPrefix, disabledSelectRow } = require("../../shared");
+const { emojiFromNumber, refreshBountyThreadStarterMessage, addLogMessageToBountyThread, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { timeConversion } = require("../../../shared");
+const { SelectMenuLimits } = require("@sapphire/discord.js-utilities");
 
 module.exports = new SubcommandWrapper("swap", "Move one of your bounties to another slot to change its reward",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
-		logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id).then(openBounties => {
-			if (openBounties.length < 1) {
-				interaction.reply({ content: "You don't seem to have any open bounties at the moment.", flags: MessageFlags.Ephemeral });
-				return;
+		const startingPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
+		const bountySlotCount = Hunter.getBountySlotCount(startingPosterLevel, origin.company.maxSimBounties);
+		if (bountySlotCount < 2) {
+			interaction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const openBounties = await logicLayer.bounties.mapOpenBountiesBySlotNumber(origin.user.id, origin.company.id);
+		if (openBounties.size < 1) {
+			interaction.reply({ content: "You don't seem to have any open bounties at the moment.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		const slotOptions = [];
+		for (let i = 0; i < bountySlotCount; i++) {
+			const slotNumber = i + 1;
+			const matchingBounty = openBounties.get(slotNumber);
+			const option = { emoji: emojiFromNumber(slotNumber), label: `Slot ${slotNumber} (Base Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, slotNumber, 0)} XP)`, value: slotNumber.toString() };
+			if (matchingBounty) {
+				option.description = truncateTextToLength(`Swap With: ${matchingBounty.title}`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption);
 			}
+			slotOptions.push(option);
+		}
 
-			interaction.reply({
-				content: "Swapping a bounty to another slot will change the XP reward for that bounty.",
-				components: [
-					new ActionRowBuilder().addComponents(
-						new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}bounty`)
-							.setPlaceholder("Select a bounty to swap...")
-							.setMaxValues(1)
-							.setOptions(selectOptionsFromBounties(openBounties))
+		const labelIdBountyId = "bounty-id";
+		const labelIdSlot = "slot";
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Swap Bounty Rewards")
+			.addTextDisplayComponents(new TextDisplayBuilder().setContent("Swapping a bounty to another slot will change the XP reward for that bounty."))
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBountiesWithBaseRewardAsDescription(openBounties, startingPosterLevel))
+					),
+				new LabelBuilder().setLabel("Bounty Slot")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdSlot)
+							.setPlaceholder("Select a bounty slot...")
+							.setOptions(slotOptions)
 					)
-				],
-				flags: MessageFlags.Ephemeral,
-				withResponse: true
-			}).then(response => {
-				const collector = response.resource.message.createMessageComponentCollector({ max: 2 });
-				let previousBounty;
-				collector.on("collect", async (collectedInteraction) => {
-					if (collectedInteraction.customId.endsWith("bounty")) {
-						previousBounty = openBounties.find(bounty => bounty.id === collectedInteraction.values[0]);
-						const startingPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-						const bountySlotCount = Hunter.getBountySlotCount(startingPosterLevel, origin.company.maxSimBounties);
-						if (bountySlotCount < 2) {
-							collectedInteraction.reply({ content: "You currently only have 1 bounty slot in this server.", flags: MessageFlags.Ephemeral });
-							return;
-						}
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
 
-						const existingBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guildId);
-						const slotOptions = [];
-						for (let i = 1; i <= bountySlotCount; i++) {
-							if (i != previousBounty.slotNumber) {
-								const existingBounty = existingBounties.find(bounty => bounty.slotNumber == i);
-								slotOptions.push(
-									{
-										emoji: emojiFromNumber(i),
-										label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-										description: `XP Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, i, existingBounty?.showcaseCount ?? 0)}`,
-										value: i.toString()
-									}
-								)
-							}
-						}
+		let sourceBounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (sourceBounty?.state !== "open") {
+			modalSubmission.reply({ content: "The selected bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-						collectedInteraction.update({
-							content: "If there is a bounty in the destination slot, it'll be swapped to the old bounty's slot.",
-							components: [
-								disabledSelectRow(`Selected Bounty: ${previousBounty.title}`),
-								new ActionRowBuilder().addComponents(
-									new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
-										.setPlaceholder("Select a slot to swap the bounty to...")
-										.setMaxValues(1)
-										.setOptions(slotOptions)
-								)
-							],
-							flags: MessageFlags.Ephemeral
-						})
-					} else {
-						await previousBounty.reload();
-						if (previousBounty.state !== "open") {
-							collectedInteraction.update({ content: "The selected bounty appears to already have been completed.", components: [] });
-						} else {
-							const hunterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-							const sourceSlot = previousBounty.slotNumber;
-							const destinationSlot = parseInt(collectedInteraction.values[0]);
-							let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id });
+		const destinationSlot = Number(modalSubmission.fields.getStringSelectValues(labelIdSlot)[0]);
+		if (sourceBounty.slotNumber === destinationSlot) {
+			modalSubmission.reply({ content: `${bold(sourceBounty.title)} is already in slot ${destinationSlot}.`, flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-							previousBounty = await previousBounty.update({ slotNumber: destinationSlot });
+		await origin.company.reload();
+		const currentPosterLevel = (await origin.hunter.reload()).getLevel(origin.company.xpCoefficient);
+		if (destinationSlot > Hunter.getBountySlotCount(currentPosterLevel, origin.company.maxSimBounties)) {
+			modalSubmission.reply({ content: "You no longer have the bounty slot you are trying to swap into.", flags: MessageFlags.Ephemeral });
+			return;
+		}
 
-              refreshBountyThreadStarterMessage(interaction.guild, origin.company, previousBounty, await previousBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, hunterLevel, await logicLayer.bounties.getHunterIdSet(previousBounty.id));
-							addLogMessageToBountyThread(interaction.guild, origin.company, previousBounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${Bounty.calculateCompleterReward(hunterLevel, destinationSlot, previousBounty.showcaseCount)} XP.`);
+		const sourceSlot = sourceBounty.slotNumber;
+		let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
+		const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, sourceBounty.showcaseCount);
 
-							if (destinationBounty?.state === "open") {
-								destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-								refreshBountyThreadStarterMessage(interaction.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, hunterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-								addLogMessageToBountyThread(interaction.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(hunterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
-							}
+		sourceBounty = await sourceBounty.update({ slotNumber: destinationSlot });
+		refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, sourceBounty, await sourceBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(sourceBounty.id));
+		addLogMessageToBountyThread(modalSubmission.guild, origin.company, sourceBounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`);
 
-							interaction.channel.send(addCompanyAnnouncementPrefix(origin.company, { content: `${interaction.member}'s bounty, ${bold(previousBounty.title)} is now worth ${Bounty.calculateCompleterReward(hunterLevel, destinationSlot, previousBounty.showcaseCount)} XP.` }));
-							interaction.deleteReply();
-						}
-					}
-				})
-			})
-		})
+		if (destinationBounty) {
+			destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
+			refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
+			addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+		}
+
+		modalSubmission.reply(addCompanyAnnouncementPrefix(origin.company, { content: `${modalSubmission.member}'s bounty, ${bold(sourceBounty.title)} is now worth ${destinationRewardValue} XP.` }));
 	}
 );

--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -17,7 +17,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to take down...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],
@@ -26,10 +25,8 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 			const [bountyId] = collectedInteraction.values;
 			const bounty = await logicLayer.bounties.findBounty(bountyId);
-			bounty.state = "deleted";
-			bounty.save();
 			logicLayer.bounties.deleteBountyCompletions(bountyId);
-			if (origin.company.bountyBoardId) {
+			if (origin.company.bountyBoardId && bounty.postingId) {
 				const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
 				const postingThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
 				if (postingThread) {

--- a/source/frontend/commands/evergreen/edit.js
+++ b/source/frontend/commands/evergreen/edit.js
@@ -18,7 +18,6 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to edit...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/evergreen/take-down.js
+++ b/source/frontend/commands/evergreen/take-down.js
@@ -13,7 +13,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 						.setPlaceholder("Select a bounty to take down...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],

--- a/source/frontend/commands/moderation/take-down.js
+++ b/source/frontend/commands/moderation/take-down.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, userMention, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors } = require("../../shared");
@@ -18,7 +18,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}${poster.id}`)
 						.setPlaceholder("Select a bounty to take down...")
-						.setMaxValues(1)
 						.setOptions(selectOptionsFromBounties(openBounties))
 				)
 			],
@@ -29,14 +28,12 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 			const [bountyId] = collectedInteraction.values;
 			openBounties.find(bounty => bounty.id === bountyId).reload().then(async bounty => {
 				logicLayer.bounties.deleteBountyCompletions(bountyId);
-				bounty.state = "deleted";
-				bounty.save();
+				bounty.update({ state: "deleted" });
 				if (origin.company.bountyBoardId) {
 					const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
 					const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 					postingThread.delete("Bounty taken down by moderator");
 				}
-				bounty.destroy();
 
 				let poster;
 				if (posterId === origin.hunter.userId) {
@@ -50,7 +47,7 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await interaction.guild.roles.fetch());
 				syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-				collectedInteraction.reply({ content: `<@${posterId}>'s bounty **${bounty.title}** has been taken down by ${interaction.member}.` });
+				collectedInteraction.reply({ content: `${userMention(posterId)}'s bounty ${bold(bounty.title)} has been taken down by ${interaction.member}.` });
 			});
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
 			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -2,8 +2,9 @@ const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, us
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, disabledSelectRow, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
+const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -119,7 +120,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 							.setChannelSelectMenuComponent(
 								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
 									.setPlaceholder("Select a channel...")
-									.setChannelTypes(ChannelType.GuildText, ChannelType.PrivateThread, ChannelType.PublicThread)
+									.setChannelTypes(ChannelType.GuildText)
 							)
 					);
 				await interaction.showModal(modal);
@@ -167,80 +168,103 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				// Early-out if no completers
 				const completions = await logicLayer.bounties.findBountyCompletions(bounty.id);
 				const memberCollection = await interaction.guild.members.fetch({ user: completions.map(reciept => reciept.userId) });
 				const validatedHunters = new Map();
+				const pendingTurnInDisplayNames = [];
 				for (const [memberId, member] of memberCollection) {
 					if (runMode !== "production" || !member.user.bot) {
-						const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, interaction.guild.id);
+						const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
 						if (!hunter.isBanned) {
 							validatedHunters.set(memberId, hunter);
+							pendingTurnInDisplayNames.push(member.displayName);
 						}
 					}
 				}
 
-				if (validatedHunters.size < 1) {
-					interaction.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+				const labelIdChannel = "channel";
+				const labelIdBountyHunters = "bounty-hunters";
+				const maxHunters = 10;
+				const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					.setTitle("Mark your Bounty Complete!")
+					.addTextDisplayComponents(new TextDisplayBuilder().setContent(`Pending Turn-Ins: ${pendingTurnInDisplayNames.length > 0 ? sentenceListEN(pendingTurnInDisplayNames) : "None yet!"}`))
+					.addLabelComponents(
+						new LabelBuilder().setLabel("Channel")
+							.setChannelSelectMenuComponent(
+								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
+									.setPlaceholder("Select a channel...")
+									.setChannelTypes(ChannelType.GuildText)
+							),
+						new LabelBuilder().setLabel("Extra Turn-Ins")
+							.setUserSelectMenuComponent(
+								new UserSelectMenuBuilder().setCustomId(labelIdBountyHunters)
+									.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+									.setMaxValues(maxHunters)
+									.setRequired(false)
+							)
+					);
+				await interaction.showModal(modal);
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+					.catch(butIgnoreInteractionCollectorErrors);
+				if (!modalSubmission) {
 					return;
 				}
 
-				interaction.reply({
-					content: `Which channel should the bounty's completion be announced in?\n\nPending Turn-Ins: ${sentenceListEN(Array.from(validatedHunters.keys()).map(id => userMention(id)))}`,
-					components: [
-						new ActionRowBuilder().addComponents(
-							new ChannelSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
-								.setPlaceholder("Select channel...")
-								.setChannelTypes(ChannelType.GuildText)
-						)
-					],
-					flags: MessageFlags.Ephemeral,
-					withResponse: true
-				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.ChannelSelect })).then(async collectedInteraction => {
-					await collectedInteraction.deferReply({ flags: MessageFlags.SuppressNotifications });
-					const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
+				// Early-out if no completers
+				const extraTurnIns = modalSubmission.fields.getSelectedMembers(labelIdBountyHunters);
+				if (extraTurnIns !== null) {
+					for (const [memberId, member] of extraTurnIns) {
+						if (runMode !== "production" || !(member.user.bot || validatedHunters.has(memberId))) {
+							const { hunter: [hunter] } = await logicLayer.hunters.findOrCreateBountyHunter(memberId, origin.company.id);
+							if (!hunter.isBanned) {
+								validatedHunters.set(memberId, hunter);
+							}
+						}
+					}
+				}
+				if (validatedHunters.size < 1) {
+					modalSubmission.reply({ content: `There aren't any eligible bounty hunters to credit with completing this bounty. If you'd like to close your bounty without crediting anyone, use ${commandMention("bounty take-down")}.`, flags: MessageFlags.Ephemeral })
+					return;
+				}
 
-					let hunterMap = await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id);
-					const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-					const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, hunterMap.get(bounty.userId), validatedHunters, season, origin.company);
-					const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunterMap.get(bounty.userId), season);
-					companyReceipt.guildName = collectedInteraction.guild.name;
+				await modalSubmission.deferReply({ flags: MessageFlags.SuppressNotifications });
+				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 
-					hunterMap = await logicLayer.hunters.getCompanyHunterMap(collectedInteraction.guild.id);
-					const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-					if (previousCompanyLevel < currentCompanyLevel) {
-						companyReceipt.levelUp = currentCompanyLevel;
-					}
-					const descendingRanks = await logicLayer.ranks.findAllRanks(collectedInteraction.guild.id);
-					const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
-					const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await collectedInteraction.guild.roles.fetch());
-					syncRankRoles(seasonalHunterReceipts, descendingRanks, collectedInteraction.guild.members);
+				let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+				const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+				const hunterReceipts = await logicLayer.bounties.completeBounty(bounty, hunterMap.get(bounty.userId), validatedHunters, season, origin.company);
+				const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "bounties", hunterMap.get(bounty.userId), season);
+				companyReceipt.guildName = modalSubmission.guild.name;
 
-					await unarchiveAndUnlockThread(collectedInteraction.channel, "bounty complete");
-					collectedInteraction.channel.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-					consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
-					await collectedInteraction.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
-					interaction.message.edit({
-						embeds: [bountyEmbed(bounty, collectedInteraction.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys(), goalProgress), await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents))],
-						components: []
-					});
-					collectedInteraction.channel.setArchived(true, "bounty completed");
-					const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${interaction.channel}, was completed!` };
-					if (goalProgress.goalCompleted) {
-						announcementOptions.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
-					}
-					collectedInteraction.channels.first().send(announcementOptions).catch(butIgnoreMissingPermissionErrors);
-					if (origin.company.scoreboardIsSeasonal) {
-						refreshReferenceChannelScoreboardSeasonal(origin.company, collectedInteraction.guild, participationMap, descendingRanks, goalProgress);
-					} else {
-						refreshReferenceChannelScoreboardOverall(origin.company, collectedInteraction.guild, hunterMap, goalProgress);
-					}
-				}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
-					// If the bounty thread was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
-					if (interaction.channel) {
-						interaction.deleteReply();
-					}
+				hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
+				const currentCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
+				if (previousCompanyLevel < currentCompanyLevel) {
+					companyReceipt.levelUp = currentCompanyLevel;
+				}
+				const descendingRanks = await logicLayer.ranks.findAllRanks(origin.company.id);
+				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
+				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
+				syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
+
+				await unarchiveAndUnlockThread(modalSubmission.channel, "bounty complete");
+				modalSubmission.channel.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
+				consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
+				await modalSubmission.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
+				await modalSubmission.message.edit({
+					embeds: [bountyEmbed(bounty, modalSubmission.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys()), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
+					components: []
 				});
+				modalSubmission.channel.setArchived(true, "bounty completed");
+				const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${modalSubmission.channel}, was completed!` };
+				if (goalProgress.goalCompleted) {
+					announcementOptions.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
+				}
+				modalSubmission.fields.getSelectedChannels(labelIdChannel).first().send(announcementOptions).catch(butIgnoreMissingPermissionErrors);
+				if (origin.company.scoreboardIsSeasonal) {
+					refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
+				} else {
+					refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
+				}
 			} break;
 			case "edit": {
 				const { modal, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), false, interaction.id);
@@ -269,9 +293,11 @@ module.exports = new SelectWrapper(mainId, 3000,
 						return;
 					}
 
+					await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
 					const updatePayload = { editCount: bounty.editCount + 1 };
 					if (title) {
 						updatePayload.title = title;
+						modalSubmission.channel.edit({ name: bounty.title });
 					}
 
 					updatePayload.description = description;
@@ -305,18 +331,8 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 					// update bounty board
 					const embeds = [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event)];
-					if (origin.company.bountyBoardId) {
-						interaction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
-							return bountyBoard.threads.fetch(bounty.postingId);
-						}).then(async thread => {
-							await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-							thread.edit({ name: bounty.title });
-							thread.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
-							return thread.fetchStarterMessage();
-						}).then(posting => {
-							posting.edit({ embeds });
-						})
-					}
+					modalSubmission.channel.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
+					interaction.message.edit({ embeds });
 
 					modalSubmission.reply({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds, flags: MessageFlags.Ephemeral });
 				});
@@ -329,82 +345,88 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
+				const openBounties = await logicLayer.bounties.mapOpenBountiesBySlotNumber(origin.user.id, origin.company.id);
 				const slotOptions = [];
-				for (let i = 1; i <= bountySlotCount; i++) {
-					if (i !== bounty.slotNumber) {
-						const existingBounty = openBounties.find(checkedBounty => checkedBounty.slotNumber === i);
-						slotOptions.push(
-							{
-								emoji: emojiFromNumber(i),
-								label: `Slot ${i}: ${existingBounty?.title ?? "Empty"}`,
-								description: `XP Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, i, existingBounty?.showcaseCount ?? 0)}`,
-								value: i.toString()
-							}
-						)
+				for (let i = 0; i < bountySlotCount; i++) {
+					const slotNumber = i + 1;
+					if (slotNumber !== bounty.slotNumber) {
+						const matchingBounty = openBounties.get(slotNumber);
+						const option = { emoji: emojiFromNumber(slotNumber), label: `Slot ${slotNumber} (Base Reward: ${Bounty.calculateCompleterReward(startingPosterLevel, slotNumber, 0)} XP)`, value: slotNumber.toString() };
+						if (matchingBounty) {
+							option.description = truncateTextToLength(`Swap With: ${matchingBounty.title}`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption);
+						}
+						slotOptions.push(option);
 					}
 				}
-				const channelSelectPlaceholder = "Select a channel to announce the swap in...";
-				interaction.reply({
-					content: "Swapping this bounty to another slot will change its XP reward.",
-					components: [
-						new ActionRowBuilder().addComponents(
-							new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}destination`)
-								.setPlaceholder("Select a slot to swap the bounty to...")
-								.setMaxValues(1)
-								.setOptions(slotOptions)
-						),
-						disabledSelectRow(channelSelectPlaceholder)
-					],
-					flags: MessageFlags.Ephemeral,
-					withResponse: true
-				}).then(response => {
-					const sourceSlot = bounty.slotNumber;
-					let destinationSlot;
-					const collector = response.resource.message.createMessageComponentCollector({ time: timeConversion(2, "m", "ms"), max: 2 });
-					collector.on("collect", async collectedInteraction => {
-						const [_, stepId] = collectedInteraction.customId.split(SKIP_INTERACTION_HANDLING)
-						if (stepId === "destination") {
-							destinationSlot = parseInt(collectedInteraction.values[0]);
-							collectedInteraction.update({
-								components: [
-									disabledSelectRow(`Destination Slot: ${destinationSlot}`),
-									new ActionRowBuilder().addComponents(
-										new ChannelSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}channel`)
-											.setPlaceholder(channelSelectPlaceholder)
-											.addChannelTypes(ChannelType.GuildText, ChannelType.AnnouncementThread, ChannelType.PrivateThread, ChannelType.PublicThread)
-									)
-								]
-							})
+
+				const labelIdSlot = "slot";
+				const labelIdChannel = "channel";
+				const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					.setTitle("Move Bounty Slots")
+					.addTextDisplayComponents(new TextDisplayBuilder().setContent("Swapping this bounty to another slot will change its Base XP Reward."))
+					.addLabelComponents(
+						new LabelBuilder().setLabel("Bounty Slot")
+							.setStringSelectMenuComponent(
+								new StringSelectMenuBuilder().setCustomId(labelIdSlot)
+									.setPlaceholder("Select a bounty slot...")
+									.setOptions(slotOptions)
+							),
+						new LabelBuilder().setLabel("Announcement Channel")
+							.setChannelSelectMenuComponent(
+								new ChannelSelectMenuBuilder().setCustomId(labelIdChannel)
+									.setPlaceholder("Select a channel...")
+									.setChannelTypes(ChannelType.GuildText)
+							)
+					);
+				await interaction.showModal(modal);
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+					.catch(butIgnoreInteractionCollectorErrors);
+				if (!modalSubmission) {
+					return;
+				}
+
+				/** Unnecessary Validations
+				 * - "bounty existence", "posting thread existence"; if a bounty thread (or the bounty, which cascades the delete to the thread) is deleted while its modal is open, the modal does not submit
+				 * - "same slot"; slot filtered out of options before input
+				 */
+				await bounty.reload();
+				if (bounty.state !== "open") {
+					modalSubmission.reply({ content: "This bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
+					return;
+				}
+
+				const destinationSlot = Number(modalSubmission.fields.getStringSelectValues(labelIdSlot)[0]);
+
+				await origin.company.reload();
+				const currentPosterLevel = (await origin.hunter.reload()).getLevel(origin.company.xpCoefficient);
+				if (destinationSlot > Hunter.getBountySlotCount(currentPosterLevel, origin.company.maxSimBounties)) {
+					modalSubmission.reply({ content: "You no longer have the bounty slot you are trying to swap into.", flags: MessageFlags.Ephemeral });
+					return;
+				}
+
+				const sourceSlot = bounty.slotNumber;
+				let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
+				const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, bounty.showcaseCount);
+
+				bounty = await bounty.update({ slotNumber: destinationSlot });
+				refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(bounty.id));
+				modalSubmission.reply({ content: `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.` });
+
+				if (destinationBounty) {
+					destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
+					refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
+					addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+				}
+
+				const channel = modalSubmission.fields.getSelectedChannels(labelIdChannel).first();
+				channel.send(addCompanyAnnouncementPrefix(origin.company, { content: `${modalSubmission.member}'s bounty, ${bold(bounty.title)} is now worth ${destinationRewardValue} XP.` }))
+					.catch(error => {
+						if (isMissingPermissionError) {
+							modalSubmission.followUp({ content: `Your bounty swap could not be announced in ${channel} because ${modalSubmission.client.user} doesn't have permission to view or send messages in that channel.`, flags: MessageFlags.Ephemeral });
 						} else {
-							await bounty.reload();
-							if (bounty.state !== "open") {
-								collectedInteraction.followUp({ content: "The selected bounty appears to already have been completed.", flags: MessageFlags.Ephemeral });
-								return;
-							}
-
-							let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id });
-							const posterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-							const destinationRewardValue = Bounty.calculateCompleterReward(posterLevel, destinationSlot, bounty.showcaseCount);
-
-							bounty = await bounty.update({ slotNumber: destinationSlot });
-
-							refreshBountyThreadStarterMessage(interaction.guild, origin.company, bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, posterLevel, await logicLayer.bounties.getHunterIdSet(bounty.id));
-							addLogMessageToBountyThread(interaction.guild, origin.company, bounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`);
-
-							if (destinationBounty?.state === "open") {
-								destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-								refreshBountyThreadStarterMessage(interaction.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, posterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-								addLogMessageToBountyThread(interaction.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(posterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
-							}
-
-							collectedInteraction.channels.first().send(addCompanyAnnouncementPrefix(origin.company, { content: `${interaction.member}'s bounty, ${bold(bounty.title)} is now worth ${destinationRewardValue} XP.` }));
-							collectedInteraction.update({ components: [] }).then(() => {
-								interaction.deleteReply();
-							})
+							console.error(error);
 						}
-					})
-				})
+					});
 			} break;
 			case "takedown": {
 				interaction.reply({
@@ -420,9 +442,6 @@ module.exports = new SelectWrapper(mainId, 3000,
 					flags: MessageFlags.Ephemeral,
 					withResponse: true
 				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
-					await bounty.reload();
-					bounty.state = "deleted";
-					bounty.save();
 					logicLayer.bounties.deleteBountyCompletions(bountyId);
 					bounty.destroy();
 

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -4,7 +4,7 @@ const { Bounty, Rank, Company, Participation, Hunter, Season, Completion, Toast 
 const { Role, Collection, AttachmentBuilder, ActionRowBuilder, UserSelectMenuBuilder, userMention, EmbedBuilder, Guild, StringSelectMenuBuilder, underline, italic, Colors, MessageFlags, GuildMember, ButtonBuilder, ButtonStyle, GuildScheduledEventPrivacyLevel, GuildScheduledEventEntityType, ModalBuilder, LabelBuilder, TextInputBuilder, TextInputStyle, bold, FileUploadBuilder, GuildScheduledEvent } = require("discord.js");
 const { SKIP_INTERACTION_HANDLING, bountyBotIconURL, discordIconURL, SAFE_DELIMITER, COMPANY_XP_COEFFICIENT } = require("../../constants");
 const { emojiFromNumber, sentenceListEN, fillableTextBar, randomCongratulatoryPhrase } = require("./stringConstructors");
-const { descendingByProperty, timeConversion, discordTimestamp } = require("../../shared");
+const { descendingByProperty, timeConversion, discordTimestamp, ascendingByProperty } = require("../../shared");
 
 /** @file Discord API (dAPI) Serializers - changes our data into the shapes dAPI wants */
 
@@ -164,6 +164,20 @@ function selectOptionsFromBounties(bounties) {
 		}
 		return optionPayload;
 	}).slice(0, SelectMenuLimits.MaximumOptionsLength);
+}
+
+/**
+ * @param {Map<number, Bounty>} bountyMap
+ * @param {number} posterLevel
+ */
+function selectOptionsFromBountiesWithBaseRewardAsDescription(bountyMap, posterLevel) {
+	// Since the bounty entries are tuples of [slotNumber, bounty], sorting by "property 0" sorts by slotNumber
+	return Array.from(bountyMap.entries()).sort(ascendingByProperty(0)).map(([slotNumber, bounty]) => ({
+		emoji: emojiFromNumber(slotNumber),
+		label: bounty.title,
+		description: truncateTextToLength(`Base Reward: ${Bounty.calculateCompleterReward(posterLevel, slotNumber, 0)} XP`, SelectMenuLimits.MaximumLengthOfDescriptionOfOption),
+		value: bounty.id
+	})).slice(0, SelectMenuLimits.MaximumOptionsLength);
 }
 
 /**
@@ -493,10 +507,11 @@ function bountyEmbed(bounty, posterGuildMember, posterLevel, shouldOmitRewardsFi
 	}
 	if (hunterIdSet.size > 0) {
 		const completersFieldText = sentenceListEN(Array.from(hunterIdSet.values().map(id => userMention(id))));
+		const turnInFieldName = bounty.state === "open" ? "Pending Turn-Ins:" : "Turned-In By:";
 		if (completersFieldText.length <= EmbedLimits.MaximumFieldValueLength) {
-			fields.push({ name: "Turned in by:", value: completersFieldText });
+			fields.push({ name: turnInFieldName, value: completersFieldText });
 		} else {
-			fields.push({ name: "Turned in by:", value: "Too many to display!" });
+			fields.push({ name: turnInFieldName, value: "Too many to display!" });
 		}
 	}
 	if (goalProgress?.goalCompleted) {
@@ -629,6 +644,7 @@ module.exports = {
 	bountyControlPanelSelectRow,
 	bountyScheduledEventPayload,
 	selectOptionsFromBounties,
+	selectOptionsFromBountiesWithBaseRewardAsDescription,
 	selectOptionsFromRanks,
 	editBountyModalAndSubmissionOptions,
 	latestVersionChangesEmbed,

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -59,6 +59,19 @@ function findOpenBounties(userId, companyId) {
 	return db.models.Bounty.findAll({ where: { userId, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
 }
 
+/**
+ * @param {string} userId
+ * @param {string} companyId
+ * @returns {Promise<Map<number, Bounty>>} a Map of the hunter's bounties with slotNumber as key
+ */
+async function mapOpenBountiesBySlotNumber(userId, companyId) {
+	const bountyMap = new Map();
+	for (const bounty of await db.models.Bounty.findAll({ where: { userId, companyId, state: "open" } })) {
+		bountyMap.set(bounty.slotNumber, bounty);
+	}
+	return bountyMap;
+}
+
 /** @param {string} companyId */
 function findEvergreenBounties(companyId) {
 	return db.models.Bounty.findAll({ where: { isEvergreen: true, companyId, state: "open" }, order: [["slotNumber", "ASC"]] });
@@ -228,6 +241,7 @@ module.exports = {
 	bulkCreateCompletions,
 	findBounty,
 	findOpenBounties,
+	mapOpenBountiesBySlotNumber,
 	findEvergreenBounties,
 	findBountyCompletions,
 	getHunterIdSet,

--- a/source/logic/goals.js
+++ b/source/logic/goals.js
@@ -63,18 +63,20 @@ const GOAL_POINT_MAP = {
  */
 async function progressGoal(company, progressType, hunter, season) {
 	const contributorIds = [];
-	let gpDisplay = 0, gpEarned = 0, gpMultiplierString = "", goalCompleted = false, currentGP = 0, requiredGP = 0;
+	const companyReceipt = {};
+	let gpDisplay = 0, gpEarned = 0, goalCompleted = false, currentGP = 0, requiredGP = 0;
 	const goal = await db.models.Goal.findOne({ where: { companyId: company.id, state: "ongoing" }, order: [["createdAt", "DESC"]] });
 	if (goal) {
 		requiredGP = goal.requiredGP;
-		gpDisplay += GOAL_POINT_MAP[progressType];
+		gpDisplay = GOAL_POINT_MAP[progressType];
 		if (goal.type === progressType) {
 			gpDisplay *= 2;
 		}
 		gpEarned = gpDisplay;
+		companyReceipt.gp = gpDisplay;
 		if (company.gpFestivalMultiplier > 1) {
 			gpEarned *= company.gpFestivalMultiplier;
-			gpMultiplierString = company.festivalMultiplierString("gp");
+			companyReceipt.gpMultiplier = company.festivalMultiplierString("gp");
 		}
 		await createGoalContribution(goal.id, hunter.userId, gpEarned);
 		hunter.increment("goalContributions");
@@ -92,10 +94,7 @@ async function progressGoal(company, progressType, hunter, season) {
 		}
 	}
 	return {
-		companyReceipt: {
-			gp: gpDisplay,
-			gpMultiplier: gpMultiplierString
-		},
+		companyReceipt,
 		goalProgress: {
 			gpContributed: gpEarned,
 			goalCompleted,


### PR DESCRIPTION
Summary
-------
- fix `/bounty take-down` crash if user has no bounties

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty take-down` early outs if user has no bounties
- [x] `/bounty take-down` resolves critical path