### PR TITLE
seconding fixes

### DIFF
--- a/source/frontend/buttons/secondtoast.js
+++ b/source/frontend/buttons/secondtoast.js
@@ -29,14 +29,9 @@ module.exports = new ButtonWrapper(mainId, 3000,
 		const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guild.id);
 		const previousCompanyLevel = Company.getLevel(origin.company.getXP(await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id)));
 
-		const recipientIds = [];
-		originalToast.Recipients.forEach(reciept => {
-			if (reciept.recipientId !== interaction.user.id) {
-				recipientIds.push(reciept.recipientId);
-			}
-		});
+		const recipientIds = originalToast.Recipients.map(receipt => receipt.recipientId);
 
-		const hunterReceipts = await logicLayer.toasts.secondToast(origin.hunter, originalToast, origin.company, recipientIds, season.id);
+		const hunterReceipts = await logicLayer.toasts.secondToast(origin.hunter, originalToast, origin.company, recipientIds.filter(id => id !== interaction.user.id), season.id);
 
 		const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "secondings", origin.hunter, season);
 		companyReceipt.guildName = interaction.guild.name;

--- a/source/frontend/commands/toast.js
+++ b/source/frontend/commands/toast.js
@@ -71,7 +71,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		let hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
 
 		const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-		const { toastId, hunterReceipts } = await logicLayer.toasts.raiseToast(interaction.guild, origin.company, interaction.user.id, validatedToasteeIds, hunterMap, season.id, toastText, imageURL);
