### PR TITLE
#564: add `/bounty ping` command and control panel option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # BountyBot Change Log
+## BountyBot Version 2.12.0fi:
+- Added command `/bounty ping` to mention bounty hunters who have reacted to the bounty's thread or marked themselves interested in the bounty's event
 ## BountyBot Version 2.11.0fib:
 ### Reaction Toasts
 - Bounty Hunters can now raise a messageless toast by reacting to another Bounty Hunter's discord message with 🥂

--- a/source/frontend/commands/bounty/index.js
+++ b/source/frontend/commands/bounty/index.js
@@ -10,6 +10,7 @@ const { slashData: subcommandSlashData, executeDictionary: subcommandExecuteDict
 	"complete.js",
 	"edit.js",
 	"list.js",
+	"ping.js",
 	"post.js",
 	"record-turn-ins.js",
 	"revoke-turn-ins.js",

--- a/source/frontend/commands/bounty/ping.js
+++ b/source/frontend/commands/bounty/ping.js
@@ -1,4 +1,4 @@
-const { ModalBuilder, UserSelectMenuBuilder, TextInputBuilder, StringSelectMenuBuilder, LabelBuilder, TextInputStyle } = require("discord.js");
+const { ModalBuilder, UserSelectMenuBuilder, TextInputBuilder, StringSelectMenuBuilder, LabelBuilder, TextInputStyle, MessageFlags } = require("discord.js");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { SubcommandWrapper } = require("../../classes");
 const { bountyPing } = require("../../shared/flows/bountyPing");
@@ -7,6 +7,12 @@ const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reacted to your bounty's thread or event",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
+		const openBounties = await logicLayer.bounties.findOpenBounties(origin.user.id, origin.company.id);
+		if (openBounties.length < 1) {
+			interaction.reply({ content: "You don't have any open bounties on this server.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
 		const labelIdBountyId = "bounty-id";
 		const labelIdMessage = "message";
 		const labelIdExcludedBountyHunters = "bounty-hunters";
@@ -18,7 +24,7 @@ module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reac
 					.setStringSelectMenuComponent(
 						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
 							.setPlaceholder("Select a bounty...")
-							.setOptions(selectOptionsFromBounties(await logicLayer.bounties.findOpenBounties(origin.user.id, origin.company.id)))
+							.setOptions(selectOptionsFromBounties(openBounties))
 					),
 				new LabelBuilder().setLabel("Message")
 					.setTextInputComponent(
@@ -47,6 +53,14 @@ module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reac
 			return;
 		}
 
-		bountyPing(logicLayer, modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, origin.company.bountyBoardId);
+		let bountyThread;
+		if (origin.company.bountyBoardId && bounty.postingId) {
+			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
+			if (bountyBoard) {
+				bountyThread = await bountyBoard.threads.fetch(bounty.postingId);
+			}
+		}
+
+		bountyPing(modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, bountyThread);
 	}
 );

--- a/source/frontend/commands/bounty/ping.js
+++ b/source/frontend/commands/bounty/ping.js
@@ -1,0 +1,52 @@
+const { ModalBuilder, UserSelectMenuBuilder, TextInputBuilder, StringSelectMenuBuilder, LabelBuilder, TextInputStyle } = require("discord.js");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { SubcommandWrapper } = require("../../classes");
+const { bountyPing } = require("../../shared/flows/bountyPing");
+const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { timeConversion } = require("../../../shared");
+
+module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reacted to your bounty's thread or event",
+	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
+		const labelIdBountyId = "bounty-id";
+		const labelIdMessage = "message";
+		const labelIdExcludedBountyHunters = "bounty-hunters";
+		const maxHunters = 10;
+		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+			.setTitle("Ping Interested Bounty Hunters")
+			.addLabelComponents(
+				new LabelBuilder().setLabel("Bounty")
+					.setStringSelectMenuComponent(
+						new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+							.setPlaceholder("Select a bounty...")
+							.setOptions(selectOptionsFromBounties(await logicLayer.bounties.findOpenBounties(origin.user.id, origin.company.id)))
+					),
+				new LabelBuilder().setLabel("Message")
+					.setTextInputComponent(
+						new TextInputBuilder().setCustomId(labelIdMessage)
+							.setStyle(TextInputStyle.Short)
+							.setPlaceholder("Add a message to go with the ping...")
+					),
+				new LabelBuilder().setLabel("Hunters to Exclude")
+					.setUserSelectMenuComponent(
+						new UserSelectMenuBuilder().setCustomId(labelIdExcludedBountyHunters)
+							.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+							.setMaxValues(maxHunters)
+							.setRequired(false)
+					)
+			);
+		await interaction.showModal(modal);
+		const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+			.catch(butIgnoreInteractionCollectorErrors);
+		if (!modalSubmission) {
+			return;
+		}
+
+		const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+		if (!bounty || bounty.state !== "open") {
+			modalSubmission.reply({ content: "Your selected bounty could not be found.", flags: MessageFlags.Ephemeral });
+			return;
+		}
+
+		bountyPing(logicLayer, modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, origin.company.bountyBoardId);
+	}
+);

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -1,10 +1,11 @@
-const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, userMention, ChannelSelectMenuBuilder, ChannelType, PermissionFlagsBits, ButtonBuilder, StringSelectMenuBuilder, bold, ButtonStyle, TimestampStyles, ModalBuilder, LabelBuilder, TextDisplayBuilder } = require('discord.js');
+const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, userMention, ChannelSelectMenuBuilder, ChannelType, PermissionFlagsBits, ButtonBuilder, StringSelectMenuBuilder, bold, ButtonStyle, TimestampStyles, ModalBuilder, LabelBuilder, TextDisplayBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
 const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
