### PR TITLE
Use unsigned database columns for counters

### DIFF
--- a/migrations/20260515002000-unsignedCountColumns.js
+++ b/migrations/20260515002000-unsignedCountColumns.js
@@ -1,0 +1,109 @@
+'use strict';
+
+function unsignedBigInt(Sequelize, options = {}) {
+	return { type: Sequelize.BIGINT.UNSIGNED, ...options };
+}
+
+function unsignedInteger(Sequelize, options = {}) {
+	return { type: Sequelize.INTEGER.UNSIGNED, ...options };
+}
+
+function signedBigInt(Sequelize, options = {}) {
+	return { type: Sequelize.BIGINT, ...options };
+}
+
+function signedInteger(Sequelize, options = {}) {
+	return { type: Sequelize.INTEGER, ...options };
+}
+
+async function changeColumns(queryInterface, Sequelize, definitions) {
+	for (const [table, columns] of Object.entries(definitions)) {
+		const tableDescription = await queryInterface.describeTable(table);
+		for (const [column, definition] of Object.entries(columns)) {
+			if (column in tableDescription) {
+				await queryInterface.changeColumn(table, column, definition(Sequelize));
+			}
+		}
+	}
+}
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		await changeColumns(queryInterface, Sequelize, {
+			Hunter: {
+				xp: S => unsignedBigInt(S, { defaultValue: 0 }),
+				mineFinished: S => unsignedBigInt(S, { defaultValue: 0 }),
+				othersFinished: S => unsignedBigInt(S, { defaultValue: 0 }),
+				toastsRaised: S => unsignedBigInt(S, { defaultValue: 0 }),
+				toastsSeconded: S => unsignedBigInt(S, { defaultValue: 0 }),
+				toastsReceived: S => unsignedBigInt(S, { defaultValue: 0 }),
+				goalsInitiated: S => unsignedBigInt(S, { defaultValue: 0 }),
+				goalContributions: S => unsignedBigInt(S, { defaultValue: 0 }),
+				penaltyCount: S => unsignedBigInt(S, { defaultValue: 0 }),
+				penaltyPointTotal: S => unsignedBigInt(S, { defaultValue: 0 })
+			},
+			Participation: {
+				xp: S => unsignedBigInt(S, { defaultValue: 0 }),
+				placement: S => unsignedInteger(S, { defaultValue: 0 }),
+				rankIndex: S => unsignedInteger(S),
+				postingsCompleted: S => unsignedInteger(S, { defaultValue: 0 }),
+				toastsRaised: S => unsignedInteger(S, { defaultValue: 0 }),
+				goalContributions: S => unsignedInteger(S, { defaultValue: 0 }),
+				dqCount: S => unsignedInteger(S, { defaultValue: 0 })
+			},
+			Season: {
+				bountiesCompleted: S => unsignedBigInt(S, { defaultValue: 0 }),
+				toastsRaised: S => unsignedBigInt(S, { defaultValue: 0 })
+			},
+			Goal: {
+				requiredGP: S => unsignedBigInt(S, { allowNull: false })
+			},
+			Bounty: {
+				slotNumber: S => unsignedInteger(S, { allowNull: false })
+			},
+			Completion: {
+				xpAwarded: S => unsignedInteger(S)
+			}
+		});
+	},
+
+	async down(queryInterface, Sequelize) {
+		await changeColumns(queryInterface, Sequelize, {
+			Hunter: {
+				xp: S => signedBigInt(S, { defaultValue: 0 }),
+				mineFinished: S => signedBigInt(S, { defaultValue: 0 }),
+				othersFinished: S => signedBigInt(S, { defaultValue: 0 }),
+				toastsRaised: S => signedBigInt(S, { defaultValue: 0 }),
+				toastsSeconded: S => signedBigInt(S, { defaultValue: 0 }),
+				toastsReceived: S => signedBigInt(S, { defaultValue: 0 }),
+				goalsInitiated: S => signedBigInt(S, { defaultValue: 0 }),
+				goalContributions: S => signedBigInt(S, { defaultValue: 0 }),
+				penaltyCount: S => signedBigInt(S, { defaultValue: 0 }),
+				penaltyPointTotal: S => signedBigInt(S, { defaultValue: 0 })
+			},
+			Participation: {
+				xp: S => signedBigInt(S, { defaultValue: 0 }),
+				placement: S => signedInteger(S, { defaultValue: 0 }),
+				rankIndex: S => signedInteger(S),
+				postingsCompleted: S => signedInteger(S, { defaultValue: 0 }),
+				toastsRaised: S => signedInteger(S, { defaultValue: 0 }),
+				goalContributions: S => signedInteger(S, { defaultValue: 0 }),
+				dqCount: S => signedInteger(S, { defaultValue: 0 })
+			},
+			Season: {
+				bountiesCompleted: S => signedBigInt(S, { defaultValue: 0 }),
+				toastsRaised: S => signedBigInt(S, { defaultValue: 0 })
+			},
+			Goal: {
+				requiredGP: S => signedBigInt(S, { allowNull: false })
+			},
+			Bounty: {
+				slotNumber: S => signedInteger(S, { allowNull: false })
+			},
+			Completion: {
+				xpAwarded: S => signedInteger(S)
+			}
+		});
+	}
+};

