### PR TITLE
#655: fix `/bounty take-down` not canceling associated Scheduled Event

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # BountyBot Change Log
+## BountyBot Version 2.11.1ib:
+- Completing or taking down bounties now cancel the bounty's event if it hasn't been closed already
 ## BountyBot Version 2.11.0fib:
 ### Reaction Toasts
 - Bounty Hunters can now raise a messageless toast by reacting to another Bounty Hunter's discord message with 🥂

--- a/source/database/models/bounties/Bounty.js
+++ b/source/database/models/bounties/Bounty.js
@@ -34,12 +34,12 @@ class Bounty extends Model {
 	 * @param {GuildScheduledEventManager} guildScheduledEventManager
 	 * @returns {GuildScheduledEvent | null}
 	 */
-	async getScheduledEvent(guildScheduledEventManager) {
+	getScheduledEvent(guildScheduledEventManager) {
 		if (!this.scheduledEventId) {
 			return null;
 		}
 
-		return (await guildScheduledEventManager.fetch(this.scheduledEventId)).first();
+		return guildScheduledEventManager.fetch(this.scheduledEventId);
 	}
 }
 

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
@@ -136,6 +136,10 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 			refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
 		} else {
 			refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
+		}
+
+		if (bounty.scheduledEventId) {
+			modalSubmission.guild.scheduledEvents.delete(bounty.scheduledEventId).catch(butIgnoreErrorIf(isUnknownGuildScheduledEventError, isMissingPermissionError));
 		}
 	}
 );

--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -2,6 +2,7 @@ const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType }
 const { SubcommandWrapper } = require("../../classes");
 const { commandMention, selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors, butIgnoreUnknownChannelErrors } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { bountyTakeDown } = require("../../shared/flows/bountyTakeDown");
 
 module.exports = new SubcommandWrapper("take-down", "Take down one of your bounties without awarding XP (forfeit posting XP)",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -12,7 +13,7 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 		}
 
 		interaction.reply({
-			content: `If you'd like to change the title, description, image, or time of your bounty, you can use ${commandMention("bounty edit")} instead.`,
+			content: `If you'd like to change the title, description, image, or time of your bounty instead, you can use ${commandMention("bounty edit")}.`,
 			components: [
 				new ActionRowBuilder().addComponents(
 					new StringSelectMenuBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
@@ -25,23 +26,14 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 		}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 			const [bountyId] = collectedInteraction.values;
 			const bounty = await logicLayer.bounties.findBounty(bountyId);
-			logicLayer.bounties.deleteBountyCompletions(bountyId);
+
+			let bountyThread;
 			if (origin.company.bountyBoardId && bounty.postingId) {
-				const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
-				const postingThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
-				if (postingThread) {
-					postingThread.delete("Bounty taken down by poster");
-				}
+				const bountyBoard = await collectedInteraction.guild.channels.fetch(origin.company.bountyBoardId);
+				bountyThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
 			}
-			bounty.destroy();
 
-			origin.hunter.decrement("xp");
-			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-			await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
-			const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-			const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await collectedInteraction.guild.roles.fetch());
-			syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-
+			bountyTakeDown(logicLayer, collectedInteraction.guild, bounty, origin.hunter, bountyThread);
 			collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
 			// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply

--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { commandMention, selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors, butIgnoreUnknownChannelErrors } = require("../../shared");
+const { commandMention, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, butIgnoreUnknownChannelErrors } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { bountyTakeDown } = require("../../shared/flows/bountyTakeDown");
 

--- a/source/frontend/commands/moderation/take-down.js
+++ b/source/frontend/commands/moderation/take-down.js
@@ -34,6 +34,9 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 					const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
 					postingThread.delete("Bounty taken down by moderator");
 				}
+				if (bounty.scheduledEventId) {
+					collectedInteraction.guild.scheduledEvents.delete(bounty.scheduledEventId);
+				}
 
 				let poster;
 				if (posterId === origin.hunter.userId) {

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -2,7 +2,7 @@ const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, us
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 const { bountyTakeDown } = require('../shared/flows/bountyTakeDown');
@@ -265,6 +265,10 @@ module.exports = new SelectWrapper(mainId, 3000,
 					refreshReferenceChannelScoreboardSeasonal(origin.company, modalSubmission.guild, participationMap, descendingRanks, goalProgress);
 				} else {
 					refreshReferenceChannelScoreboardOverall(origin.company, modalSubmission.guild, hunterMap, goalProgress);
+				}
+
+				if (bounty.scheduledEventId) {
+					modalSubmission.guild.scheduledEvents.delete(bounty.scheduledEventId).catch(butIgnoreErrorIf(isUnknownGuildScheduledEventError, isMissingPermissionError));
 				}
 			} break;
 			case "edit": {

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -5,6 +5,7 @@ const { timeConversion, discordTimestamp } = require('../../shared');
 const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
+const { bountyTakeDown } = require('../shared/flows/bountyTakeDown');
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -442,20 +443,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 					flags: MessageFlags.Ephemeral,
 					withResponse: true
 				}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.Button })).then(async collectedInteraction => {
-					logicLayer.bounties.deleteBountyCompletions(bountyId);
-					bounty.destroy();
-
-					origin.hunter.decrement("xp");
-					const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
-					await logicLayer.seasons.changeSeasonXP(interaction.user.id, interaction.guildId, season.id, -1);
-					const descendingRanks = await logicLayer.ranks.findAllRanks(interaction.guild.id);
-					const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await collectedInteraction.guild.roles.fetch());
-					syncRankRoles(seasonalHunterReceipts, descendingRanks, interaction.guild.members);
-
-					return collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
-				}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
-					interaction.channel.delete("Bounty taken down by poster");
-				});
+					await collectedInteraction.update({ content: "Your bounty has been taken down.", components: [] });
+					bountyTakeDown(logicLayer, collectedInteraction.guild, bounty, origin.hunter, collectedInteraction.channel);
+				}).catch(butIgnoreInteractionCollectorErrors);
 			} break;
 		}
 	}

