### PR TITLE
Season Scoreboard null rankmoji fix

### DIFF
--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -333,7 +333,7 @@ async function seasonalScoreboardEmbed(company, guild, participationMap, ranks, 
 	const scorelines = [];
 	for (const [id, participation] of Array.from(participationMap.entries()).sort((a, b) => b[1].xp - a[1].xp)) {
 		if (participation.xp > 0 && hunterMembers.has(id)) {
-			scorelines.push(`${!(participation.rankIndex === null || participation.isRankDisqualified) ? `${rankmojiArray[participation.rankIndex]} ` : ""}#${participation.placement} **${hunterMembers.get(id).displayName}** ${participation.xp} season XP`);
+			scorelines.push(`${!(participation.rankIndex === null || participation.isRankDisqualified) && rankmojiArray[participation.rankIndex] ? `${rankmojiArray[participation.rankIndex]} ` : ""}#${participation.placement} **${hunterMembers.get(id).displayName}** ${participation.xp} season XP`);
 		}
 	}
 	const embed = new EmbedBuilder().setColor(Colors.Blurple)


### PR DESCRIPTION


Summary
-------
- Added null check

Local Tests Performed
---------------------
- [X] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [X] Season scoreboard no longer has "null" beginnings if no rankmoji are applied to the given rank

Issue
-----
Closes #?
