### PR TITLE
#609 & #561: consolidate thread handling behavior

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 ## BountyBot Version 2.12.0fi:
 - Added command `/bounty ping` to mention bounty hunters who have reacted to the bounty's thread or marked themselves interested in the bounty's event
 - `/create-default bounty-board-forum` now has an option for customizing the new channel's name
+- Completing a bounty now applies ~~strikethrough~~ to its title on the bounty board
+- The following actions now sends record keeping messages to bounty board threads: showcasing a bounty, adding a thumbnail
+- Fixed several crashes related to missed fetches on the bounty board
 ## BountyBot Version 2.11.1ib:
 - Completing or taking down bounties now cancel the bounty's event if it hasn't been closed already
 - Fixed a crash when attempting to make an event for a bounty while missing permission

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder, PermissionFlagsBits, strikethrough } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, getBountyBoardThread, refreshBountyBoardThread } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, getBountyBoardThread, refreshBountyBoardThread, auditReasonBountyComplete } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
@@ -112,7 +112,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
 			modalSubmission.editReply(acknowledgeOptions);
 
-			const auditLogReason = "bounty marked completed by poster";
+			const auditLogReason = auditReasonBountyComplete;
 			const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
 			if (bountyThread) {
 				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder, PermissionFlagsBits, strikethrough } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, getBountyBoardThread, refreshBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, getBountyBoardThread, refreshBountyBoardThread } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
@@ -119,7 +119,7 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 					refreshBountyBoardThread(await bountyThread.fetchStarterMessage(), { embed: bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress), title: strikethrough(bounty.title) }, auditLogReason);
 					await unarchiveAndUnlockThread(bountyThread, auditLogReason);
 				}
-				if (threadCanRecieveMessages(bountyThread)) {
+				if (bountyThread.sendable) {
 					bountyThread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
 				}
 				bountyThread.edit({ archived: true, appliedTags: [origin.company.bountyBoardCompletedTagId], reason: auditLogReason });

--- a/source/frontend/commands/bounty/complete.js
+++ b/source/frontend/commands/bounty/complete.js
@@ -1,6 +1,6 @@
-const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder } = require("discord.js");
+const { MessageFlags, userMention, channelMention, bold, ModalBuilder, LabelBuilder, UserSelectMenuBuilder, StringSelectMenuBuilder, PermissionFlagsBits, strikethrough } = require("discord.js");
 const { timeConversion } = require("../../../shared");
-const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, sentenceListEN, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError } = require("../../shared");
+const { commandMention, bountyEmbed, goalCompletionEmbed, sendRewardMessage, syncRankRoles, unarchiveAndUnlockThread, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, butIgnoreErrorIf, isUnknownGuildScheduledEventError, isMissingPermissionError, getBountyBoardThread, refreshBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
 const { SubcommandWrapper } = require("../../classes");
 const { Company } = require("../../../database/models");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
@@ -111,20 +111,19 @@ module.exports = new SubcommandWrapper("complete", "Close one of your open bount
 		if (origin.company.bountyBoardId) {
 			acknowledgeOptions.content += `${channelMention(bounty.postingId)}, was completed!`;
 			modalSubmission.editReply(acknowledgeOptions);
-			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
-			bountyBoard.threads.fetch(bounty.postingId).then(async thread => {
-				await unarchiveAndUnlockThread(thread, "bounty complete");
-				thread.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
-				thread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
-				return thread.fetchStarterMessage();
-			}).then(async posting => {
-				posting.edit({
-					embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
-					components: []
-				}).then(() => {
-					posting.channel.setArchived(true, "bounty completed");
-				});
-			});
+
+			const auditLogReason = "bounty marked completed by poster";
+			const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+			if (bountyThread) {
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					refreshBountyBoardThread(await bountyThread.fetchStarterMessage(), { embed: bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), true, origin.company, new Set([...validatedHunters.keys()]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress), title: strikethrough(bounty.title) }, auditLogReason);
+					await unarchiveAndUnlockThread(bountyThread, auditLogReason);
+				}
+				if (threadCanRecieveMessages(bountyThread)) {
+					bountyThread.send({ content: rewardMessageContent, flags: MessageFlags.SuppressNotifications });
+				}
+				bountyThread.edit({ archived: true, appliedTags: [origin.company.bountyBoardCompletedTagId], reason: auditLogReason });
+			}
 		} else {
 			acknowledgeOptions.content += `${bold(bounty.title)}, was completed!`;
 			modalSubmission.editReply(acknowledgeOptions).then(message => {

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, unorderedList, bold, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, refreshBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
+const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, refreshBountyBoardThread } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("edit", "Edit the title, description, image, or time of one of your bounties",
@@ -103,7 +103,7 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 						refreshBountyBoardThread(await bountyThread.fetchStarterMessage(), { embed }, auditLogReason);
 						await unarchiveAndUnlockThread(bountyThread, auditLogReason);
 					}
-					if (threadCanRecieveMessages(bountyThread)) {
+					if (bountyThread.sendable) {
 						bountyThread.send({ content: "This bounty was edited.", flags: MessageFlags.SuppressNotifications });
 					}
 				}

--- a/source/frontend/commands/bounty/edit.js
+++ b/source/frontend/commands/bounty/edit.js
@@ -1,6 +1,6 @@
-const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, unorderedList, bold } = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, unorderedList, bold, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { textsHaveAutoModInfraction, commandMention, bountyEmbed, validateScheduledEventTimestamps, bountyScheduledEventPayload, editBountyModalAndSubmissionOptions, selectOptionsFromBounties, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, refreshBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
 module.exports = new SubcommandWrapper("edit", "Edit the title, description, image, or time of one of your bounties",
@@ -92,22 +92,21 @@ module.exports = new SubcommandWrapper("edit", "Edit the title, description, ima
 				}
 				await bounty.update(updatePayload);
 
-				// update bounty board
-				const embeds = [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event)];
-				if (origin.company.bountyBoardId) {
-					interaction.guild.channels.fetch(origin.company.bountyBoardId).then(bountyBoard => {
-						return bountyBoard.threads.fetch(bounty.postingId);
-					}).then(async thread => {
-						await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-						thread.edit({ name: bounty.title });
-						thread.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
-						return thread.fetchStarterMessage();
-					}).then(posting => {
-						posting.edit({ embeds });
-					})
-				}
+				const embed = bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event);
+				modalSubmission.update({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds: [embed], components: [] });
 
-				modalSubmission.update({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds, components: [] });
+				// update bounty board
+				const auditLogReason = "bounty edited by poster";
+				const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+				if (bountyThread) {
+					if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+						refreshBountyBoardThread(await bountyThread.fetchStarterMessage(), { embed }, auditLogReason);
+						await unarchiveAndUnlockThread(bountyThread, auditLogReason);
+					}
+					if (threadCanRecieveMessages(bountyThread)) {
+						bountyThread.send({ content: "This bounty was edited.", flags: MessageFlags.SuppressNotifications });
+					}
+				}
 			});
 		}).catch(butIgnoreInteractionCollectorErrors);
 	}

--- a/source/frontend/commands/bounty/ping.js
+++ b/source/frontend/commands/bounty/ping.js
@@ -2,7 +2,7 @@ const { ModalBuilder, UserSelectMenuBuilder, TextInputBuilder, StringSelectMenuB
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { SubcommandWrapper } = require("../../classes");
 const { bountyPing } = require("../../shared/flows/bountyPing");
-const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 
 module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reacted to your bounty's thread or event",
@@ -53,14 +53,7 @@ module.exports = new SubcommandWrapper("ping", "Mention bounty hunters that reac
 			return;
 		}
 
-		let bountyThread;
-		if (origin.company.bountyBoardId && bounty.postingId) {
-			const bountyBoard = await modalSubmission.guild.channels.fetch(origin.company.bountyBoardId);
-			if (bountyBoard) {
-				bountyThread = await bountyBoard.threads.fetch(bounty.postingId);
-			}
-		}
-
+		const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
 		bountyPing(modalSubmission, { message: labelIdMessage, excludedBountyHunters: labelIdExcludedBountyHunters }, bounty, bountyThread);
 	}
 );