--- a/source/frontend/shared/dAPIResponses.js
+++ b/source/frontend/shared/dAPIResponses.js
@@ -19,6 +19,7 @@ function butIgnoreErrorIf(...ignoreThese) {
 const isAutomodError = error => [200000, 200001].includes(error.code);
 const isInteractionCollectorError = error => error.code === DiscordjsErrorCodes.InteractionCollectorError;
 const isUnknownChannelError = error => error.code === 10003;
+const isUnknownGuildScheduledEventError = error => error.code === 10070;
 const isMissingPermissionError = error => error.code === 50013;
 const isCantDirectMessageThisUserError = error => error.code === 50007;
 
@@ -36,6 +37,7 @@ module.exports = {
 	isAutomodError,
 	isInteractionCollectorError,
 	isUnknownChannelError,
+	isUnknownGuildScheduledEventError,
 	isMissingPermissionError,
 	isCantDirectMessageThisUserError,
 	butIgnoreInteractionCollectorErrors,

--- a/source/frontend/shared/flows/bountyTakeDown.js
+++ b/source/frontend/shared/flows/bountyTakeDown.js
@@ -1,0 +1,33 @@
+const { MessageFlags, Guild } = require("discord.js");
+const { Bounty, Hunter } = require("../../../database/models");
+const { butIgnoreUnknownChannelErrors, butIgnoreMissingPermissionErrors } = require("../dAPIResponses");
+const { syncRankRoles } = require("../dAPIRequests");
+
+/**
+ * @param {typeof import("../../../logic")} logicLayer
+ * @param {Guild} guild
+ * @param {Bounty} bounty
+ * @param {Hunter} posterHunter
+ * @param {import("discord.js").ForumThreadChannel | undefined} bountyThread
+ */
+async function bountyTakeDown(logicLayer, guild, bounty, posterHunter, bountyThread) {
+	await logicLayer.bounties.deleteBountyCompletions(bounty.id);
+	if (bountyThread) {
+		bountyThread.delete("Bounty taken down by poster").catch(butIgnoreMissingPermissionErrors);
+	}
+	if (bounty.scheduledEventId) {
+		guild.scheduledEvents.delete(bounty.scheduledEventId).catch(butIgnoreMissingPermissionErrors);
+	}
+	bounty.destroy();
+
+	posterHunter.decrement("xp");
+	const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(bounty.companyId);
+	await logicLayer.seasons.changeSeasonXP(bounty.userId, bounty.companyId, season.id, -1);
+	const descendingRanks = await logicLayer.ranks.findAllRanks(bounty.companyId);
+	const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await guild.roles.fetch());
+	syncRankRoles(seasonalHunterReceipts, descendingRanks, guild.members);
+}
+
+module.exports = {
+	bountyTakeDown
+};

--- a/source/frontend/shared/flows/bountyTakeDown.js
+++ b/source/frontend/shared/flows/bountyTakeDown.js
@@ -25,7 +25,7 @@ async function bountyTakeDown(logicLayer, guild, bounty, posterHunter, bountyThr
 	await logicLayer.seasons.changeSeasonXP(bounty.userId, bounty.companyId, season.id, -1);
 	const descendingRanks = await logicLayer.ranks.findAllRanks(bounty.companyId);
 	const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(await logicLayer.seasons.getParticipationMap(season.id), descendingRanks, await guild.roles.fetch());
-	syncRankRoles(seasonalHunterReceipts, descendingRanks, guild.members);
+	return syncRankRoles(seasonalHunterReceipts, descendingRanks, guild.members);
 }
 
 module.exports = {

--- a/source/frontend/shared/flows/bountyTakeDown.js
+++ b/source/frontend/shared/flows/bountyTakeDown.js
@@ -1,6 +1,6 @@
 const { Guild } = require("discord.js");
 const { Bounty, Hunter } = require("../../../database/models");
-const { butIgnoreMissingPermissionErrors } = require("../dAPIResponses");
+const { butIgnoreMissingPermissionErrors, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError } = require("../dAPIResponses");
 const { syncRankRoles } = require("../dAPIRequests");
 
 /**
@@ -16,7 +16,7 @@ async function bountyTakeDown(logicLayer, guild, bounty, posterHunter, bountyThr
 		bountyThread.delete("Bounty taken down by poster").catch(butIgnoreMissingPermissionErrors);
 	}
 	if (bounty.scheduledEventId) {
-		guild.scheduledEvents.delete(bounty.scheduledEventId).catch(butIgnoreMissingPermissionErrors);
+		guild.scheduledEvents.delete(bounty.scheduledEventId).catch(butIgnoreErrorIf(isUnknownGuildScheduledEventError, isMissingPermissionError));
 	}
 	bounty.destroy();
 

--- a/source/frontend/shared/flows/bountyTakeDown.js
+++ b/source/frontend/shared/flows/bountyTakeDown.js
@@ -1,6 +1,6 @@
-const { MessageFlags, Guild } = require("discord.js");
+const { Guild } = require("discord.js");
 const { Bounty, Hunter } = require("../../../database/models");
-const { butIgnoreUnknownChannelErrors, butIgnoreMissingPermissionErrors } = require("../dAPIResponses");
+const { butIgnoreMissingPermissionErrors } = require("../dAPIResponses");
 const { syncRankRoles } = require("../dAPIRequests");
 
 /**


### PR DESCRIPTION
Summary
-------
- fix `/bounty take-down` not canceling associated Scheduled Event (applied in command, on control panel, and in evergreen)
- consolidate common logic between command and control panel option
- fixed fetches where discord.js was previously returning a collection of 1 event when fetching by id

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty take-down` (command) removes associated Scheduled Event
- [x] bounty control panel take down removes associated Scheduled Event

Issue
-----
Closes #655