### PR TITLE
#552: Switch server config from taking image urls to file uploads

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 ### Premium Features
 - Added premium commands `/festival start-gp` and `/festival close-gp` for toggling times where gp contributions are multiplied (old festival commands renamed to `/festival start-xp` and `/festival close-xp`)
 - Added the `nickname` option to `/config-premium` to allow bot managers to set a nickname for BountyBot that won't get cleared by toggling festivals on or off
+- Split premium configuration of thumbnails used for certain actions out of `/config-premium` into two new commands: `/config-server-thumbnails-premium` and `/config-user-thumbnails-premium`. These new commands use the newer image upload UI in modals for easier file selection.
 ### Other Changes
 - The completing a bounty via the select in the bounty board can now add turn-ins like the slash command
 - Fixed Goal Point contributions not showing up in reward messages

--- a/source/frontend/commands/_commandDictionary.js
+++ b/source/frontend/commands/_commandDictionary.js
@@ -6,6 +6,8 @@ exports.commandFiles = [
 	"bounty",
 	"commands.js",
 	"config-premium.js",
+	"config-server-thumbnails-premium.js",
+	"config-user-thumbnails-premium.js",
 	"config-server.js",
 	"create-default",
 	"data-policy.js",

--- a/source/frontend/commands/config-premium.js
+++ b/source/frontend/commands/config-premium.js
@@ -44,83 +44,6 @@ module.exports = new CommandWrapper(mainId, "Configure premium BountyBot setting
 			}
 		}
 