--- a/source/frontend/commands/bounty/record-turn-ins.js
+++ b/source/frontend/commands/bounty/record-turn-ins.js
@@ -1,6 +1,6 @@
 const { userMention, bold, MessageFlags, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { sentenceListEN, commandMention, randomCongratulatoryPhrase, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, threadCanRecieveMessages, unarchiveAndUnlockThread } = require("../../shared");
+const { sentenceListEN, commandMention, randomCongratulatoryPhrase, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
@@ -62,7 +62,7 @@ module.exports = new SubcommandWrapper("record-turn-ins", "Record turn-ins of on
 					(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(bountyThread, "bounty turn-ins recorded by poster");
 				}
-				if (threadCanRecieveMessages(bountyThread)) {
+				if (bountyThread.sendable) {
 					bountyThread.send({ content: `${newTurnInList} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
 				}
 			}

--- a/source/frontend/commands/bounty/record-turn-ins.js
+++ b/source/frontend/commands/bounty/record-turn-ins.js
@@ -1,6 +1,6 @@
-const { userMention, bold, MessageFlags, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder } = require("discord.js");
+const { userMention, bold, MessageFlags, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { sentenceListEN, commandMention, refreshBountyThreadStarterMessage, randomCongratulatoryPhrase, selectOptionsFromBounties, butIgnoreUnknownChannelErrors, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { sentenceListEN, commandMention, randomCongratulatoryPhrase, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, threadCanRecieveMessages, unarchiveAndUnlockThread } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
@@ -55,9 +55,16 @@ module.exports = new SubcommandWrapper("record-turn-ins", "Record turn-ins of on
 			await logicLayer.bounties.bulkCreateCompletions(bounty.id, bounty.companyId, Array.from(eligibleTurnInIds), null);
 			const newTurnInList = sentenceListEN(Array.from(newTurnInIds.values().map(id => userMention(id))));
 			sentences.unshift(`Turn-ins of ${bold(bounty.title)} have been recorded for the following hunters: ${newTurnInList}`);
-			const post = await refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), eligibleTurnInIds).catch(butIgnoreUnknownChannelErrors);
-			if (post) {
-				post.channel.send({ content: `${newTurnInList} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
+
+			const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+			if (bountyThread) {
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(bountyThread, "bounty turn-ins recorded by poster");
+				}
+				if (threadCanRecieveMessages(bountyThread)) {
+					bountyThread.send({ content: `${newTurnInList} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
+				}
 			}
 		}
 

--- a/source/frontend/commands/bounty/revoke-turn-ins.js
+++ b/source/frontend/commands/bounty/revoke-turn-ins.js
@@ -1,6 +1,6 @@
 const { MessageFlags, userMention, bold, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { sentenceListEN, selectOptionsFromBounties, commandMention, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, threadCanRecieveMessages } = require("../../shared");
+const { sentenceListEN, selectOptionsFromBounties, commandMention, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
@@ -55,7 +55,7 @@ module.exports = new SubcommandWrapper("revoke-turn-ins", "Revoke the turn-ins o
 				(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 				await unarchiveAndUnlockThread(bountyThread, "bounty turn-ins revoked by poster");
 			}
-			if (threadCanRecieveMessages(bountyThread)) {
+			if (bountyThread.sendable) {
 				bountyThread.send({ content: `${mentionList} ${removedIds.length === 1 ? "has had their turn-in" : "have had their turn-ins"} revoked.` });
 			}
 		}

--- a/source/frontend/commands/bounty/revoke-turn-ins.js
+++ b/source/frontend/commands/bounty/revoke-turn-ins.js
@@ -1,6 +1,6 @@
-const { MessageFlags, userMention, bold, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder } = require("discord.js");
+const { MessageFlags, userMention, bold, StringSelectMenuBuilder, UserSelectMenuBuilder, ModalBuilder, LabelBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { sentenceListEN, refreshBountyThreadStarterMessage, selectOptionsFromBounties, commandMention, butIgnoreUnknownChannelErrors, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { sentenceListEN, selectOptionsFromBounties, commandMention, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, threadCanRecieveMessages } = require("../../shared");
 const { timeConversion } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 
@@ -49,10 +49,15 @@ module.exports = new SubcommandWrapper("revoke-turn-ins", "Revoke the turn-ins o
 		const mentionList = sentenceListEN(removedIds.map(id => userMention(id)));
 		modalSubmission.reply({ content: `These bounty hunters' turn-ins of ${bold(bounty.title)} have been revoked: ${mentionList}`, flags: MessageFlags.Ephemeral });
 
-		const post = await refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), await logicLayer.bounties.getHunterIdSet(bounty.id))
-			.catch(butIgnoreUnknownChannelErrors);
-		if (post) {
-			post.channel.send({ content: `${mentionList} ${removedIds.length === 1 ? "has had their turn-in" : "have had their turn-ins"} revoked.` });
+		const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+		if (bountyThread) {
+			if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+				(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+				await unarchiveAndUnlockThread(bountyThread, "bounty turn-ins revoked by poster");
+			}
+			if (threadCanRecieveMessages(bountyThread)) {
+				bountyThread.send({ content: `${mentionList} ${removedIds.length === 1 ? "has had their turn-in" : "have had their turn-ins"} revoked.` });
+			}
 		}
 	}
 );

--- a/source/frontend/commands/bounty/showcase.js
+++ b/source/frontend/commands/bounty/showcase.js
@@ -1,8 +1,8 @@
-const { StringSelectMenuBuilder, MessageFlags, TimestampStyles, ModalBuilder, TextDisplayBuilder, LabelBuilder } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, TimestampStyles, ModalBuilder, TextDisplayBuilder, LabelBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { timeConversion, discordTimestamp } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
-const { selectOptionsFromBounties, bountyEmbed, refreshBountyThreadStarterMessage, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreUnknownChannelErrors } = require("../../shared");
+const { selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
 
 module.exports = new SubcommandWrapper("showcase", "Show the embed for one of your existing bounties and increase the reward",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -57,15 +57,20 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for one of yo
 
 		bounty = await bounty.increment("showcaseCount");
 		await origin.hunter.update({ lastShowcaseTimestamp: new Date() });
-		const hunterIdSet = await logicLayer.bounties.getHunterIdSet(bountyId);
 		const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-		const bountyScheduledEvent = await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents);
-		refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, bountyScheduledEvent, modalSubmission.member, currentPosterLevel, hunterIdSet)
-			.catch(butIgnoreUnknownChannelErrors);
-		await unarchiveAndUnlockThread(modalSubmission.channel, "bounty showcased");
-		modalSubmission.reply({
-			content: `${modalSubmission.member} increased the reward on their bounty!`,
-			embeds: [bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, hunterIdSet, bountyScheduledEvent)]
-		});
+		const embed = bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents));
+		const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+
+		modalSubmission.reply({ content: `${modalSubmission.member} increased the reward on their bounty!`, embeds: [embed] });
+
+		if (bountyThread) {
+			if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+				(await bountyThread.fetchStarterMessage()).edit({ embeds: [embed] });
+				await unarchiveAndUnlockThread(bountyThread, "bounty showcased by poster");
+			}
+			if (threadCanRecieveMessages(bountyThread)) {
+				bountyThread.send({ content: `${modalSubmission.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
+			}
+		}
 	}
 );

--- a/source/frontend/commands/bounty/showcase.js
+++ b/source/frontend/commands/bounty/showcase.js
@@ -2,7 +2,7 @@ const { StringSelectMenuBuilder, MessageFlags, TimestampStyles, ModalBuilder, Te
 const { SubcommandWrapper } = require("../../classes");
 const { timeConversion, discordTimestamp } = require("../../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
-const { selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, threadCanRecieveMessages } = require("../../shared");
+const { selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../../shared");
 
 module.exports = new SubcommandWrapper("showcase", "Show the embed for one of your existing bounties and increase the reward",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -68,7 +68,7 @@ module.exports = new SubcommandWrapper("showcase", "Show the embed for one of yo
 				(await bountyThread.fetchStarterMessage()).edit({ embeds: [embed] });
 				await unarchiveAndUnlockThread(bountyThread, "bounty showcased by poster");
 			}
-			if (threadCanRecieveMessages(bountyThread)) {
+			if (bountyThread.sendable) {
 				bountyThread.send({ content: `${modalSubmission.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
 			}
 		}

--- a/source/frontend/commands/bounty/swap.js
+++ b/source/frontend/commands/bounty/swap.js
@@ -1,7 +1,7 @@
-const { StringSelectMenuBuilder, MessageFlags, bold, ModalBuilder, LabelBuilder, TextDisplayBuilder } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, bold, ModalBuilder, LabelBuilder, TextDisplayBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty, Hunter } = require("../../../database/models");
-const { emojiFromNumber, refreshBountyThreadStarterMessage, addLogMessageToBountyThread, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength } = require("../../shared");
+const { emojiFromNumber, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength, getBountyBoardThread, unarchiveAndUnlockThread, threadCanRecieveMessages, bountyEmbed } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { timeConversion } = require("../../../shared");
 const { SelectMenuLimits } = require("@sapphire/discord.js-utilities");
@@ -80,15 +80,34 @@ module.exports = new SubcommandWrapper("swap", "Move one of your bounties to ano
 		const sourceSlot = sourceBounty.slotNumber;
 		let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
 		const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, sourceBounty.showcaseCount);
+		const auditLogReason = destinationBounty ?
+			`bounty poster swapped slots of bounties ${sourceSlot} and ${destinationSlot}` :
+			`bounty swapped from slot ${sourceSlot} to ${destinationSlot} by poster`;
 
 		sourceBounty = await sourceBounty.update({ slotNumber: destinationSlot });
-		refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, sourceBounty, await sourceBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(sourceBounty.id));
-		addLogMessageToBountyThread(modalSubmission.guild, origin.company, sourceBounty, `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`);
+		const sourceBountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, sourceBounty.postingId);
+		if (sourceBountyThread) {
+			if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+				(await sourceBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(sourceBounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(sourceBounty.id), await sourceBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+				await unarchiveAndUnlockThread(sourceBountyThread, auditLogReason);
+			}
+			if (threadCanRecieveMessages(sourceBountyThread)) {
+				sourceBountyThread.send({ content: `This bounty's slot was switched from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`, flags: MessageFlags.SuppressNotifications });
+			}
+		}
 
 		if (destinationBounty) {
 			destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-			refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-			addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+			const destinationBountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, destinationBounty.postingId);
+			if (destinationBountyThread) {
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					(await destinationBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(destinationBounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(destinationBounty.id), await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(destinationBountyThread, auditLogReason);
+				}
+				if (threadCanRecieveMessages(destinationBountyThread)) {
+					destinationBountyThread.send({ content: `This bounty's slot was switched from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`, flags: MessageFlags.SuppressNotifications });
+				}
+			}
 		}
 
 		modalSubmission.reply(addCompanyAnnouncementPrefix(origin.company, { content: `${modalSubmission.member}'s bounty, ${bold(sourceBounty.title)} is now worth ${destinationRewardValue} XP.` }));

--- a/source/frontend/commands/bounty/swap.js
+++ b/source/frontend/commands/bounty/swap.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, MessageFlags, bold, ModalBuilder, LabelBuilder, TextDisplayBuilder, PermissionFlagsBits } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { Bounty, Hunter } = require("../../../database/models");
-const { emojiFromNumber, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength, getBountyBoardThread, unarchiveAndUnlockThread, threadCanRecieveMessages, bountyEmbed } = require("../../shared");
+const { emojiFromNumber, addCompanyAnnouncementPrefix, butIgnoreInteractionCollectorErrors, selectOptionsFromBountiesWithBaseRewardAsDescription, truncateTextToLength, getBountyBoardThread, unarchiveAndUnlockThread, bountyEmbed } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { timeConversion } = require("../../../shared");
 const { SelectMenuLimits } = require("@sapphire/discord.js-utilities");
@@ -91,7 +91,7 @@ module.exports = new SubcommandWrapper("swap", "Move one of your bounties to ano
 				(await sourceBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(sourceBounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(sourceBounty.id), await sourceBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 				await unarchiveAndUnlockThread(sourceBountyThread, auditLogReason);
 			}
-			if (threadCanRecieveMessages(sourceBountyThread)) {
+			if (sourceBountyThread.sendable) {
 				sourceBountyThread.send({ content: `This bounty's slot was switched from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`, flags: MessageFlags.SuppressNotifications });
 			}
 		}
@@ -104,7 +104,7 @@ module.exports = new SubcommandWrapper("swap", "Move one of your bounties to ano
 					(await destinationBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(destinationBounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(destinationBounty.id), await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(destinationBountyThread, auditLogReason);
 				}
-				if (threadCanRecieveMessages(destinationBountyThread)) {
+				if (destinationBountyThread.sendable) {
 					destinationBountyThread.send({ content: `This bounty's slot was switched from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`, flags: MessageFlags.SuppressNotifications });
 				}
 			}

--- a/source/frontend/commands/bounty/take-down.js
+++ b/source/frontend/commands/bounty/take-down.js
@@ -1,6 +1,6 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
-const { commandMention, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, butIgnoreUnknownChannelErrors } = require("../../shared");
+const { commandMention, selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
 const { bountyTakeDown } = require("../../shared/flows/bountyTakeDown");
 
@@ -27,12 +27,7 @@ module.exports = new SubcommandWrapper("take-down", "Take down one of your bount
 			const [bountyId] = collectedInteraction.values;
 			const bounty = await logicLayer.bounties.findBounty(bountyId);
 
-			let bountyThread;
-			if (origin.company.bountyBoardId && bounty.postingId) {
-				const bountyBoard = await collectedInteraction.guild.channels.fetch(origin.company.bountyBoardId);
-				bountyThread = await bountyBoard.threads.fetch(bounty.postingId).catch(butIgnoreUnknownChannelErrors);
-			}
-
+			const bountyThread = await getBountyBoardThread(collectedInteraction.guild, origin.company.bountyBoardId, bounty.postingId);
 			bountyTakeDown(logicLayer, collectedInteraction.guild, bounty, origin.hunter, bountyThread);
 			collectedInteraction.reply({ content: "Your bounty has been taken down.", flags: MessageFlags.Ephemeral });
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {

--- a/source/frontend/commands/moderation/take-down.js
+++ b/source/frontend/commands/moderation/take-down.js
@@ -1,7 +1,7 @@
 const { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags, ComponentType, userMention, bold } = require("discord.js");
 const { SubcommandWrapper } = require("../../classes");
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require("../../../constants");
-const { selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors } = require("../../shared");
+const { selectOptionsFromBounties, syncRankRoles, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../../shared");
 
 module.exports = new SubcommandWrapper("take-down", "Take down another user's bounty",
 	async function executeSubcommand(interaction, origin, runMode, logicLayer) {
@@ -29,10 +29,9 @@ module.exports = new SubcommandWrapper("take-down", "Take down another user's bo
 			openBounties.find(bounty => bounty.id === bountyId).reload().then(async bounty => {
 				logicLayer.bounties.deleteBountyCompletions(bountyId);
 				bounty.update({ state: "deleted" });
-				if (origin.company.bountyBoardId) {
-					const bountyBoard = await interaction.guild.channels.fetch(origin.company.bountyBoardId);
-					const postingThread = await bountyBoard.threads.fetch(bounty.postingId);
-					postingThread.delete("Bounty taken down by moderator");
+				const bountyThread = await getBountyBoardThread(interaction.guild, origin.company.bountyBoardId, bounty.postingId);
+				if (bountyThread) {
+					bountyThread.delete(`bounty taken down by moderator (id: ${interaction.user.id})`);
 				}
 				if (bounty.scheduledEventId) {
 					collectedInteraction.guild.scheduledEvents.delete(bounty.scheduledEventId);

--- a/source/frontend/context_menus/Record_Bounty_Turn-In.js
+++ b/source/frontend/context_menus/Record_Bounty_Turn-In.js
@@ -1,7 +1,7 @@
 const { InteractionContextType, PermissionFlagsBits, ModalBuilder, userMention, bold, MessageFlags, LabelBuilder, StringSelectMenuBuilder } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { commandMention, randomCongratulatoryPhrase, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, getBountyBoardThread, threadCanRecieveMessages } = require('../shared');
+const { commandMention, randomCongratulatoryPhrase, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, getBountyBoardThread } = require('../shared');
 const { timeConversion } = require('../../shared');
 
 /** @type {typeof import("../../logic")} */
@@ -61,7 +61,7 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 					(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, new Set([interaction.targetId]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(bountyThread, "bounty turn-in recorded by poster");
 				}
-				if (threadCanRecieveMessages(bountyThread)) {
+				if (bountyThread.sendable) {
 					bountyThread.send({ content: `${userMention(interaction.targetId)} has turned-in this bounty! ${randomCongratulatoryPhrase()}!` });
 				}
 			}

--- a/source/frontend/context_menus/Record_Bounty_Turn-In.js
+++ b/source/frontend/context_menus/Record_Bounty_Turn-In.js
@@ -1,7 +1,7 @@
 const { InteractionContextType, PermissionFlagsBits, ModalBuilder, userMention, bold, MessageFlags, LabelBuilder, StringSelectMenuBuilder } = require('discord.js');
 const { UserContextMenuWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING } = require('../../constants');
-const { commandMention, randomCongratulatoryPhrase, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties } = require('../shared');
+const { commandMention, randomCongratulatoryPhrase, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, selectOptionsFromBounties, getBountyBoardThread, threadCanRecieveMessages } = require('../shared');
 const { timeConversion } = require('../../shared');
 
 /** @type {typeof import("../../logic")} */
@@ -53,16 +53,18 @@ module.exports = new UserContextMenuWrapper(mainId, PermissionFlagsBits.SendMess
 				return;
 			}
 			await logicLayer.bounties.bulkCreateCompletions(bountyId, bounty.companyId, [interaction.targetId], null);
-			const boardId = origin.company.bountyBoardId;
-			const { postingId } = bounty;
-			if (boardId && postingId) {
-				const boardChannel = await modalSubmission.guild.channels.fetch(boardId);
-				const post = await boardChannel.threads.fetch(postingId);
-				await unarchiveAndUnlockThread(post, "Unarchived to update posting");
-				post.send({ content: `${userMention(interaction.targetId)} has turned-in this bounty! ${randomCongratulatoryPhrase()}!` });
-				(await post.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, new Set([interaction.targetId]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
-			}
 			modalSubmission.reply({ content: `${userMention(interaction.targetId)}'s turn-in of ${bold(bounty.title)} has been recorded! They will recieve the reward XP when you ${commandMention("bounty complete")}.`, flags: MessageFlags.Ephemeral });
+
+			const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+			if (bountyThread) {
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, new Set([interaction.targetId]), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(bountyThread, "bounty turn-in recorded by poster");
+				}
+				if (threadCanRecieveMessages(bountyThread)) {
+					bountyThread.send({ content: `${userMention(interaction.targetId)} has turned-in this bounty! ${randomCongratulatoryPhrase()}!` });
+				}
+			}
 		}).catch(butIgnoreInteractionCollectorErrors);
 	}
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags, ComponentType, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { timeConversion } = require("../../shared");
-const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, threadCanRecieveMessages } = require("../shared");
+const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
 
 /** @type {typeof import("../../logic")} */
@@ -60,7 +60,7 @@ module.exports = new ItemTemplateSet(
 						(await bountyThread.fetchStarterMessage()).edit({ embeds: [embed] });
 						await unarchiveAndUnlockThread(bountyThread, "Bonus Bounty Showcase item used");
 					}
-					if (threadCanRecieveMessages(bountyThread)) {
+					if (bountyThread.sendable) {
 						bountyThread.send({ content: `${collectedInteraction.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
 					}
 				}

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags, ComponentType, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { timeConversion } = require("../../shared");
-const { commandMention, selectOptionsFromBounties, bountyEmbed, refreshBountyThreadStarterMessage, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors } = require("../shared");
+const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread, threadCanRecieveMessages } = require("../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
 
 /** @type {typeof import("../../logic")} */
@@ -47,14 +47,23 @@ module.exports = new ItemTemplateSet(
 
 				bounty.increment("showcaseCount");
 				await bounty.reload();
-				const hunterIdSet = await logicLayer.bounties.getHunterIdSet(collectedInteraction.values[0]);
 				const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-				refreshBountyThreadStarterMessage(collectedInteraction.guild, origin.company, bounty, await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents), collectedInteraction.member, currentPosterLevel, hunterIdSet);
-				await unarchiveAndUnlockThread(collectedInteraction.channel, "bounty showcased");
-				collectedInteraction.channel.send({
-					content: `${collectedInteraction.member} increased the reward on their bounty!`,
-					embeds: [bountyEmbed(bounty, collectedInteraction.member, currentPosterLevel, false, origin.company, hunterIdSet, await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents))]
-				});
+				const embed = bountyEmbed(bounty, collectedInteraction.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(collectedInteraction.values[0]), await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents));
+				const bountyThread = await getBountyBoardThread(collectedInteraction.guild, origin.company.bountyBoardId, bounty.postingId);
+
+				// Send new message channel to avoid unloadable message reference in UI
+				collectedInteraction.channel.send({ content: `${collectedInteraction.member} increased the reward on their bounty!`, embeds: [embed] });
+				collectedInteraction.update({ components: [] });
+
+				if (bountyThread) {
+					if (collectedInteraction.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+						(await bountyThread.fetchStarterMessage()).edit({ embeds: [embed] });
+						await unarchiveAndUnlockThread(bountyThread, "Bonus Bounty Showcase item used");
+					}
+					if (threadCanRecieveMessages(bountyThread)) {
+						bountyThread.send({ content: `${collectedInteraction.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
+					}
+				}
 			}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
 				// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
 				if (interaction.channel) {

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -1,7 +1,7 @@
-const { StringSelectMenuBuilder, ModalBuilder, MessageFlags, LabelBuilder, FileUploadBuilder, channelMention } = require("discord.js");
+const { StringSelectMenuBuilder, ModalBuilder, MessageFlags, LabelBuilder, FileUploadBuilder, channelMention, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
-const { selectOptionsFromBounties, refreshBountyThreadStarterMessage, butIgnoreInteractionCollectorErrors } = require("../shared");
+const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, threadCanRecieveMessages, commandMention } = require("../shared");
 const { timeConversion } = require("../../shared");
 
 /** @type {typeof import("../../logic")} */
@@ -35,19 +35,30 @@ module.exports = new ItemTemplateSet(
 			return interaction.awaitModalSubmit({ filter: (incoming) => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
 				const bounty = await openBounties.find(bounty => bounty.id === modalSubmission.fields.getStringSelectValues("bounty-id")[0]).reload();
 				if (bounty?.state !== "open") {
-					return modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
+					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
+					return;
 				}
 
 				const imageFileCollection = modalSubmission.fields.getUploadedFiles("image", true);
 				const firstAttachment = imageFileCollection.first();
 				if (!firstAttachment) {
-					return modalSubmission.reply({ content: "There was an error handling the submitted image.", flags: MessageFlags.Ephemeral });
+					modalSubmission.reply({ content: "There was an error handling the submitted image.", flags: MessageFlags.Ephemeral });
+					return;
 				}
 
-				await bounty.update({ thumbnailURL: firstAttachment.url }).then(async bounty => {
-					refreshBountyThreadStarterMessage(interaction.guild, origin.company, bounty, await bounty.getScheduledEvent(interaction.guild.scheduledEvents), interaction.member, origin.hunter.getLevel(origin.company.xpCoefficient), await logicLayer.bounties.getHunterIdSet(bounty.id));
-				});
-				return modalSubmission.reply({ content: `The thumbnail on ${bounty.title} has been updated.${bounty.postingId !== null ? ` ${channelMention(bounty.postingId)}` : ""}`, flags: MessageFlags.Ephemeral });
+				await bounty.update({ thumbnailURL: firstAttachment.url });
+				modalSubmission.reply({ content: `The thumbnail on ${bounty.title} has been updated.${bounty.postingId !== null ? ` ${channelMention(bounty.postingId)}` : ""}`, flags: MessageFlags.Ephemeral });
+
+				const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
+				if (bountyThread) {
+					if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+						(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(interaction.guild.scheduledEvents))] });
+						await unarchiveAndUnlockThread(bountyThread, "Bounty Thumbnail item used");
+					}
+					if (threadCanRecieveMessages(bountyThread)) {
+						bountyThread.send({ content: `This bounty's poster used ${commandMention("item")} to add a thumbnail to this bounty.`, flags: MessageFlags.SuppressNotifications });
+					}
+				}
 			}).catch(butIgnoreInteractionCollectorErrors);
 		}
 	)

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, ModalBuilder, MessageFlags, LabelBuilder, FileUploadBuilder, channelMention, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
-const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, threadCanRecieveMessages, commandMention } = require("../shared");
+const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, commandMention } = require("../shared");
 const { timeConversion } = require("../../shared");
 
 /** @type {typeof import("../../logic")} */
@@ -55,7 +55,7 @@ module.exports = new ItemTemplateSet(
 						(await bountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(interaction.guild.scheduledEvents))] });
 						await unarchiveAndUnlockThread(bountyThread, "Bounty Thumbnail item used");
 					}
-					if (threadCanRecieveMessages(bountyThread)) {
+					if (bountyThread.sendable) {
 						bountyThread.send({ content: `This bounty's poster used ${commandMention("item")} to add a thumbnail to this bounty.`, flags: MessageFlags.SuppressNotifications });
 					}
 				}

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -2,7 +2,7 @@ const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, us
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError, getBountyBoardThread, threadCanRecieveMessages, refreshBountyBoardThread } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError, getBountyBoardThread, refreshBountyBoardThread } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 const { bountyPing } = require('../shared/flows/bountyPing');
@@ -72,7 +72,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty turn-ins recorded by poster");
 				}
-				if (threadCanRecieveMessages(modalSubmission.channel)) {
+				if (modalSubmission.channel.sendable) {
 					modalSubmission.reply({ content: `${sentenceListEN(Array.from(newTurnInIds.values().map(id => userMention(id))))} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
 				}
 			} break;
@@ -110,7 +110,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty turn-ins revoked by poster");
 				}
-				if (threadCanRecieveMessages(modalSubmission.channel)) {
+				if (modalSubmission.channel.sendable) {
 					modalSubmission.reply({ content: `${sentenceListEN(removedIds.map(id => userMention(id)))} ${removedIds.length === 1 ? "has" : "have"} been removed as ${removedIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
 				}
 			} break;
@@ -169,7 +169,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					modalSubmission.message.edit({ embeds });
 					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty showcased by poster");
 				}
-				if (threadCanRecieveMessages(modalSubmission.channel)) {
+				if (modalSubmission.channel.sendable) {
 					modalSubmission.reply({ content: `${modalSubmission.member} increased the reward on this bounty!` });
 				}
 			} break;
@@ -275,7 +275,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				if (threadCanRecieveMessages(modalSubmission.channel)) {
+				if (modalSubmission.channel.sendable) {
 					await modalSubmission.deferReply({ flags: MessageFlags.SuppressNotifications });
 				}
 				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
@@ -390,7 +390,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 						refreshBountyBoardThread(modalSubmission.message, { title: bounty.title, embed }, auditLogReason);
 						await unarchiveAndUnlockThread(modalSubmission.channel, "Unarchived to update posting");
 					}
-					if (threadCanRecieveMessages(modalSubmission.channel)) {
+					if (modalSubmission.channel.sendable) {
 						await modalSubmission.reply({ content: "This bounty was edited.", flags: MessageFlags.SuppressNotifications });
 						modalSubmission.followUp({ content: `You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds: [embed], flags: MessageFlags.Ephemeral })
 					}
@@ -475,7 +475,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.guild, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 					await unarchiveAndUnlockThread(modalSubmission.channel, auditLogReason);
 				}
-				if (threadCanRecieveMessages(modalSubmission.channel)) {
+				if (modalSubmission.channel.sendable) {
 					modalSubmission.channel.send({ content: `This bounty's slot was switched from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`, flags: MessageFlags.SuppressNotifications });
 				}
 
@@ -487,7 +487,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 							(await destinationBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.guild, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(destinationBounty.id), await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
 							await unarchiveAndUnlockThread(destinationBountyThread, auditLogReason);
 						}
-						if (threadCanRecieveMessages(destinationBountyThread)) {
+						if (destinationBountyThread.sendable) {
 							destinationBountyThread.send({ content: `This bounty's slot was switched from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`, flags: MessageFlags.SuppressNotifications });
 						}
 					}

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -1,8 +1,8 @@
-const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, userMention, ChannelSelectMenuBuilder, ChannelType, PermissionFlagsBits, ButtonBuilder, StringSelectMenuBuilder, bold, ButtonStyle, TimestampStyles, ModalBuilder, LabelBuilder, TextDisplayBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, userMention, ChannelSelectMenuBuilder, ChannelType, PermissionFlagsBits, ButtonBuilder, StringSelectMenuBuilder, bold, ButtonStyle, TimestampStyles, ModalBuilder, LabelBuilder, TextDisplayBuilder, TextInputBuilder, TextInputStyle, strikethrough } = require('discord.js');
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, refreshBountyThreadStarterMessage, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, addLogMessageToBountyThread, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError, getBountyBoardThread, threadCanRecieveMessages, refreshBountyBoardThread } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 const { bountyPing } = require('../shared/flows/bountyPing');
@@ -67,10 +67,14 @@ module.exports = new SelectWrapper(mainId, 3000,
 				}
 
 				await logicLayer.bounties.bulkCreateCompletions(bounty.id, bounty.companyId, Array.from(eligibleTurnInIds), null);
-				await unarchiveAndUnlockThread(modalSubmission.channel, "Unarchived to update posting");
-				modalSubmission.reply({ content: `${sentenceListEN(Array.from(newTurnInIds.values().map(id => userMention(id))))} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
 
-				interaction.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, eligibleTurnInIds, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty turn-ins recorded by poster");
+				}
+				if (threadCanRecieveMessages(modalSubmission.channel)) {
+					modalSubmission.reply({ content: `${sentenceListEN(Array.from(newTurnInIds.values().map(id => userMention(id))))} ${newTurnInIds.size === 1 ? "has" : "have"} turned in this bounty! ${randomCongratulatoryPhrase()}!` });
+				}
 			} break;
 			case "revoketurnin": {
 				const labelIdBountyHunters = "bounty-hunters";
@@ -101,10 +105,14 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 				const removedIds = modalSubmission.fields.getSelectedMembers(labelIdBountyHunters).map((_, key) => key);
 				await logicLayer.bounties.deleteSelectedBountyCompletions(bountyId, removedIds);
-				await unarchiveAndUnlockThread(modalSubmission.channel, "completers removed from bounty");
-				modalSubmission.reply({ content: `${sentenceListEN(removedIds.map(id => userMention(id)))} ${removedIds.length === 1 ? "has" : "have"} been removed as ${removedIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
 
-				interaction.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] })
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty turn-ins revoked by poster");
+				}
+				if (threadCanRecieveMessages(modalSubmission.channel)) {
+					modalSubmission.reply({ content: `${sentenceListEN(removedIds.map(id => userMention(id)))} ${removedIds.length === 1 ? "has" : "have"} been removed as ${removedIds.length === 1 ? "a completer" : "completers"} of this bounty.` });
+				}
 			} break;
 			case "showcase": {
 				const nextShowcaseInMS = new Date(origin.hunter.lastShowcaseTimestamp).valueOf() + timeConversion(1, "w", "ms");
@@ -152,16 +160,18 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 				bounty = await bounty.increment("showcaseCount");
 				await origin.hunter.update({ lastShowcaseTimestamp: new Date() });
-				const hunterIdSet = await logicLayer.bounties.getHunterIdSet(bountyId);
 				const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-				const updatedEmbeds = [bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, hunterIdSet, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))]
-				channel.send({
-					content: `${modalSubmission.member} increased the reward on their bounty!`,
-					embeds: updatedEmbeds
-				});
-				await unarchiveAndUnlockThread(channel, "bounty showcased");
-				modalSubmission.reply({ content: `Your bounty ${bold(bounty.title)} was showcased in ${channel} and its reward was increased!`, flags: MessageFlags.Ephemeral });
-				interaction.message.edit({ embeds: updatedEmbeds })
+				const embeds = [bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))];
+
+				channel.send({ content: `${modalSubmission.member} increased the reward on their bounty!`, embeds });
+
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					modalSubmission.message.edit({ embeds });
+					await unarchiveAndUnlockThread(modalSubmission.channel, "bounty showcased by poster");
+				}
+				if (threadCanRecieveMessages(modalSubmission.channel)) {
+					modalSubmission.reply({ content: `${modalSubmission.member} increased the reward on this bounty!` });
+				}
 			} break;
 			case "ping":
 				const labelIdMessage = "message";
@@ -265,7 +275,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 					return;
 				}
 
-				await modalSubmission.deferReply({ flags: MessageFlags.SuppressNotifications });
+				if (threadCanRecieveMessages(modalSubmission.channel)) {
+					await modalSubmission.deferReply({ flags: MessageFlags.SuppressNotifications });
+				}
 				const season = await logicLayer.seasons.incrementSeasonStat(bounty.companyId, "bountiesCompleted");
 
 				let hunterMap = await logicLayer.hunters.getCompanyHunterMap(origin.company.id);
@@ -283,16 +295,17 @@ module.exports = new SelectWrapper(mainId, 3000,
 				const participationMap = await logicLayer.seasons.getParticipationMap(season.id);
 				const seasonalHunterReceipts = await logicLayer.seasons.updatePlacementsAndRanks(participationMap, descendingRanks, await modalSubmission.guild.roles.fetch());
 				syncRankRoles(seasonalHunterReceipts, descendingRanks, modalSubmission.guild.members);
-
-				await unarchiveAndUnlockThread(modalSubmission.channel, "bounty complete");
-				modalSubmission.channel.setAppliedTags([origin.company.bountyBoardCompletedTagId]);
 				consolidateHunterReceipts(hunterReceipts, seasonalHunterReceipts);
+
 				await modalSubmission.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
-				await modalSubmission.message.edit({
-					embeds: [bountyEmbed(bounty, modalSubmission.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys()), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress)],
-					components: []
-				});
-				modalSubmission.channel.setArchived(true, "bounty completed");
+
+				const auditLogReason = "bounty marked completed by poster";
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					refreshBountyBoardThread(modalSubmission.message, { title: strikethrough(bounty.title), embed: bountyEmbed(bounty, modalSubmission.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys()), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress) }, auditLogReason);
+					await unarchiveAndUnlockThread(modalSubmission.channel, auditLogReason);
+				}
+				modalSubmission.channel.edit({ archived: true, appliedTags: [origin.company.bountyBoardCompletedTagId], reason: auditLogReason });
+
 				const announcementOptions = { content: `${userMention(bounty.userId)}'s bounty, ${modalSubmission.channel}, was completed!` };
 				if (goalProgress.goalCompleted) {
 					announcementOptions.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
@@ -335,11 +348,9 @@ module.exports = new SelectWrapper(mainId, 3000,
 						return;
 					}
 
-					await unarchiveAndUnlockThread(modalSubmission.channel, "Unarchived to update posting");
 					const updatePayload = { editCount: bounty.editCount + 1 };
 					if (title) {
 						updatePayload.title = title;
-						modalSubmission.channel.edit({ name: bounty.title });
 					}
 
 					updatePayload.description = description;
@@ -371,12 +382,18 @@ module.exports = new SelectWrapper(mainId, 3000,
 					}
 					await bounty.update(updatePayload);
 
-					// update bounty board
-					const embeds = [bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event)];
-					modalSubmission.channel.send({ content: "The bounty was edited.", flags: MessageFlags.SuppressNotifications });
-					interaction.message.edit({ embeds });
+					const embed = bountyEmbed(bounty, modalSubmission.member, origin.hunter.getLevel(origin.company.xpCoefficient), false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), event);
 
