### PR TITLE
Overall Scoreboard Ordering Bug Fix

### DIFF
--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -385,18 +385,17 @@ async function seasonalScoreboardEmbed(company, guild, participationMap, ranks, 
  * @param {Company} company
  * @param {Guild} guild
  * @param {Map<string, Hunter>} hunterMap
- * @param {Rank[]} ranks
  * @param {{ currentGP: number; requiredGP: number; }} goalProgress
  */
 async function overallScoreboardEmbed(company, guild, hunterMap, goalProgress) {
 	const hunterMembers = await guild.members.fetch({ user: Array.from(hunterMap.keys()) });
 
 	const scorelines = [];
-	for (const guildMember of Array.from(hunterMembers.values()).sort(descendingByProperty("xp"))) {
-		const hunter = hunterMap.get(guildMember.id);
+	for (const hunter of Array.from(hunterMap.values()).sort(descendingByProperty("xp"))) {
 		if (hunter?.xp < 1) {
 			break;
 		}
+		const guildMember = hunterMembers.get(hunter.userId);
 		scorelines.push(`${bold(guildMember.displayName)} ${underline(`Level ${hunter.getLevel(company.xpCoefficient)}`)} ${italic(`${hunter.xp} XP`)}`);
 	}
 	const embed = new EmbedBuilder().setColor(Colors.Blurple)


### PR DESCRIPTION
Summary
-------
- Removed unneeded JSDoc parameter
- Changed the initial scoreboard line loop to iterate over the hunter map in order to fetch by XP order
- Changed the internal member access to fetch from the guild collection instead of the hunter map
- Moved the guild member fetch to after the early out

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] Overall scoreboard now lists in descending experience order

Issue
-----
Closes #?
