### PR TITLE
fix evergreen bounty embeds showing "Pending Turn-Ins" instead of "Turned-In By"

### DIFF
--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -518,7 +518,7 @@ function bountyEmbed(bounty, posterGuildMember, posterLevel, shouldOmitRewardsFi
 	}
 	if (hunterIdSet.size > 0) {
 		const completersFieldText = sentenceListEN(Array.from(hunterIdSet.values().map(id => userMention(id))));
-		const turnInFieldName = bounty.state === "open" ? "Pending Turn-Ins:" : "Turned-In By:";
+		const turnInFieldName = !bounty.isEvergreen && bounty.state === "open" ? "Pending Turn-Ins:" : "Turned-In By:";
 		if (completersFieldText.length <= EmbedLimits.MaximumFieldValueLength) {
 			fields.push({ name: turnInFieldName, value: completersFieldText });
 		} else {


### PR DESCRIPTION
Summary
-------
- fix evergreen bounty embeds showing "Pending Turn-Ins" instead of "Turned-In By"

Also checked on the suspicious reward message for reaching Level 2 "The base reward of your even-numbered bounty slots has increased (max: 2 Reward XP in Slot #2)!". This turned out to be correctly describing the internal state, despite the lack of usefulness for the end user. Made an issue #644 to address that.

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/evergreen complete` shows an embed correct completers field title