### PR TITLE
early out if no evergreen bounties in refreshEvergreenBountiesThread

### DIFF
--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -39,6 +39,10 @@ function makeEvergreenBountiesThread(threadManager, embeds, company) {
  * @param {Record<string, Set<string>>} hunterIdMap
  */
 async function refreshEvergreenBountiesThread(bountyBoardChannel, evergreenBounties, company, companyLevel, bountyBotGuildMember, hunterIdMap) {
+	if (evergreenBounties.length < 1) {
+		return;
+	}
+
 	const embeds = evergreenBounties.sort(ascendingByProperty("slotNumber")).map(bounty => bountyEmbed(bounty, bountyBotGuildMember, companyLevel, false, company, hunterIdMap[bounty.id]));
 	if (company.evergreenThreadId) {
 		return bountyBoardChannel.threads.fetch(company.evergreenThreadId).then(async thread => {


### PR DESCRIPTION
Summary
-------
- early out if no evergreen bounties in refreshEvergreenBountiesThread

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] bot doesn't crash if trying to update evergreen bounty thread with no evergreen bounties