+		const { toastId, hunterReceipts } = await logicLayer.toasts.raiseToast(interaction.guild, origin.company, interaction.user.id, Array.from(validatedToasteeIds), hunterMap, season.id, toastText, imageURL);
 		let goalProgress = { goalCompleted: false, currentGP: 0, requiredGP: 0 };
 		let companyReceipt = {};
 		if (hunterReceipts.size > 0) {
@@ -87,7 +87,7 @@ module.exports = new CommandWrapper(mainId, "Raise a toast to other bounty hunte
 		}
 		companyReceipt.guildName = interaction.guild.name;
 
-		const embeds = [toastEmbed(origin.company.toastThumbnailURL, toastText, validatedToasteeIds, interaction.member, goalProgress, imageURL)];
+		const embeds = [toastEmbed(origin.company.toastThumbnailURL, toastText, Array.from(validatedToasteeIds), interaction.member, goalProgress, imageURL)];
 		if (goalProgress.goalCompleted) {
 			embeds.push(goalCompletionEmbed(goalProgress.contributorIds));
 		}

--- a/source/frontend/context_menus/Raise_a_Toast.js
+++ b/source/frontend/context_menus/Raise_a_Toast.js
@@ -53,7 +53,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			let hunterMap = await logicLayer.hunters.getCompanyHunterMap(interaction.guild.id);
 
 			const previousCompanyLevel = Company.getLevel(origin.company.getXP(hunterMap));
-			const { toastId, hunterReceipts } = await logicLayer.toasts.raiseToast(modalSubmission.guild, origin.company, interaction.user.id, new Set([interaction.targetId]), hunterMap, season.id, toastText, null);
+			const { toastId, hunterReceipts } = await logicLayer.toasts.raiseToast(modalSubmission.guild, origin.company, interaction.user.id, [interaction.targetId], hunterMap, season.id, toastText, null);
 			let goalProgress = { goalCompleted: false, currentGP: 0, requiredGP: 0 };
 			let companyReceipt = {};
 			if (hunterReceipts.size > 0) {
@@ -69,7 +69,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 			}
 			companyReceipt.guildName = interaction.guild.name;
 
-			const embeds = [toastEmbed(origin.company.toastThumbnailURL, toastText, new Set([interaction.targetId]), modalSubmission.member, goalProgress)];
+			const embeds = [toastEmbed(origin.company.toastThumbnailURL, toastText, [interaction.targetId], modalSubmission.member, goalProgress)];
 			if (goalProgress.goalCompleted) {
 				embeds.push(goalCompletionEmbed(goalProgress.contributorIds));
 			}

--- a/source/frontend/shared/dAPISerializers.js
+++ b/source/frontend/shared/dAPISerializers.js
@@ -539,17 +539,17 @@ function bountyEmbed(bounty, posterGuildMember, posterLevel, shouldOmitRewardsFi
 /**
  * @param {string} thumbnailURL
  * @param {string} toastText
- * @param {Set<string>} recipientIdSet
+ * @param {string[]} recipientIds
  * @param {GuildMember} senderMember
  * @param {{ goalCompleted: boolean; currentGP: number; requiredGP: number; }} goalProgress
  * @param {string | null} imageURL
  * @param {string[] | undefined} seconderMentions
  */
-function toastEmbed(thumbnailURL, toastText, recipientIdSet, senderMember, goalProgress, imageURL, seconderMentions) {
+function toastEmbed(thumbnailURL, toastText, recipientIds, senderMember, goalProgress, imageURL, seconderMentions) {
 	const embed = new EmbedBuilder().setColor("e5b271")
 		.setThumbnail(thumbnailURL)
 		.setTitle(toastText)
-		.setDescription(`A toast to ${sentenceListEN(Array.from(recipientIdSet).map(id => userMention(id)))}!`)
+		.setDescription(`A toast to ${sentenceListEN(recipientIds.map(id => userMention(id)))}!`)
 		.setFooter({ text: senderMember.displayName, iconURL: senderMember.user.avatarURL() });
 	if (goalProgress.goalCompleted) {
 		embed.addFields({ name: "Server Goal", value: `${fillableTextBar(15, 15, 15)} Complete!` });

--- a/source/frontend/shared/stringConstructors.js
+++ b/source/frontend/shared/stringConstructors.js
@@ -97,7 +97,7 @@ function sentenceListEN(texts, isMutuallyExclusive) {
  * @param {number} companyMaxBountySlots
  */
 function rewardSummary(actionType, companyReceipt, hunterReceipts, companyMaxBountySlots) {
-	if (Object.keys(companyReceipt).length + hunterReceipts.size === 0) {
+	if (Object.keys(companyReceipt).length + hunterReceipts.size === 1) { // `guildName` is a guaranteed key in `companyReciept`
 		return "";
 	}
 

--- a/source/index.js
+++ b/source/index.js
@@ -290,9 +290,9 @@ dAPIClient.on(Events.MessageReactionAdd, async (reaction, user) => {
 	const descendingRanks = await logicBlob.ranks.findAllRanks(guild.id);
 	const guildRoles = await guild.roles.fetch();
 	let goalProgress;
+	const recipientIds = [hostMessage.author.id];
 	if (existingToast) {
 		// If extant toast, create Seconding
-		const recipientIds = [hostMessage.author.id];
 		const companyReceipt = { guildName: guild.name };
 		goalProgress = await logicBlob.goals.progressGoal(company, "secondings", interactingHunter, season);
 		if (goalProgress.gpContributed > 0) {
@@ -320,9 +320,8 @@ dAPIClient.on(Events.MessageReactionAdd, async (reaction, user) => {
 	} else {
 		// If no extant toast, create Toast
 		const hunterMap = await logicBlob.hunters.getCompanyHunterMap(guild.id);
-		const recipientSet = new Set([hostMessage.author.id]);
 		const toastText = `${randomCongratulatoryPhrase()}! Reaction Toast: ${hostMessage.url}`;
-		const { toastId, hunterReceipts } = await logicBlob.toasts.raiseToast(guild, company, user.id, recipientSet, hunterMap, season.id, toastText, null, hostMessage.id);
+		const { toastId, hunterReceipts } = await logicBlob.toasts.raiseToast(guild, company, user.id, recipientIds, hunterMap, season.id, toastText, null, hostMessage.id);
 
 		const companyReceipt = { guildName: guild.name };
 		const currentCompanyLevel = Company.getLevel(company.getXP(await logicBlob.hunters.getCompanyHunterMap(guild.id)));
@@ -335,7 +334,7 @@ dAPIClient.on(Events.MessageReactionAdd, async (reaction, user) => {
 		}
 
 		reaction.message.channel.send({
-			embeds: [toastEmbed(company.toastThumbnailURL, toastText, recipientSet, await guild.members.fetch(user.id), goalProgress)],
+			embeds: [toastEmbed(company.toastThumbnailURL, toastText, recipientIds, await guild.members.fetch(user.id), goalProgress)],
 			components: [secondingButtonRow(toastId)],
 		}).then(async message => {
 			await logicBlob.toasts.setToastMessageId(toastId, message.id);

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -85,7 +85,7 @@ function isToastCrit(critRoll, effectiveToastLevel) {
  * @param {Guild} guild
  * @param {Company} company
  * @param {string} senderId
- * @param {Set<string>} toasteeIds
+ * @param {string[]} toasteeIds
  * @param {Map<string, Hunter>} hunterMap
  * @param {string} seasonId
  * @param {string} toastText
@@ -123,7 +123,7 @@ async function raiseToast(guild, company, senderId, toasteeIds, hunterMap, seaso
 	let critValue = 0;
 	const startingSenderLevel = hunterMap.get(senderId).getLevel(company.xpCoefficient);
 	const xpMultiplierString = company.festivalMultiplierString("xp");
-	for (const id of toasteeIds.values()) {
+	for (const id of toasteeIds) {
 		const rawToast = { toastId: toast.id, recipientId: id, isRewarded: !hunterIdsToastedInLastDay.has(id) && rewardsAvailable > 0, wasCrit: false };
 		if (rawToast.isRewarded) {
 			const hunterReceipt = {};


### PR DESCRIPTION
Summary
-------
- fix seconding a toast removing seconder from recipients on embed
- `toastEmbed` takes array of ids instead of set of ids (most flows submit an array of a single id, set deduping only used in one flow)
- fix reward summary early out not catching no reciept state (companyReciept guaranteed to include 1 or more keys)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] seconding a toast no longer removes the seconders' name from the recipient list, but still doesn't grant them xp