--- a/source/database/models/bounties/Bounty.js
+++ b/source/database/models/bounties/Bounty.js
@@ -63,7 +63,7 @@ function initModel(sequelize) {
 			type: DataTypes.STRING
 		},
 		slotNumber: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			allowNull: false
 		},
 		isEvergreen: {

--- a/source/database/models/bounties/Completion.js
+++ b/source/database/models/bounties/Completion.js
@@ -33,7 +33,7 @@ function initModel(sequelize) {
 			type: DataTypes.STRING
 		},
 		xpAwarded: {
-			type: DataTypes.INTEGER
+			type: DataTypes.INTEGER.UNSIGNED
 		}
 	}, {
 		sequelize,

--- a/source/database/models/companies/Goal.js
+++ b/source/database/models/companies/Goal.js
@@ -30,7 +30,7 @@ function initModel(sequelize) {
 			allowNull: false
 		},
 		requiredGP: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			allowNull: false
 		}
 	}, {

--- a/source/database/models/seasons/Participation.js
+++ b/source/database/models/seasons/Participation.js
@@ -40,30 +40,30 @@ function initModel(sequelize) {
 			defaultValue: false
 		},
 		xp: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		placement: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			defaultValue: 0
 		},
 		rankIndex: {
-			type: DataTypes.INTEGER
+			type: DataTypes.INTEGER.UNSIGNED
 		},
 		postingsCompleted: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			defaultValue: 0
 		},
 		toastsRaised: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			defaultValue: 0
 		},
 		goalContributions: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			defaultValue: 0
 		},
 		dqCount: {
-			type: DataTypes.INTEGER,
+			type: DataTypes.INTEGER.UNSIGNED,
 			defaultValue: 0
 		}
 	}, {

--- a/source/database/models/seasons/Season.js
+++ b/source/database/models/seasons/Season.js
@@ -35,11 +35,11 @@ function initModel(sequelize) {
 			}
 		},
 		bountiesCompleted: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		toastsRaised: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		}
 	}, {

--- a/source/database/models/users/Hunter.js
+++ b/source/database/models/users/Hunter.js
@@ -74,38 +74,38 @@ function initModel(sequelize) {
 			type: DataTypes.STRING
 		},
 		xp: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		lastShowcaseTimestamp: {
 			type: DataTypes.DATE
 		},
 		mineFinished: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		othersFinished: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		toastsRaised: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		toastsSeconded: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		toastsReceived: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		goalsInitiated: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		goalContributions: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		isBanned: {
@@ -117,11 +117,11 @@ function initModel(sequelize) {
 			defaultValue: false
 		},
 		penaltyCount: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		penaltyPointTotal: {
-			type: DataTypes.BIGINT,
+			type: DataTypes.BIGINT.UNSIGNED,
 			defaultValue: 0
 		},
 		profileColor: {


### PR DESCRIPTION
## Summary
- Mark non-negative counter/score columns as unsigned in Sequelize models
- Add a reversible migration to update existing database columns
- Covers Hunter, Participation, Season, Goal, Bounty, and Completion fields listed in #616

## Validation
- `npm ci`
- `node -c` on updated model files and migration
- In-memory SQLite model sync plus migration `up`/`down` smoke test

Closes #616