### PR TITLE
Use bounty thread log helper in bounty command flows

### DIFF
--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, addLogMessageToBountyThread } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
@@ -110,21 +110,18 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 
 		if (origin.company.bountyBoardId) {
 			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
-			modalSubmission.editReply(acknowledgeOptions);
-			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
-			bountyBoard.threads.fetch(bounty.postingId).then(async thread => {
-				await unarchiveAndUnlockThread(thread, "bounty complete");
-				thread.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-				thread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
-				return thread.fetchStarterMessage();
-			}).then(async posting => {
-				posting.edit({
+			await modalSubmission.editReply(acknowledgeOptions);
+			const logMessage = await addLogMessageToBountyThread(modalSubmission.guild, origin.company, bounty, rewardMessageContent);
+			if (logMessage) {
+				const thread = logMessage.channel;
+				await thread.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
+				const posting = await thread.fetchStarterMessage();
+				await posting.edit({
 					embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
 					components: []
-				}).then(() => {
-					posting.channel.setArchived(true, "bounty completed");
 				});
-			});
+				await thread.setArchived(true, "bounty completed");
+			}
 		} else {
 			acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
 			modalSubmission.editReply(acknowledgeOptions).then(message => {

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, unorderedList, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, addLogMessageToBountyThread } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("edit", "Edit the title, description, image, or time of one of your bounties",
@@ -95,16 +95,13 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				// update bounty board
 				const embeds = [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event)];
 				if (origin.company.bountyBoardId) {
-					interaction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
-						return bountyBoard.threads.fetch(bounty.postingId);
-					}).then(async thread => {
-						await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-						thread.edit({ name: bounty.title });
-						thread.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
-						return thread.fetchStarterMessage();
-					}).then(posting => {
-						posting.edit({ embeds });
-					})
+					const logMessage = await addLogMessageToBountyThread(modalSubmission.guild, origin.company, bounty, "The bounty was edited.");
+					if (logMessage) {
+						const thread = logMessage.channel;
+						await thread.edit({ name: bounty.title });
+						const posting = await thread.fetchStarterMessage();
+						await posting.edit({ embeds });
+					}
 				}
 
 				modalSubmission.update({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds, components: [] });

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -82,12 +82,17 @@ async function refreshBountyThreadStarterMessage(guild, company, bounty, bountyS
 }
 
 /** Add a message to the bounty in the bounty board to log state changes.
- * To avoid spam and for general bounty readability, limit using this to
- * once per bounty per command.
+ * This fetches the bounty board and bounty thread from dAPI, so call it at
+ * most once per flow and reuse the returned message's channel when follow-up
+ * work needs the thread.
+ *
+ * Prefer direct thread operations instead of this helper when the flow already
+ * has natural access to the bounty thread.
  * @param {Guild} guild
  * @param {Company} company
  * @param {Bounty} bounty
  * @param {string} auditMessage
+ * @returns {Promise<Message | null>}
  */
 async function addLogMessageToBountyThread(guild, company, bounty, auditMessage) {
 	if (!company.bountyBoardId || !bounty.postingId) {


### PR DESCRIPTION
Fixes #609.

## What changed
- Routed `/bounty complete` thread reward logging through `addLogMessageToBountyThread`, then reused the returned thread to update tags, edit the starter embed, and archive the completed bounty thread.
- Routed `/bounty edit` thread audit logging through `addLogMessageToBountyThread`, then reused the returned thread to rename the thread and refresh the starter embed.
- Updated the helper documentation to clarify it fetches dAPI resources, should only be used once per flow, and should not replace direct thread access when a flow already has the thread naturally.

## Why this is good
This keeps the slash-command paths aligned with the shared logging helper introduced in #608 without touching the `bountycontrolpanel` flows, which already operate inside the bounty thread. The code now avoids duplicating the fetch/unarchive/send pattern in `/bounty complete` and `/bounty edit`, while preserving the existing user-visible behavior: completion still posts the reward summary, updates the starter embed, applies the completed tag, and archives the thread; edits still log the edit and refresh the bounty embed.

## Verification
- `npm ci`
- `node --check source/frontend/shared/dAPIRequests.js`
- `node --check source/frontend/commands/bounty/complete.js`
- `node --check source/frontend/commands/bounty/edit.js`

I also attempted a full module import, but this repo requires a private `config/auth.json` at import time, so I kept verification to dependency install and syntax checks.

Payment/contact email: prathamagarwal176@gmail.com