### PR TITLE
Edit fixes for Select Menu Option:

### DIFF
--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -293,7 +293,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 						return;
 					}
 
-					await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
+					await unarchiveAndUnlockThread(modalSubmission.channel, "Unarchived to update posting");
 					const updatePayload = { editCount: bounty.editCount + 1 };
 					if (title) {
 						updatePayload.title = title;
@@ -306,7 +306,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					if (imageAttachmentCollection) {
 						const firstAttachment = imageAttachmentCollection.first();
 						if (firstAttachment) {
-							updatePayload.attachmentURL = imageAttachmentCollection;
+							updatePayload.attachmentURL = firstAttachment.url;
 						} else {
 							updatePayload.attachmentURL = null;
 						}


### PR DESCRIPTION
Summary
-------
- Using the correct reference for unlocking the related thread
- Fetching the proper URL for attachments

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] Users can edit bounties using the select menu option on the bounty (with thumbnails)

Issue
-----
Closes #?
