### PR TITLE
#670: fix Seconder being added to toast embed recipient list on Crit Toast

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # BountyBot Change Log
-## BountyBot Version 2.12.0fi:
+## BountyBot Version 2.12.0fib:
 - Added command `/bounty ping` to mention bounty hunters who have reacted to the bounty's thread or marked themselves interested in the bounty's event
 - `/create-default bounty-board-forum` now has an option for customizing the new channel's name
+- Fixed Critical Secondings adding the Seconder to the Toast's list of recipients
 ## BountyBot Version 2.11.1ib:
 - Completing or taking down bounties now cancel the bounty's event if it hasn't been closed already
 - Fixed a crash when attempting to make an event for a bounty while missing permission

--- a/source/frontend/buttons/secondtoast.js
+++ b/source/frontend/buttons/secondtoast.js
@@ -31,7 +31,7 @@ module.exports = new ButtonWrapper(mainId, 3000,
 
 		const recipientIds = originalToast.Recipients.map(receipt => receipt.recipientId);
 
-		const hunterReceipts = await logicLayer.toasts.secondToast(origin.hunter, originalToast, origin.company, recipientIds.filter(id => id !== interaction.user.id), season.id);
+		const hunterReceipts = await logicLayer.toasts.secondToast(origin.hunter, originalToast, origin.company, recipientIds, season.id);
 
 		const { companyReceipt, goalProgress } = await logicLayer.goals.progressGoal(origin.company, "secondings", origin.hunter, season);
 		companyReceipt.guildName = interaction.guild.name;

--- a/source/logic/toasts.js
+++ b/source/logic/toasts.js
@@ -210,6 +210,9 @@ async function secondToast(seconder, toast, company, recipientIds, seasonId) {
 
 	const xpMultiplierString = company.festivalMultiplierString("xp");
 	for (const userId of recipientIds) {
+		if (userId === seconder.userId) {
+			continue;
+		}
 		const hunterReceipt = {};
 		const [participation, participationCreated] = await db.models.Participation.findOrCreate({ where: { companyId: company.id, userId, seasonId }, defaults: { xp: 1 } });
 		if (!participationCreated) {
@@ -263,7 +266,6 @@ async function secondToast(seconder, toast, company, recipientIds, seasonId) {
 
 		if (isToastCrit(Math.random() * 100, lowestEffectiveToastLevel)) {
 			critSeconds++;
-			recipientIds.push(seconder.userId);
 		}
 	}
 


### PR DESCRIPTION
Summary
-------
- fix Seconder being added to toast embed recipient list on Crit Toast
- move "exclude seconder from rewards" filter into logic layer

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] seconding a toast doesn't crash on critical path

Issue
-----
Closes #670