### PR TITLE
#635: add option to customize bounty board forum name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # BountyBot Change Log
+## BountyBot Version 2.12.0fi:
+- `/create-default bounty-board-forum` now has an option for customizing the new channel's name
 ## BountyBot Version 2.11.0fib:
 ### Reaction Toasts
 - Bounty Hunters can now raise a messageless toast by reacting to another Bounty Hunter's discord message with 🥂

--- a/source/frontend/commands/create-default/bounty-board-forum.js
+++ b/source/frontend/commands/create-default/bounty-board-forum.js
@@ -5,11 +5,13 @@ const { Company } = require("../../../database/models");
 
 module.exports = new SubcommandWrapper("bounty-board-forum", "Create a new bounty board forum channel sibling to this channel",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
+		const customChannelName = interaction.options.getString("channel-name");
+
 		let bountyBoard;
 		try {
 			bountyBoard = await interaction.guild.channels.create({
 				parent: interaction.channel.parentId,
-				name: "the-bounty-board",
+				name: customChannelName ?? "the-bounty-board",
 				type: ChannelType.GuildForum,
 				permissionOverwrites: [
 					{
@@ -75,5 +77,12 @@ module.exports = new SubcommandWrapper("bounty-board-forum", "Create a new bount
 
 		origin.company.save();
 		interaction.reply({ content: `A new bounty board has been created: ${bountyBoard}`, flags: MessageFlags.Ephemeral });
+	}
+).setOptions(
+	{
+		type: "String",
+		name: "channel-name",
+		description: "The name for the bounty board forum",
+		required: false
 	}
 );


### PR DESCRIPTION
Summary
-------
- add option to customize bounty board forum name

NOTE: intended for v2.12.0fi (do not merge until after v2.11.1ib ships)

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] using `/create-default bounty-board-forum` with channel name option creates a channel with that name

Issue
-----
Closes #635