+const { bountyPing } = require('../shared/flows/bountyPing');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -23,7 +24,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		switch (interaction.values[0]) {
+		switch (interaction.values[0]) { //TODONOW add ping
 			case "nochange":
 				/* Discord Selects keep their selection after resolving. If a user wants to use the same command
 				   twice in a row but doesn't want other changes to be applied (like to fix a typo in a previous
@@ -161,6 +162,42 @@ module.exports = new SelectWrapper(mainId, 3000,
 				modalSubmission.reply({ content: `Your bounty ${bold(bounty.title)} was showcased in ${channel} and its reward was increased!`, flags: MessageFlags.Ephemeral });
 				interaction.message.edit({ embeds: updatedEmbeds })
 			} break;
+			case "ping":
+				const labelIdMessage = "message";
+				const labelIdExcludedBountyHunters = "bounty-hunters";
+				const maxHunters = 10;
+				const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+					.setTitle("Ping Interested Bounty Hunters")
+					.addLabelComponents(
+						new LabelBuilder().setLabel("Message")
+							.setTextInputComponent(
+								new TextInputBuilder().setCustomId(labelIdMessage)
+									.setStyle(TextInputStyle.Short)
+									.setPlaceholder("Add a message to go with the ping...")
+							),
+						new LabelBuilder().setLabel("Hunters to Exclude")
+							.setUserSelectMenuComponent(
+								new UserSelectMenuBuilder().setCustomId(labelIdExcludedBountyHunters)
+									.setPlaceholder(`Select up to ${maxHunters} bounty hunters...`)
+									.setMaxValues(maxHunters)
+									.setRequired(false)
+							)
+					);
+				await interaction.showModal(modal);
+				const modalSubmission = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") })
+					.catch(butIgnoreInteractionCollectorErrors);
+				if (!modalSubmission) {
+					return;
+				}
+
+				bounty = await logicLayer.bounties.findBounty(bountyId);
+				if (!bounty || bounty.state !== "open") {
+					modalSubmission.reply({ content: "Your selected bounty could not be found.", flags: MessageFlags.Ephemeral });
+					return;
+				}
+
+				bountyPing(logicLayer, modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, origin.company.bountyBoardId, interaction.channel);
+				break;
 			case "complete": {
 				// disallow completion within 5 minutes of creating bounty
 				if (runMode === "production" && new Date() < new Date(new Date(bounty.createdAt) + timeConversion(5, "m", "ms"))) {

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -24,7 +24,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 			return;
 		}
 
-		switch (interaction.values[0]) { //TODONOW add ping
+		switch (interaction.values[0]) {
 			case "nochange":
 				/* Discord Selects keep their selection after resolving. If a user wants to use the same command
 				   twice in a row but doesn't want other changes to be applied (like to fix a typo in a previous
@@ -196,7 +196,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				bountyPing(logicLayer, modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, origin.company.bountyBoardId, interaction.channel);
+				bountyPing(modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, interaction.channel);
 				break;
 			case "complete": {
 				// disallow completion within 5 minutes of creating bounty

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -115,6 +115,7 @@ function bountyControlPanelSelectRow(bountyId) {
 					{ emoji: "📥", label: "Record other hunters' turn-ins", description: "Confirm another hunter has turned-in this bounty", value: "recordturnin" },
 					{ emoji: "🚫", label: "Revoke other hunters' turn-ins", description: "Remove credit for turning in this bounty from another hunter", value: "revoketurnin" },
 					{ emoji: "🔝", label: "Showcase this bounty", description: "Increase the rewards on this bounty and promote it in another channel", value: "showcase" },
+					{ emoji: "🔴", label: "Ping interested bounty hunters", description: "Message and mention interested bounty hunters (reacted to bounty board thread or marked on event)", value: "ping" },
 					{ emoji: "✅", label: "Complete this bounty", description: "Distribute rewards for turn-ins and mark this bounty completed", value: "complete" },
 					{ emoji: "📝", label: "Edit this bounty", description: "Change details about this bounty", value: "edit" },
 					{ emoji: "🔄", label: "Swap this bounty to another slot", description: "Move this bounty to another slot, changing its base reward", value: "swap" },

--- a/source/frontend/shared/flows/bountyPing.js
+++ b/source/frontend/shared/flows/bountyPing.js
@@ -1,30 +1,18 @@
-const { ModalBuilder, LabelBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder, MessageFlags, TextInputBuilder, TextInputStyle, userMention, ModalSubmitInteraction } = require("discord.js");
-const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors } = require("../../shared");
-const { timeConversion } = require("../../../shared");
-const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
-const { InteractionOrigin } = require("../../classes");
+const { MessageFlags, userMention, ModalSubmitInteraction } = require("discord.js");
 const { Bounty } = require("../../../database/models");
 
 /**
- * @param {typeof import("../../../logic")} logicLayer
  * @param {ModalSubmitInteraction} modalSubmission
  * @param {{ message: string; excludedBountyHunters: string; }} labelIds
  * @param {Bounty} bounty
- * @param {string | null} bountyBoardId
  * @param {import("discord.js").ForumThreadChannel | undefined} bountyThread
  */
-async function bountyPing(logicLayer, modalSubmission, labelIds, bounty, bountyBoardId, bountyThread) {
+async function bountyPing(modalSubmission, labelIds, bounty, bountyThread) {
 	if (!bounty || bounty.state !== "open") {
 		modalSubmission.reply({ content: "Your selected bounty could not be found.", flags: MessageFlags.Ephemeral });
 		return;
 	}
 	const interestedHunterIds = new Set();
-	if (!bountyThread && bountyBoardId && bounty.postingId) {
-		const bountyBoard = await modalSubmission.guild.channels.fetch(bountyBoardId);
-		if (bountyBoard) {
-			bountyThread = await bountyBoard.threads.fetch(bounty.postingId);
-		}
-	}
 	if (bountyThread) {
 		// Using the force flag here because route through the bounty control panel didn't have reactions cached (discord.js bug?)
 		const postingMessage = await bountyThread.fetchStarterMessage({ force: true });
@@ -42,7 +30,7 @@ async function bountyPing(logicLayer, modalSubmission, labelIds, bounty, bountyB
 		const scheduledEvent = await modalSubmission.guild.scheduledEvents.fetch(bounty.scheduledEventId);
 		if (scheduledEvent) {
 			const subscribers = await scheduledEvent.fetchSubscribers();
-			for (const [id, user] of subscribers) {
+			for (const id of subscribers.keys()) {
 				interestedHunterIds.add(id);
 			}
 		}

--- a/source/frontend/shared/flows/bountyPing.js
+++ b/source/frontend/shared/flows/bountyPing.js
@@ -1,0 +1,63 @@
+const { ModalBuilder, LabelBuilder, StringSelectMenuBuilder, UserSelectMenuBuilder, MessageFlags, TextInputBuilder, TextInputStyle, userMention, ModalSubmitInteraction } = require("discord.js");
+const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { timeConversion } = require("../../../shared");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { InteractionOrigin } = require("../../classes");
+const { Bounty } = require("../../../database/models");
+
+/**
+ * @param {typeof import("../../../logic")} logicLayer
+ * @param {ModalSubmitInteraction} modalSubmission
+ * @param {{ message: string; excludedBountyHunters: string; }} labelIds
+ * @param {Bounty} bounty
+ * @param {string | null} bountyBoardId
+ * @param {import("discord.js").ForumThreadChannel | undefined} bountyThread
+ */
+async function bountyPing(logicLayer, modalSubmission, labelIds, bounty, bountyBoardId, bountyThread) {
+	if (!bounty || bounty.state !== "open") {
+		modalSubmission.reply({ content: "Your selected bounty could not be found.", flags: MessageFlags.Ephemeral });
+		return;
+	}
+	const interestedHunterIds = new Set();
+	if (!bountyThread && bountyBoardId && bounty.postingId) {
+		const bountyBoard = await modalSubmission.guild.channels.fetch(bountyBoardId);
+		if (bountyBoard) {
+			bountyThread = await bountyBoard.threads.fetch(bounty.postingId);
+		}
+	}
+	if (bountyThread) {
+		// Using the force flag here because route through the bounty control panel didn't have reactions cached (discord.js bug?)
+		const postingMessage = await bountyThread.fetchStarterMessage({ force: true });
+		if (postingMessage) {
+			const interestedReactionsManager = postingMessage.reactions.cache.get("👀");
+			if (interestedReactionsManager) {
+				for (const userSnowflake of (await interestedReactionsManager.users.fetch()).keys()) {
+					interestedHunterIds.add(userSnowflake);
+				}
+			}
+		}
+	}
+
+	if (bounty.scheduledEventId) {
+		const scheduledEvent = await modalSubmission.guild.scheduledEvents.fetch(bounty.scheduledEventId);
+		if (scheduledEvent) {
+			const subscribers = await scheduledEvent.fetchSubscribers();
+			for (const [id, user] of subscribers) {
+				interestedHunterIds.add(id);
+			}
+		}
+	}
+
+	const excludedHuntersCollection = modalSubmission.fields.getSelectedUsers(labelIds.excludedBountyHunters);
+	if (excludedHuntersCollection) {
+		for (const id of excludedHuntersCollection.keys()) {
+			interestedHunterIds.delete(id);
+		}
+	}
+
+	modalSubmission.reply({ content: `${Array.from(interestedHunterIds.values()).map(id => userMention(id))} ${modalSubmission.fields.getTextInputValue(labelIds.message)}` });
+}
+
+module.exports = {
+	bountyPing
+};


### PR DESCRIPTION
Summary
-------
- add `/bounty ping` command and control panel option

NOTE: intended for v2.12.0fi (do not merge until after v2.11.1ib ships)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty ping` mentions users that have marked interested on a bounty's event or reacted to the bounty's thread
- [x] user mentions aren't duplicated if a user has both reacted to the thread and marked interested
- [x] users marked as excluded aren't mentioned

Issue
-----
Closes #564