### PR TITLE
bounty edit improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,6 @@
 ### Other Changes
 - The completing a bounty via the select in the bounty board can now add turn-ins like the slash command
 - Fixed Goal Point contributions not showing up in reward messages
-### Known Issues
-- When editing a bounty, not submitting a description, image, or timestamp pair, always deletes those data from the bounty (this will be fixed with modal checkboxes in the future)
 ## BountyBot Version 2.10.1bi:
 This version includes the addition of the "b" version category, for "bug fixes".
 - Fixed several crashes related to missing permissions, modal timeouts, trying to DM users who've blocked BountyBot, and residual data from former server members

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -31,14 +31,14 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				return;
 			}
 
-			const { modal, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents), false, interaction.id);
+			const { modal, inputIds, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents), false, interaction.id);
 			collectedInteraction.showModal(modal);
 			return interaction.awaitModalSubmit(submissionOptions).then(async modalSubmission => {
 				await bounty.reload();
 				const errors = [];
 
-				const title = modalSubmission.fields.getTextInputValue("title");
-				const description = modalSubmission.fields.getTextInputValue("description");
+				const title = modalSubmission.fields.getTextInputValue(inputIds.title);
+				const description = modalSubmission.fields.getTextInputValue(inputIds.description);
 				const autoModInfraction = await textsHaveAutoModInfraction(modalSubmission.channel, modalSubmission.member, [title, description], "edit bounty")
 				if (autoModInfraction == null) {
 					errors.push(`Could not check if the toast breaks automod rules. ${modalSubmission.client.user} may not have the Manage Server permission required to check the automod rules.`);
@@ -46,8 +46,8 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 					errors.push("The bounty's new title or description would trip this server's AutoMod.");
 				}
 
-				const startTimestamp = parseInt(modalSubmission.fields.getTextInputValue("startTimestamp"));
-				const endTimestamp = parseInt(modalSubmission.fields.getTextInputValue("endTimestamp"));
+				const startTimestamp = parseInt(modalSubmission.fields.getTextInputValue(inputIds.startTimestamp));
+				const endTimestamp = parseInt(modalSubmission.fields.getTextInputValue(inputIds.endTimestamp));
 				if (startTimestamp || endTimestamp) {
 					errors.push(...validateScheduledEventTimestamps(startTimestamp, endTimestamp));
 				}
@@ -65,7 +65,7 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 
 				updatePayload.description = description;
 
-				const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles("image");
+				const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles(inputIds.image);
 				if (imageAttachmentCollection) {
 					const firstAttachment = imageAttachmentCollection.first();
 					if (firstAttachment) {

--- a/source/frontend/commands/bounty/post.js
+++ b/source/frontend/commands/bounty/post.js
@@ -74,15 +74,15 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 								.setMaxLength(EmbedLimits.MaximumTitleLength)
 						),
 					new LabelBuilder().setLabel("Description")
-						.setDescription("A detailed description of the bounty. Leave empty to clear.")
+						.setDescription("A detailed description of the bounty.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(descriptionId)
 								.setRequired(false)
 								.setStyle(TextInputStyle.Paragraph)
-								.setPlaceholder("Get a 1 XP bonus on completion for the following: description, image URL, timestamps")
+								.setPlaceholder("Get a 1 XP bonus on completion for the following: description, image, timestamps")
 						),
 					new LabelBuilder().setLabel("Event Start")
-						.setDescription("The Unix Timestamp for the start time. Leave empty to clear.")
+						.setDescription("The Unix Timestamp for the start time.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(startTimestampId)
 								.setRequired(false)
@@ -90,7 +90,7 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 								.setPlaceholder("Required if making an event with the bounty")
 						),
 					new LabelBuilder().setLabel("Event End")
-						.setDescription("The Unix Timestamp for the end time. Leave empty to clear.")
+						.setDescription("The Unix Timestamp for the end time.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(endTimestampId)
 								.setRequired(false)
@@ -98,7 +98,7 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 								.setPlaceholder("Required if making an event with the bounty")
 						),
 					new LabelBuilder().setLabel("Image")
-						.setDescription("A diagram or splash image for the bounty. Reupload to keep.")
+						.setDescription("A diagram or splash image for the bounty.")
 						.setFileUploadComponent(
 							new FileUploadBuilder().setCustomId(imageId)
 								.setRequired(false)

--- a/source/frontend/commands/bounty/post.js
+++ b/source/frontend/commands/bounty/post.js
@@ -70,24 +70,27 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(titleId)
 								.setStyle(TextInputStyle.Short)
-								.setPlaceholder("Discord markdown allowed...")
+								.setPlaceholder("Most Discord markdown allowed...")
 								.setMaxLength(EmbedLimits.MaximumTitleLength)
 						),
 					new LabelBuilder().setLabel("Description")
+						.setDescription("A detailed description of the bounty. Leave empty to clear.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(descriptionId)
 								.setRequired(false)
 								.setStyle(TextInputStyle.Paragraph)
 								.setPlaceholder("Get a 1 XP bonus on completion for the following: description, image URL, timestamps")
 						),
-					new LabelBuilder().setLabel("Event Start (Unix Timestamp)")
+					new LabelBuilder().setLabel("Event Start")
+						.setDescription("The Unix Timestamp for the start time. Leave empty to clear.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(startTimestampId)
 								.setRequired(false)
 								.setStyle(TextInputStyle.Short)
 								.setPlaceholder("Required if making an event with the bounty")
 						),
-					new LabelBuilder().setLabel("Event End (Unix Timestamp)")
+					new LabelBuilder().setLabel("Event End")
+						.setDescription("The Unix Timestamp for the end time. Leave empty to clear.")
 						.setTextInputComponent(
 							new TextInputBuilder().setCustomId(endTimestampId)
 								.setRequired(false)
@@ -95,6 +98,7 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 								.setPlaceholder("Required if making an event with the bounty")
 						),
 					new LabelBuilder().setLabel("Image")
+						.setDescription("A diagram or splash image for the bounty. Reupload to keep.")
 						.setFileUploadComponent(
 							new FileUploadBuilder().setCustomId(imageId)
 								.setRequired(false)

--- a/source/frontend/commands/evergreen/edit.js
+++ b/source/frontend/commands/evergreen/edit.js
@@ -32,12 +32,12 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 				return;
 			}
 
-			const { modal, submissionOptions } = editBountyModalAndSubmissionOptions(selectedBounty, await selectedBounty.get(collectedInteraction.guild.scheduledEvents), true, collectedInteraction.id);
+			const { modal, inputIds, submissionOptions } = editBountyModalAndSubmissionOptions(selectedBounty, await selectedBounty.get(collectedInteraction.guild.scheduledEvents), true, collectedInteraction.id);
 			collectedInteraction.showModal(modal);
 			return interaction.awaitModalSubmit(submissionOptions).then(async modalSubmission => {
 				interaction.deleteReply();
-				const title = modalSubmission.fields.getTextInputValue("title");
-				const description = modalSubmission.fields.getTextInputValue("description");
+				const title = modalSubmission.fields.getTextInputValue(inputIds.title);
+				const description = modalSubmission.fields.getTextInputValue(inputIds.description);
 
 				const errors = [];
 				const autoModInfraction = await textsHaveAutoModInfraction(modalSubmission.channel, modalSubmission.member, [title, description], "evergreen edit");
@@ -59,7 +59,7 @@ module.exports = new SubcommandWrapper("edit", "Change the name, description, or
 
 				updatePayload.description = description;
 
-				const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles("image");
+				const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles(inputIds.image);
 				if (imageAttachmentCollection) {
 					const firstAttachment = imageAttachmentCollection.first();
 					if (firstAttachment) {

--- a/source/frontend/commands/evergreen/post.js
+++ b/source/frontend/commands/evergreen/post.js
@@ -32,16 +32,18 @@ module.exports = new SubcommandWrapper("post", `Post an evergreen bounty, limit 
 					.setTextInputComponent(
 						new TextInputBuilder().setCustomId(labelIdTitle)
 							.setStyle(TextInputStyle.Short)
-							.setPlaceholder("Discord markdown allowed...")
+							.setPlaceholder("Most Discord markdown allowed...")
 							.setMaxLength(EmbedLimits.MaximumTitleLength)
 					),
 				new LabelBuilder().setLabel("Description")
+					.setDescription("A detailed description of the bounty. Leave empty to clear.")
 					.setTextInputComponent(
 						new TextInputBuilder().setCustomId(labelIdDescription)
 							.setStyle(TextInputStyle.Paragraph)
 							.setPlaceholder("Bounties with clear instructions are easier to complete...")
 					),
 				new LabelBuilder().setLabel("Image")
+					.setDescription("A diagram or splash image for the bounty. Reupload to keep.")
 					.setFileUploadComponent(
 						new FileUploadBuilder().setCustomId(labelIdImage)
 							.setRequired(false)

--- a/source/frontend/commands/evergreen/post.js
+++ b/source/frontend/commands/evergreen/post.js
@@ -36,14 +36,14 @@ module.exports = new SubcommandWrapper("post", `Post an evergreen bounty, limit 
 							.setMaxLength(EmbedLimits.MaximumTitleLength)
 					),
 				new LabelBuilder().setLabel("Description")
-					.setDescription("A detailed description of the bounty. Leave empty to clear.")
+					.setDescription("A detailed description of the bounty.")
 					.setTextInputComponent(
 						new TextInputBuilder().setCustomId(labelIdDescription)
 							.setStyle(TextInputStyle.Paragraph)
 							.setPlaceholder("Bounties with clear instructions are easier to complete...")
 					),
 				new LabelBuilder().setLabel("Image")
-					.setDescription("A diagram or splash image for the bounty. Reupload to keep.")
+					.setDescription("A diagram or splash image for the bounty.")
 					.setFileUploadComponent(
 						new FileUploadBuilder().setCustomId(labelIdImage)
 							.setRequired(false)

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -267,13 +267,13 @@ module.exports = new SelectWrapper(mainId, 3000,
 				}
 			} break;
 			case "edit": {
-				const { modal, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), false, interaction.id);
+				const { modal, inputIds, submissionOptions } = editBountyModalAndSubmissionOptions(bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), false, interaction.id);
 				interaction.showModal(modal).then(() => interaction.awaitModalSubmit(submissionOptions)).then(async modalSubmission => {
 					await bounty.reload();
 					const errors = [];
 
-					const title = modalSubmission.fields.getTextInputValue("title");
-					const description = modalSubmission.fields.getTextInputValue("description");
+					const title = modalSubmission.fields.getTextInputValue(inputIds.title);
+					const description = modalSubmission.fields.getTextInputValue(inputIds.description);
 					const autoModInfraction = await textsHaveAutoModInfraction(modalSubmission.channel, modalSubmission.member, [title, description], "edit bounty");
 					if (autoModInfraction == null) {
 						errors.push(`Could not check if the toast breaks automod rules. ${modalSubmission.client.user} may not have the Manage Server permission required to check the automod rules.`);
@@ -281,8 +281,8 @@ module.exports = new SelectWrapper(mainId, 3000,
 						errors.push("The bounty's new title or description would trip this server's AutoMod.");
 					}
 
-					const startTimestamp = parseInt(modalSubmission.fields.getTextInputValue("startTimestamp"));
-					const endTimestamp = parseInt(modalSubmission.fields.getTextInputValue("endTimestamp"));
+					const startTimestamp = parseInt(modalSubmission.fields.getTextInputValue(inputIds.startTimestamp));
+					const endTimestamp = parseInt(modalSubmission.fields.getTextInputValue(inputIds.endTimestamp));
 					if (startTimestamp || endTimestamp) {
 						errors.push(...validateScheduledEventTimestamps(startTimestamp, endTimestamp));
 					}
@@ -302,7 +302,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 					updatePayload.description = description;
 
-					const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles("image");
+					const imageAttachmentCollection = modalSubmission.fields.getUploadedFiles(inputIds.image);
 					if (imageAttachmentCollection) {
 						const firstAttachment = imageAttachmentCollection.first();
 						if (firstAttachment) {

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -227,7 +227,7 @@ function editBountyModalAndSubmissionOptions(bounty, bountyScheduledEvent, isEve
 					new TextInputBuilder().setCustomId("description")
 						.setRequired(false)
 						.setStyle(TextInputStyle.Paragraph)
-						.setPlaceholder(isEvergreen ? "Bounties with clear instructions are easier to complete..." : "Get a 1 XP bonus on completion for the following: description, image URL, timestamps")
+						.setPlaceholder(isEvergreen ? "Bounties with clear instructions are easier to complete..." : "Get a 1 XP bonus on completion for the following: description, image, timestamps")
 						.setValue(bounty.description ?? "")
 				),
 			new LabelBuilder().setLabel("Image")

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -205,6 +205,11 @@ function selectOptionsFromRanks(ranks, allGuildRoles) {
  * @param {string} key for constructing the ModalBuilder's customId uniquely
  */
 function editBountyModalAndSubmissionOptions(bounty, bountyScheduledEvent, isEvergreen, key) {
+	const inputIds = {
+		title: "title",
+		description: "description",
+		image: "image"
+	};
 	const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${SAFE_DELIMITER}${key}`)
 		.setTitle(truncateTextToLength(`Edit Bounty: ${bounty.title}`, ModalLimits.MaximumTitleCharacters))
 		.addLabelComponents(
@@ -213,10 +218,11 @@ function editBountyModalAndSubmissionOptions(bounty, bountyScheduledEvent, isEve
 					new TextInputBuilder().setCustomId("title")
 						.setRequired(false)
 						.setStyle(TextInputStyle.Short)
-						.setPlaceholder("Discord markdown allowed...")
+						.setPlaceholder("Most Discord markdown allowed...")
 						.setValue(bounty.title)
 				),
 			new LabelBuilder().setLabel("Description")
+				.setDescription("A detailed description of the bounty. Leave empty to clear.")
 				.setTextInputComponent(
 					new TextInputBuilder().setCustomId("description")
 						.setRequired(false)
@@ -225,12 +231,15 @@ function editBountyModalAndSubmissionOptions(bounty, bountyScheduledEvent, isEve
 						.setValue(bounty.description ?? "")
 				),
 			new LabelBuilder().setLabel("Image")
+				.setDescription("A diagram or splash image for the bounty. Reupload to keep.")
 				.setFileUploadComponent(
 					new FileUploadBuilder().setCustomId("image")
 						.setRequired(false)
 				)
 		);
 	if (!isEvergreen) {
+		inputIds.startTimestamp = "startTimestamp";
+		inputIds.endTimestamp = "endTimestamp";
 		const eventStartComponent = new TextInputBuilder().setCustomId("startTimestamp")
 			.setRequired(false)
 			.setStyle(TextInputStyle.Short)
@@ -245,13 +254,15 @@ function editBountyModalAndSubmissionOptions(bounty, bountyScheduledEvent, isEve
 			eventEndComponent.setValue((bountyScheduledEvent.scheduledEndTimestamp / 1000).toString());
 		}
 		modal.addLabelComponents(
-			new LabelBuilder().setLabel("Event Start (Unix Timestamp)")
+			new LabelBuilder().setLabel("Event Start")
+				.setDescription("The Unix Timestamp for the start time. Leave empty to clear.")
 				.setTextInputComponent(eventStartComponent),
-			new LabelBuilder().setLabel("Event End (Unix Timestamp)")
+			new LabelBuilder().setLabel("Event End")
+				.setDescription("The Unix Timestamp for the end time. Leave empty to clear.")
 				.setTextInputComponent(eventEndComponent)
 		)
 	}
-	return { modal, submissionOptions: { filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") } };
+	return { modal, inputIds, submissionOptions: { filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") } };
 }
 
 /** The version embed lists the following: changes in the most recent update, known issues in the most recent update, and links to support the project */


### PR DESCRIPTION
Summary
-------
- include instructions in edit modal's label descriptions instead of having a Known Issue
- editBountyModalAndSubmissionOptions returns input ids for its fields
   - startTimestamp and endTimestamp being optional on the inputIds is non-ideal because it doesn't glean the auto-complete benefits of the other ids, but this can be addressed in the future as it's likely the function will be split into separate evergreen and standard bounty versions

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] inspect edit modals to confirm acceptable UX