### PR TITLE
bounty take-down improvements

### DIFF
--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -25,8 +25,6 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 			const [bountyId] = collectedInteraction.values;
 			const bounty = await logicLayer.bounties.findBounty(bountyId);
-			bounty.state = "deleted";
-			bounty.save();
 			logicLayer.bounties.deleteBountyCompletions(bountyId);
 			if (origin.company.bountyBoardId && bounty.postingId) {
 				const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);

--- a/source/frontend/commands/moderation/take-down.js
+++ b/source/frontend/commands/moderation/take-down.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, userMention, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors } = require("../../shared");
@@ -28,14 +28,12 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 			const [bountyId] = collectedInteraction.values;
 			openBounties.find(bounty => bounty.id === bountyId).reload().then(async bounty => {
 				logicLayer.bounties.deleteBountyCompletions(bountyId);
-				bounty.state = "deleted";
-				bounty.save();
+				bounty.update({ state: "deleted" });
 				if (origin.company.bountyBoardId) {
 					const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
 					const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 					postingThread.delete("Bounty taken down by moderator");
 				}
-				bounty.destroy();
 
 				let poster;
 				if (posterId === origin.hunter.userId) {
@@ -49,7 +47,7 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 				const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
 				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await interaction.guild.roles.fetch());
 				syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-				collectedInteraction.reply({ content: `<@${posterId}>'s bounty **${bounty.title}** has been taken down by ${interaction.member}.` });
+				collectedInteraction.reply({ content: `${userMention(posterId)}'s bounty ${bold(bounty.title)} has been taken down by ${interaction.member}.` });
 			});
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
 			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -442,9 +442,6 @@ module.exports = new SelectWrapper(mainId, 3000,
 					flags: MessageFlags.Ephemeral,
 					withResponse: true
 				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
-					await bounty.reload();
-					bounty.state = "deleted";
-					bounty.save();
 					logicLayer.bounties.deleteBountyCompletions(bountyId);
 					bounty.destroy();
 


### PR DESCRIPTION
Summary
-------
- moderation take-downs no longer delete bounty row in database
- poster take-downs no longer update bounty row in database (which would be deleted later)
- use formatter instead of markdown in moderation take-down

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)