-					modalSubmission.reply({ content: `Bounty edited! You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds, flags: MessageFlags.Ephemeral });
+					// update bounty board
+					const auditLogReason = "bounty edited by poster";
+					if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+						refreshBountyBoardThread(modalSubmission.message, { title: bounty.title, embed }, auditLogReason);
+						await unarchiveAndUnlockThread(modalSubmission.channel, "Unarchived to update posting");
+					}
+					if (threadCanRecieveMessages(modalSubmission.channel)) {
+						await modalSubmission.reply({ content: "This bounty was edited.", flags: MessageFlags.SuppressNotifications });
+						modalSubmission.followUp({ content: `You can use ${commandMention("bounty showcase")} to let other bounty hunters know about the changes.`, embeds: [embed], flags: MessageFlags.Ephemeral })
+					}
 				});
 			} break;
 			case "swap": {
@@ -449,15 +466,31 @@ module.exports = new SelectWrapper(mainId, 3000,
 				const sourceSlot = bounty.slotNumber;
 				let destinationBounty = await logicLayer.bounties.findBounty({ slotNumber: destinationSlot, userId: origin.user.id, companyId: origin.company.id, state: "open" });
 				const destinationRewardValue = Bounty.calculateCompleterReward(currentPosterLevel, destinationSlot, bounty.showcaseCount);
+				const auditLogReason = destinationBounty ?
+					`bounty poster swapped slots of bounties ${sourceSlot} and ${destinationSlot}` :
+					`bounty swapped from slot ${sourceSlot} to ${destinationSlot} by poster`;
 
 				bounty = await bounty.update({ slotNumber: destinationSlot });
-				refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, bounty, await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(bounty.id));
-				modalSubmission.reply({ content: `Switched this bounty's slot from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.` });
+				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					modalSubmission.message.edit({ embeds: [bountyEmbed(bounty, modalSubmission.guild, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+					await unarchiveAndUnlockThread(modalSubmission.channel, auditLogReason);
+				}
+				if (threadCanRecieveMessages(modalSubmission.channel)) {
+					modalSubmission.channel.send({ content: `This bounty's slot was switched from ${sourceSlot} to ${destinationSlot}. It is now worth ${destinationRewardValue} XP.`, flags: MessageFlags.SuppressNotifications });
+				}
 
 				if (destinationBounty) {
 					destinationBounty = await destinationBounty.update({ slotNumber: sourceSlot });
-					refreshBountyThreadStarterMessage(modalSubmission.guild, origin.company, destinationBounty, await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), modalSubmission.member, currentPosterLevel, await logicLayer.bounties.getHunterIdSet(destinationBounty.id));
-					addLogMessageToBountyThread(modalSubmission.guild, origin.company, destinationBounty, `Switched this bounty's slot from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`);
+					const destinationBountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, destinationBounty.postingId);
+					if (destinationBountyThread) {
+						if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+							(await destinationBountyThread.fetchStarterMessage()).edit({ embeds: [bountyEmbed(bounty, modalSubmission.guild, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(destinationBounty.id), await destinationBounty.getScheduledEvent(modalSubmission.guild.scheduledEvents))] });
+							await unarchiveAndUnlockThread(destinationBountyThread, auditLogReason);
+						}
+						if (threadCanRecieveMessages(destinationBountyThread)) {
+							destinationBountyThread.send({ content: `This bounty's slot was switched from ${destinationSlot} to ${sourceSlot}. It is now worth ${Bounty.calculateCompleterReward(currentPosterLevel, sourceSlot, destinationBounty.showcaseCount)} XP.`, flags: MessageFlags.SuppressNotifications });
+						}
+					}
 				}
 
 				const channel = modalSubmission.fields.getSelectedChannels(labelIdChannel).first();

--- a/source/frontend/selects/bountycontrolpanel.js
+++ b/source/frontend/selects/bountycontrolpanel.js
@@ -2,7 +2,7 @@ const { MessageFlags, ActionRowBuilder, UserSelectMenuBuilder, ComponentType, us
 const { SelectWrapper } = require('../classes');
 const { SKIP_INTERACTION_HANDLING, ZERO_WIDTH_WHITE_SPACE } = require('../../constants');
 const { timeConversion, discordTimestamp } = require('../../shared');
-const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError, getBountyBoardThread, refreshBountyBoardThread } = require('../shared');
+const { sentenceListEN, randomCongratulatoryPhrase, bountyEmbed, commandMention, syncRankRoles, goalCompletionEmbed, emojiFromNumber, addCompanyAnnouncementPrefix, textsHaveAutoModInfraction, bountyScheduledEventPayload, validateScheduledEventTimestamps, editBountyModalAndSubmissionOptions, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, butIgnoreMissingPermissionErrors, rewardSummary, consolidateHunterReceipts, refreshReferenceChannelScoreboardSeasonal, refreshReferenceChannelScoreboardOverall, isMissingPermissionError, truncateTextToLength, butIgnoreErrorIf, isUnknownGuildScheduledEventError, getBountyBoardThread, refreshBountyBoardThread, auditReasonBountyComplete } = require('../shared');
 const { Company, Bounty, Hunter } = require('../../database/models');
 const { SelectMenuLimits } = require('@sapphire/discord.js-utilities');
 const { bountyPing } = require('../shared/flows/bountyPing');
@@ -299,7 +299,7 @@ module.exports = new SelectWrapper(mainId, 3000,
 
 				await modalSubmission.editReply({ content: rewardSummary("bounty", companyReceipt, hunterReceipts, origin.company.maxSimBounties) });
 
-				const auditLogReason = "bounty marked completed by poster";
+				const auditLogReason = auditReasonBountyComplete;
 				if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
 					refreshBountyBoardThread(modalSubmission.message, { title: strikethrough(bounty.title), embed: bountyEmbed(bounty, modalSubmission.member, hunterMap.get(bounty.userId).getLevel(origin.company.xpCoefficient), true, origin.company, new Set(validatedHunters.keys()), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents), goalProgress) }, auditLogReason);
 					await unarchiveAndUnlockThread(modalSubmission.channel, auditLogReason);

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -69,11 +69,6 @@ async function unarchiveAndUnlockThread(thread, auditLogReason) {
 	}
 }
 
-/** @param {ThreadChannel} thread */
-function threadCanRecieveMessages(thread) {
-	return !(thread.archived || thread.locked);
-}
-
 /** Updates the embeds in a forum thread's title and starter message
  * @param {Message} starterMessage
  * @param {{ title: string; embed: EmbedBuilder; }} changes
@@ -237,7 +232,6 @@ module.exports = {
 	refreshEvergreenBountiesThread,
 	makeEvergreenBountiesThread,
 	unarchiveAndUnlockThread,
-	threadCanRecieveMessages,
 	refreshBountyBoardThread,
 	getBountyBoardThread,
 	refreshReferenceChannelScoreboardSeasonal,

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -1,8 +1,9 @@
-const { GuildTextThreadManager, EmbedBuilder, Guild, MessageFlags, Message, GuildMemberManager, ForumChannel, ThreadChannel, GuildMember, GuildScheduledEvent } = require("discord.js");
+const { GuildTextThreadManager, EmbedBuilder, Guild, MessageFlags, Message, GuildMemberManager, ForumChannel, ThreadChannel, GuildMember } = require("discord.js");
 const { Bounty, Company, Rank, Participation } = require("../../database/models");
 const { bountyEmbed, overallScoreboardEmbed, seasonalScoreboardEmbed } = require("./dAPISerializers");
 const { ascendingByProperty } = require("../../shared");
 const { GuildMemberLimits } = require("@sapphire/discord.js-utilities");
+const { butIgnoreUnknownChannelErrors, butIgnoreUnknownMessageErrors } = require("./dAPIResponses");
 
 /**
  * @file Discord API (dAPI) Requests - groups of requests to dAPI formalized into functions
@@ -55,48 +56,56 @@ async function refreshEvergreenBountiesThread(bountyBoardChannel, evergreenBount
 	}
 }
 
-/** Update the bounty's embed in the bounty board
- * @param {Guild} guild
- * @param {Company} company
- * @param {Bounty} bounty
- * @param {GuildScheduledEvent | null} bountyScheduledEvent
- * @param {GuildMember} posterGuildMember
- * @param {number} posterLevel
- * @param {Set<string>} hunterIdSet
+/**
+ * @param {ThreadChannel} thread
+ * @param {string} auditLogReason
  */
-async function refreshBountyThreadStarterMessage(guild, company, bounty, bountyScheduledEvent, posterGuildMember, posterLevel, hunterIdSet) {
-	if (!company.bountyBoardId || !bounty.postingId) {
-		return null;
+async function unarchiveAndUnlockThread(thread, auditLogReason) {
+	if (thread.archived) {
+		await thread.setArchived(false, auditLogReason);
 	}
-
-	return guild.channels.fetch(company.bountyBoardId).then(bountyBoard => {
-		return bountyBoard.threads.fetch(bounty.postingId);
-	}).then(async thread => {
-		await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-		thread.edit({ name: bounty.title });
-		return thread.fetchStarterMessage();
-	}).then(async posting => {
-		posting.edit({ embeds: [bountyEmbed(bounty, posterGuildMember, posterLevel, false, company, hunterIdSet, bountyScheduledEvent)] });
-		return posting;
-	})
+	if (thread.locked) {
+		await thread.setLocked(false, auditLogReason);
+	}
 }
 
-/** Add a message to the bounty in the bounty board to log state changes.
- * To avoid spam and for general bounty readability, limit using this to
- * once per bounty per command.
- * @param {Guild} guild
- * @param {Company} company
- * @param {Bounty} bounty
- * @param {string} auditMessage
+/** @param {ThreadChannel} thread */
+function threadCanRecieveMessages(thread) {
+	return !(thread.archived || thread.locked);
+}
+
+/** Updates the embeds in a forum thread's title and starter message
+ * @param {Message} starterMessage
+ * @param {{ title: string; embed: EmbedBuilder; }} changes
+ * @param {string} auditLogReason the reason to group all changes under in the server's audit log
  */
-async function addLogMessageToBountyThread(guild, company, bounty, auditMessage) {
-	if (!company.bountyBoardId || !bounty.postingId) {
+async function refreshBountyBoardThread(starterMessage, { title, embed }, auditLogReason) {
+	if (title !== starterMessage.channel.name) {
+		starterMessage.channel.edit({ name: title, reason: auditLogReason });
+	}
+
+	const starterMessageEditPayload = { embeds: [embed] };
+	if (auditLogReason === "bounty marked completed by poster") {
+		starterMessageEditPayload.components = [];
+	}
+	starterMessage.edit(starterMessageEditPayload);
+}
+
+/** Fetches a bounty's thread from the bounty board forum
+ * @param {Guild} guild
+ * @param {string} bountyBoardId
+ * @param {string} postingId
+ * @returns {Promise<ThreadChannel | null>}
+ */
+async function getBountyBoardThread(guild, bountyBoardId, postingId) {
+	if (!bountyBoardId || !postingId) {
 		return null;
 	}
-	const bountyBoard = await guild.channels.fetch(company.bountyBoardId);
-	const thread = await bountyBoard.threads.fetch(bounty.postingId);
-	await unarchiveAndUnlockThread(thread, "Unarchived to update posting");
-	return thread.send({ content: auditMessage, flags: MessageFlags.SuppressNotifications });
+	const bountyBoard = await guild.channels.fetch(bountyBoardId).catch(butIgnoreUnknownChannelErrors);
+	if (!bountyBoard) {
+		return null;
+	}
+	return bountyBoard.threads.fetch(postingId).catch(butIgnoreUnknownMessageErrors) ?? null;
 }
 
 /** Update the Seasonal Scoreboard embed in a server's scoreboard reference channel
@@ -200,19 +209,6 @@ async function syncRankRoles(hunterRecipts, descendingRanks, guildMemberManager)
 }
 
 /**
- * @param {ThreadChannel} thread
- * @param {string} auditLogReason
- */
-async function unarchiveAndUnlockThread(thread, auditLogReason) {
-	if (thread.archived) {
-		await thread.setArchived(false, auditLogReason);
-	}
-	if (thread.locked) {
-		await thread.setLocked(false, auditLogReason);
-	}
-}
-
-/**
  * @param {GuildMember} bountyBotGuildMember
  * @param {Company} company
  */
@@ -240,12 +236,13 @@ async function updateBotNicknameForFestival(bountyBotGuildMember, company) {
 module.exports = {
 	refreshEvergreenBountiesThread,
 	makeEvergreenBountiesThread,
-	refreshBountyThreadStarterMessage,
-	addLogMessageToBountyThread,
+	unarchiveAndUnlockThread,
+	threadCanRecieveMessages,
+	refreshBountyBoardThread,
+	getBountyBoardThread,
 	refreshReferenceChannelScoreboardSeasonal,
 	refreshReferenceChannelScoreboardOverall,
 	sendRewardMessage,
 	syncRankRoles,
-	unarchiveAndUnlockThread,
 	updateBotNicknameForFestival
 };

--- a/source/frontend/shared/dAPIRequests.js
+++ b/source/frontend/shared/dAPIRequests.js
@@ -3,7 +3,7 @@ const { Bounty, Company, Rank, Participation } = require("../../database/models"
 const { bountyEmbed, overallScoreboardEmbed, seasonalScoreboardEmbed } = require("./dAPISerializers");
 const { ascendingByProperty } = require("../../shared");
 const { GuildMemberLimits } = require("@sapphire/discord.js-utilities");
-const { butIgnoreUnknownChannelErrors, butIgnoreUnknownMessageErrors } = require("./dAPIResponses");
+const { butIgnoreUnknownChannelErrors, isUnknownMessageError } = require("./dAPIResponses");
 
 /**
  * @file Discord API (dAPI) Requests - groups of requests to dAPI formalized into functions
@@ -69,6 +69,8 @@ async function unarchiveAndUnlockThread(thread, auditLogReason) {
 	}
 }
 
+const auditReasonBountyComplete = "bounty marked completed by poster";
+
 /** Updates the embeds in a forum thread's title and starter message
  * @param {Message} starterMessage
  * @param {{ title: string; embed: EmbedBuilder; }} changes
@@ -80,7 +82,7 @@ async function refreshBountyBoardThread(starterMessage, { title, embed }, auditL
 	}
 
 	const starterMessageEditPayload = { embeds: [embed] };
-	if (auditLogReason === "bounty marked completed by poster") {
+	if (auditLogReason === auditReasonBountyComplete) {
 		starterMessageEditPayload.components = [];
 	}
 	starterMessage.edit(starterMessageEditPayload);
@@ -100,7 +102,12 @@ async function getBountyBoardThread(guild, bountyBoardId, postingId) {
 	if (!bountyBoard) {
 		return null;
 	}
-	return bountyBoard.threads.fetch(postingId).catch(butIgnoreUnknownMessageErrors) ?? null;
+	return bountyBoard.threads.fetch(postingId).catch(error => {
+		if (!isUnknownMessageError(error)) {
+			console.error(error);
+		}
+		return null;
+	});
 }
 
 /** Update the Seasonal Scoreboard embed in a server's scoreboard reference channel
@@ -232,6 +239,7 @@ module.exports = {
 	refreshEvergreenBountiesThread,
 	makeEvergreenBountiesThread,
 	unarchiveAndUnlockThread,
+	auditReasonBountyComplete,
 	refreshBountyBoardThread,
 	getBountyBoardThread,
 	refreshReferenceChannelScoreboardSeasonal,

--- a/source/frontend/shared/dAPIResponses.js
+++ b/source/frontend/shared/dAPIResponses.js
@@ -19,6 +19,7 @@ function butIgnoreErrorIf(...ignoreThese) {
 const isAutomodError = error => [200000, 200001].includes(error.code);
 const isInteractionCollectorError = error => error.code === DiscordjsErrorCodes.InteractionCollectorError;
 const isUnknownChannelError = error => error.code === 10003;
+const isUnknownMessageError = error => error.code === 10008;
 const isUnknownGuildScheduledEventError = error => error.code === 10070;
 const isMissingPermissionError = error => error.code === 50013;
 const isCantDirectMessageThisUserError = error => error.code === 50007;
@@ -27,6 +28,8 @@ const isCantDirectMessageThisUserError = error => error.code === 50007;
 const butIgnoreInteractionCollectorErrors = butIgnoreErrorIf(isInteractionCollectorError);
 
 const butIgnoreUnknownChannelErrors = butIgnoreErrorIf(isUnknownChannelError);
+
+const butIgnoreUnknownMessageErrors = butIgnoreErrorIf(isUnknownMessageError);
 
 const butIgnoreMissingPermissionErrors = butIgnoreErrorIf(isMissingPermissionError);
 
@@ -37,11 +40,13 @@ module.exports = {
 	isAutomodError,
 	isInteractionCollectorError,
 	isUnknownChannelError,
+	isUnknownMessageError,
 	isUnknownGuildScheduledEventError,
 	isMissingPermissionError,
 	isCantDirectMessageThisUserError,
 	butIgnoreInteractionCollectorErrors,
 	butIgnoreUnknownChannelErrors,
+	butIgnoreUnknownMessageErrors,
 	butIgnoreMissingPermissionErrors,
 	butIgnoreCantDirectMessageThisUserErrors
 }

--- a/source/frontend/shared/flows/bountyPing.js
+++ b/source/frontend/shared/flows/bountyPing.js
@@ -1,6 +1,5 @@
 const { MessageFlags, userMention, ModalSubmitInteraction, ThreadChannel } = require("discord.js");
 const { Bounty } = require("../../../database/models");
-const { threadCanRecieveMessages } = require("../dAPIRequests");
 
 /**
  * @param {ModalSubmitInteraction} modalSubmission
@@ -44,7 +43,7 @@ async function bountyPing(modalSubmission, labelIds, bounty, bountyThread) {
 		}
 	}
 
-	if (threadCanRecieveMessages(modalSubmission.channel)) {
+	if (modalSubmission.channel.sendable) {
 		modalSubmission.reply({ content: `${Array.from(interestedHunterIds.values()).map(id => userMention(id))} ${modalSubmission.fields.getTextInputValue(labelIds.message)}` });
 	}
 }

--- a/source/frontend/shared/flows/bountyPing.js
+++ b/source/frontend/shared/flows/bountyPing.js
@@ -1,11 +1,12 @@
-const { MessageFlags, userMention, ModalSubmitInteraction } = require("discord.js");
+const { MessageFlags, userMention, ModalSubmitInteraction, ThreadChannel } = require("discord.js");
 const { Bounty } = require("../../../database/models");
+const { threadCanRecieveMessages } = require("../dAPIRequests");
 
 /**
  * @param {ModalSubmitInteraction} modalSubmission
  * @param {{ message: string; excludedBountyHunters: string; }} labelIds
  * @param {Bounty} bounty
- * @param {import("discord.js").ForumThreadChannel | undefined} bountyThread
+ * @param {ThreadChannel | null} bountyThread
  */
 async function bountyPing(modalSubmission, labelIds, bounty, bountyThread) {
 	if (!bounty || bounty.state !== "open") {
@@ -43,7 +44,9 @@ async function bountyPing(modalSubmission, labelIds, bounty, bountyThread) {
 		}
 	}
 
-	modalSubmission.reply({ content: `${Array.from(interestedHunterIds.values()).map(id => userMention(id))} ${modalSubmission.fields.getTextInputValue(labelIds.message)}` });
+	if (threadCanRecieveMessages(modalSubmission.channel)) {
+		modalSubmission.reply({ content: `${Array.from(interestedHunterIds.values()).map(id => userMention(id))} ${modalSubmission.fields.getTextInputValue(labelIds.message)}` });
+	}
 }
 
 module.exports = {

--- a/source/frontend/shared/flows/bountyTakeDown.js
+++ b/source/frontend/shared/flows/bountyTakeDown.js
@@ -8,7 +8,7 @@ const { syncRankRoles } = require("../dAPIRequests");
  * @param {Guild} guild
  * @param {Bounty} bounty
  * @param {Hunter} posterHunter
- * @param {import("discord.js").ForumThreadChannel | undefined} bountyThread
+ * @param {import("discord.js").ForumThreadChannel | null} bountyThread
  */
 async function bountyTakeDown(logicLayer, guild, bounty, posterHunter, bountyThread) {
 	await logicLayer.bounties.deleteBountyCompletions(bounty.id);

--- a/wiki/Developers.md
+++ b/wiki/Developers.md
@@ -25,6 +25,7 @@ Welcome prospective developers! We're so glad you've interested in helping out.
 - This project uses tabs for indentation to reduce file size and keypresses during code navigation
 - Bot feedback messages should be written in 3rd-person passive tense (to avoid unnecessary personification) and make requests in polite language
     - Example: "Your bounty could not be posted. Please remove phrases disallowed by the server from the title and try again."
+- Within a single command flow, use a constant string for audit log reason, to make it easier for Discord to bundle logs
 
 ### File and Directory Naming Convention
 Please use `camelCase` unless one of the following exceptions apply:


### PR DESCRIPTION
Summary
-------
This initially looked like it would be a logic DRYing effort, but context differences made it feel more important to value composibility despite the appearance of duplication.

The main "similar appearing" code has 4 parts, 3 of which vary based on context:
1. Thread mutations (some flows only want to update the embeds, others also want to update the thread name)
2. Attempt to prepare the thread for 3 & 4
3. Acknowledge the pending interaction (reply vs update, ephemeral vs public, etc)
4. Other side-effects (announcements in other channels, etc)

Many of these steps are single lines (after getting required resources [which is also context dependent] and actually getting into the then block that allows them to fire), so creating a larger controller to handle the dynamism feels quite overkill to me at this time.

More important in my opinion is the 4th bullet below: wherein we can make help server admins by keeping their Audit Logs readable.

- cull duplicate fetches of bounty threads
- implement bounty board thread getter to consistently handle thread and forum request misses
- refactored log message logic to reduce duplicate detection logic and avoid awaiting requests known to be missing permissions
- discovered Discord "audit log bundling", and started "one audit log reason per flow" convention

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/bounty record-turn-ins` completes critical path without crashing

Issue
-----
Closes #609, Closes #561