-		const toastThumbnailURL = interaction.options.getString("toast-thumbnail-url");
-		if (toastThumbnailURL) {
-			try {
-				new URL(toastThumbnailURL);
-				updatePayload.toastThumbnailURL = toastThumbnailURL;
-				content += `\n- The toast thumbnail was set to <${toastThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const openBountyThumbnailURL = interaction.options.getString("open-bounty-thumbnail-url");
-		if (openBountyThumbnailURL) {
-			try {
-				new URL(openBountyThumbnailURL);
-				updatePayload.openBountyThumbnailURL = openBountyThumbnailURL;
-				content += `\n- The open bounty thumbnail was set to <${openBountyThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const completedBountyThumbnailURL = interaction.options.getString("completed-bounty-thumbnail-url");
-		if (completedBountyThumbnailURL) {
-			try {
-				new URL(completedBountyThumbnailURL);
-				updatePayload.completedBountyThumbnailURL = completedBountyThumbnailURL;
-				content += `\n- The completed bounty thumbnail was set to <${completedBountyThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const deletedBountyThumbnailURL = interaction.options.getString("deleted-bounty-thumbnail-url");
-		if (deletedBountyThumbnailURL) {
-			try {
-				new URL(deletedBountyThumbnailURL);
-				updatePayload.deletedBountyThumbnailURL = deletedBountyThumbnailURL;
-				content += `\n- The deleted bounty thumbnail was set to <${deletedBountyThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const scoreboardThumbnailURL = interaction.options.getString("scoreboard-thumbnail-url");
-		if (scoreboardThumbnailURL) {
-			try {
-				new URL(scoreboardThumbnailURL);
-				updatePayload.scoreboardThumbnailURL = scoreboardThumbnailURL;
-				content += `\n- The scoreboard thumbnail was set to <${scoreboardThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const goalCompletionThumbnailURL = interaction.options.getString("goal-completion-thumbnail-url");
-		if (goalCompletionThumbnailURL) {
-			try {
-				new URL(goalCompletionThumbnailURL);
-				updatePayload.goalCompletionThumbnailURL = goalCompletionThumbnailURL;
-				content += `\n- The server bonuses thumbnail was set to <${goalCompletionThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
-		const raffleThumbnailURL = interaction.options.getString("raffle-thumbnail-url");
-		if (raffleThumbnailURL) {
-			try {
-				new URL(raffleThumbnailURL);
-				updatePayload.raffleThumbnailURL = raffleThumbnailURL;
-				content += `\n- The server bonuses thumbnail was set to <${raffleThumbnailURL}>.`;
-			} catch (error) {
-				errors.push(error.message);
-			}
-		}
-
 		origin.company.update(updatePayload);
 		if (errors.length > 0) {
 			content += `\n\nThe following errors were encountered:\n${unorderedList(errors)}`;
@@ -144,48 +67,6 @@ module.exports = new CommandWrapper(mainId, "Configure premium BountyBot setting
 		type: "Integer",
 		name: "bounty-slots",
 		description: `Configure the max number (between 1 and ${GLOBAL_MAX_BOUNTY_SLOTS}) of bounty slots hunters can have (default 5)`,
-		required: false
-	},
-	{
-		type: "String",
-		name: "toast-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail on toasts",
-		required: false
-	},
-	{
-		type: "String",
-		name: "open-bounty-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail on open bounties",
-		required: false
-	},
-	{
-		type: "String",
-		name: "completed-bounty-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail on completed bounties",
-		required: false
-	},
-	{
-		type: "String",
-		name: "deleted-bounty-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail on deleted bounties",
-		required: false
-	},
-	{
-		type: "String",
-		name: "scoreboard-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail on the scoreboard",
-		required: false
-	},
-	{
-		type: "String",
-		name: "goal-completion-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail in server goal completion messages",
-		required: false
-	},
-	{
-		type: "String",
-		name: "raffle-thumbnail-url",
-		description: "Set a url pointing to an image to use as thumbnail in raffle winner messages",
 		required: false
 	}
 );

--- a/source/frontend/commands/config-server-thumbnails-premium.js
+++ b/source/frontend/commands/config-server-thumbnails-premium.js
@@ -1,0 +1,61 @@
+const { InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
+const { SKIP_INTERACTION_HANDLING } = require('../../constants');
+const { CommandWrapper } = require("../classes");
+const { timeConversion } = require('../../shared');
+
+const mainId = "config-server-thumbnails-premium";
+const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
+	"scoreboard-thumbnail": {
+		payloadProperty: "scoreboardThumbnailURL",
+		messageStub: "scoreboard thumbnail",
+		description: "Set an image to use as thumbnail on the scoreboard",
+		modalLabel: "Scoreboard Thumbnail"
+	},
+	"goal-completion-thumbnail": {
+		payloadProperty: "goalCompletionThumbnailURL",
+		messageStub: "goal completion thumbnail",
+		description: "Set an image to use as thumbnail in server goal completion messages",
+		modalLabel: "Goal Completion Thumbnail"
+	},
+	"raffle-thumbnail": {
+		payloadProperty: "raffleThumbnailURL",
+		messageStub: "raffle thumbnail",
+		description: "Set an image to use as thumbnail in raffle winner messages",
+		modalLabel: "Raffle Thumbnail"
+	}
+}));
+module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for BountyBot on this server", null, true, [InteractionContextType.Guild], 3000,
+	async (interaction, origin, runMode) => {
+		const modalLabelComponents = [];
+		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
+			const { description, modalLabel } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
+				.setFileUploadComponent(
+					new FileUploadBuilder().setCustomId(imageField)
+						.setRequired(false)
+				))
+		}
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`).setTitle("Configure Server Thumbnails").addLabelComponents(modalLabelComponents);
+		
+		interaction.showModal(modal);
+		const modalInteraction = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") });
+		const updatePayload = {};
+
+		let replyContent = "The following thumbnails have been configured:";
+
+		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
+			const { payloadProperty, messageStub } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
+			if (thumbnailCollection) {
+				const firstAttachment = thumbnailCollection.first();
+				if (firstAttachment) {
+					updatePayload[payloadProperty] = firstAttachment.url;
+					replyContent += `\n- The ${messageStub} was set to <${firstAttachment.url}>.`;
+				}
+			}
+		}
+
+		origin.company.update(updatePayload);
+		modalInteraction.reply({ content: replyContent, flags: MessageFlags.Ephemeral });
+	}
+);

--- a/source/frontend/commands/config-server-thumbnails-premium.js
+++ b/source/frontend/commands/config-server-thumbnails-premium.js
@@ -1,4 +1,4 @@
-const { InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
+const { PermissionFlagsBits, InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
 const { CommandWrapper } = require("../classes");
 const { timeConversion } = require('../../shared');
@@ -24,11 +24,10 @@ const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
 		modalLabel: "Raffle Thumbnail"
 	}
 }));
-module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for BountyBot on this server", null, true, [InteractionContextType.Guild], 3000,
+module.exports = new CommandWrapper(mainId, "Configure thumbnails for server messages (Premium)", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	async (interaction, origin, runMode) => {
 		const modalLabelComponents = [];
-		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
-			const { description, modalLabel } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+		for (const [ imageField, { description, modalLabel }  ] of imageFieldToPayloadPropertyAndMessage.keys()) {
 			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
 				.setFileUploadComponent(
 					new FileUploadBuilder().setCustomId(imageField)
@@ -43,8 +42,7 @@ module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for Bo
 
 		let replyContent = "The following thumbnails have been configured:";
 
-		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
-			const { payloadProperty, messageStub } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+		for (const [ imageField, { payloadProperty, messageStub } ] of imageFieldToPayloadPropertyAndMessage.keys()) {
 			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
 			if (thumbnailCollection) {
 				const firstAttachment = thumbnailCollection.first();

--- a/source/frontend/commands/config-user-thumbnails-premium.js
+++ b/source/frontend/commands/config-user-thumbnails-premium.js
@@ -1,0 +1,67 @@
+const { InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
+const { SKIP_INTERACTION_HANDLING } = require('../../constants');
+const { CommandWrapper } = require("../classes");
+const { timeConversion } = require('../../shared');
+
+const mainId = "config-user-thumbnails-premium";
+const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
+	"toast-thumbnail": {
+		payloadProperty: "toastThumbnailURL",
+		messageStub: "toast thumbnail",
+		description: "Set an image to use as thumbnail on toasts",
+		modalLabel: "Toast Thumbnail"
+	},
+	"open-bounty-thumbnail": {
+		payloadProperty: "openBountyThumbnailURL",
+		messageStub: "open bounty thumbnail",
+		description: "Set an image to use as thumbnail on open bounties",
+		modalLabel: "Open Bounty Thumbnail"
+	},
+	"completed-bounty-thumbnail": {
+		payloadProperty: "completedBountyThumbnailURL",
+		messageStub: "completed bounty thumbnail",
+		description: "Set an image to use as thumbnail on completed bounties",
+		modalLabel: "Completed Bounty Thumbnail"
+	},
+	"deleted-bounty-thumbnail": {
+		payloadProperty: "deletedBountyThumbnailURL",
+		messageStub: "deleted bounty thumbnail",
+		description: "Set an image to use as thumbnail on deleted bounties",
+		modalLabel: "Deleted Bounty Thumbnail"
+	}
+}));
+module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for BountyBot on this server", null, true, [InteractionContextType.Guild], 3000,
+	async (interaction, origin, runMode) => {
+		const modalLabelComponents = [];
+		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
+			const { description, modalLabel } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
+				.setFileUploadComponent(
+					new FileUploadBuilder().setCustomId(imageField)
+						.setRequired(false)
+				))
+		}
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`).setTitle("Configure User Thumnbails").addLabelComponents(modalLabelComponents);
+		
+		interaction.showModal(modal);
+		const modalInteraction = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") });
+		const updatePayload = {};
+
+		let replyContent = "The following thumbnails have been configured:";
+
+		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
+			const { payloadProperty, messageStub } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
+			if (thumbnailCollection) {
+				const firstAttachment = thumbnailCollection.first();
+				if (firstAttachment) {
+					updatePayload[payloadProperty] = firstAttachment.url;
+					replyContent += `\n- The ${messageStub} was set to <${firstAttachment.url}>.`;
+				}
+			}
+		}
+
+		origin.company.update(updatePayload);
+		modalInteraction.reply({ content: replyContent, flags: MessageFlags.Ephemeral });
+	}
+);

--- a/source/frontend/commands/config-user-thumbnails-premium.js
+++ b/source/frontend/commands/config-user-thumbnails-premium.js
@@ -1,4 +1,4 @@
-const { InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
+const { PermissionFlagsBits, InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
 const { CommandWrapper } = require("../classes");
 const { timeConversion } = require('../../shared');
@@ -30,11 +30,10 @@ const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
 		modalLabel: "Deleted Bounty Thumbnail"
 	}
 }));
