### PR TITLE
fix crashes on posting bounty with scheduled event

### DIFF
--- a/source/frontend/commands/bounty/post.js
+++ b/source/frontend/commands/bounty/post.js
@@ -166,7 +166,7 @@ module.exports = new SubcommandWrapper("post", "Post your own bounty (+1 XP)",
 
 				let event = null;
 				if (startTimestamp && endTimestamp) {
-					const eventPayload = bountyScheduledEventPayload(title, modalSubmission.member.displayName, bounty.slotNumber, description, rawBounty.attachmentURL, startTimestamp, endTimestamp);
+					const eventPayload = bountyScheduledEventPayload(title, modalSubmission.member.displayName, rawBounty.slotNumber, description, rawBounty.attachmentURL, startTimestamp, endTimestamp);
 					event = await modalSubmission.guild.scheduledEvents.create(eventPayload);
 					rawBounty.scheduledEventId = event.id;
 				}

--- a/source/frontend/shared/validations.js
+++ b/source/frontend/shared/validations.js
@@ -1,5 +1,6 @@
 const { AutoModerationActionType, GuildMember, TextChannel } = require("discord.js");
 const { butIgnoreMissingPermissionErrors, butIgnoreCantDirectMessageThisUserErrors } = require("./dAPIResponses");
+const { YEAR_IN_MS } = require("../../constants");
 
 /** @file Validations - Checks for issues with user input data */
 


### PR DESCRIPTION
Summary
-------
- fix missing import
- fix incorrect variable used in creating scheduled event for bounty

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty post` with timestamps correctly makes scheduled event