-module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for BountyBot on this server", null, true, [InteractionContextType.Guild], 3000,
+module.exports = new CommandWrapper(mainId, "Configure thumbnails shown for Toasts and Bounties (Premium)", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	async (interaction, origin, runMode) => {
 		const modalLabelComponents = [];
-		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
-			const { description, modalLabel } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+		for (const [ imageField, { description, modalLabel } ] of imageFieldToPayloadPropertyAndMessage) {
 			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
 				.setFileUploadComponent(
 					new FileUploadBuilder().setCustomId(imageField)
@@ -49,8 +48,7 @@ module.exports = new CommandWrapper(mainId, "Configure premium thumbnails for Bo
 
 		let replyContent = "The following thumbnails have been configured:";
 
-		for (const imageField of imageFieldToPayloadPropertyAndMessage.keys()) {
-			const { payloadProperty, messageStub } = imageFieldToPayloadPropertyAndMessage.get(imageField);
+		for (const [ imageField, { payloadProperty, messageStub } ] of imageFieldToPayloadPropertyAndMessage) {
 			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
 			if (thumbnailCollection) {
 				const firstAttachment = thumbnailCollection.first();


### PR DESCRIPTION
Summary
-------
- Added two new commands, since there are enough thumbnail configurations to need to be split across two modals

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] Old command now only has the 3 relevant inputs
- [X] New commands show modals with appropriate dialogue
- [X] New modals complete successfully with feedback
- [X] Side effects from new modal submissions are visible

Issue
-----
Closes #552
