### PR TITLE
#636: use Container to show labeled received images in thumbnail config commands

### DIFF
--- a/source/frontend/commands/config-server-thumbnails-premium.js
+++ b/source/frontend/commands/config-server-thumbnails-premium.js
@@ -1,59 +1,27 @@
-const { PermissionFlagsBits, InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
-const { SKIP_INTERACTION_HANDLING } = require('../../constants');
+const { PermissionFlagsBits, InteractionContextType } = require("discord.js");
 const { CommandWrapper } = require("../classes");
-const { timeConversion } = require('../../shared');
+const { configCompanyThumbnails } = require("../shared/flows/configCompanyThumbnails");
 
 const mainId = "config-server-thumbnails-premium";
-const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
-	"scoreboard-thumbnail": {
-		payloadProperty: "scoreboardThumbnailURL",
-		messageStub: "scoreboard thumbnail",
+const thumbnailUpdateData = [
+	{
+		label: "Scoreboard Thumbnail",
 		description: "Set an image to use as thumbnail on the scoreboard",
-		modalLabel: "Scoreboard Thumbnail"
+		payloadProperty: "scoreboardThumbnailURL"
 	},
-	"goal-completion-thumbnail": {
-		payloadProperty: "goalCompletionThumbnailURL",
-		messageStub: "goal completion thumbnail",
+	{
+		label: "Goal Completion Thumbnail",
 		description: "Set an image to use as thumbnail in server goal completion messages",
-		modalLabel: "Goal Completion Thumbnail"
+		payloadProperty: "goalCompletionThumbnailURL"
 	},
-	"raffle-thumbnail": {
-		payloadProperty: "raffleThumbnailURL",
-		messageStub: "raffle thumbnail",
+	{
+		label: "Raffle Thumbnail",
 		description: "Set an image to use as thumbnail in raffle winner messages",
-		modalLabel: "Raffle Thumbnail"
+		payloadProperty: "raffleThumbnailURL"
 	}
-}));
+];
 module.exports = new CommandWrapper(mainId, "Configure thumbnails for server messages (Premium)", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	async (interaction, origin, runMode) => {
-		const modalLabelComponents = [];
-		for (const [imageField, { description, modalLabel }] of imageFieldToPayloadPropertyAndMessage) {
-			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
-				.setFileUploadComponent(
-					new FileUploadBuilder().setCustomId(imageField)
-						.setRequired(false)
-				))
-		}
-		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`).setTitle("Configure Server Thumbnails").addLabelComponents(modalLabelComponents);
-
-		interaction.showModal(modal);
-		const modalInteraction = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") });
-		const updatePayload = {};
-
-		let replyContent = "The following thumbnails have been configured:";
-
-		for (const [imageField, { payloadProperty, messageStub }] of imageFieldToPayloadPropertyAndMessage) {
-			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
-			if (thumbnailCollection) {
-				const firstAttachment = thumbnailCollection.first();
-				if (firstAttachment) {
-					updatePayload[payloadProperty] = firstAttachment.url;
-					replyContent += `\n- The ${messageStub} was set to <${firstAttachment.url}>.`;
-				}
-			}
-		}
-
-		origin.company.update(updatePayload);
-		modalInteraction.reply({ content: replyContent, flags: MessageFlags.Ephemeral });
+		configCompanyThumbnails("Server Message Thumbnail", thumbnailUpdateData, interaction, origin.company);
 	}
 );

--- a/source/frontend/commands/config-user-thumbnails-premium.js
+++ b/source/frontend/commands/config-user-thumbnails-premium.js
@@ -1,65 +1,32 @@
-const { PermissionFlagsBits, InteractionContextType, MessageFlags, ModalBuilder, LabelBuilder, FileUploadBuilder } = require("discord.js");
-const { SKIP_INTERACTION_HANDLING } = require('../../constants');
+const { PermissionFlagsBits, InteractionContextType } = require("discord.js");
 const { CommandWrapper } = require("../classes");
-const { timeConversion } = require('../../shared');
+const { configCompanyThumbnails } = require("../shared/flows/configCompanyThumbnails");
 
 const mainId = "config-user-thumbnails-premium";
-const imageFieldToPayloadPropertyAndMessage = new Map(Object.entries({
-	"toast-thumbnail": {
-		payloadProperty: "toastThumbnailURL",
-		messageStub: "toast thumbnail",
+const thumbnailUpdateData = [
+	{
+		label: "Toast Thumbnail",
 		description: "Set an image to use as thumbnail on toasts",
-		modalLabel: "Toast Thumbnail"
+		payloadProperty: "toastThumbnailURL"
 	},
-	"open-bounty-thumbnail": {
-		payloadProperty: "openBountyThumbnailURL",
-		messageStub: "open bounty thumbnail",
+	{
+		label: "Open Bounty Thumbnail",
 		description: "Set an image to use as thumbnail on open bounties",
-		modalLabel: "Open Bounty Thumbnail"
+		payloadProperty: "openBountyThumbnailURL"
 	},
-	"completed-bounty-thumbnail": {
-		payloadProperty: "completedBountyThumbnailURL",
-		messageStub: "completed bounty thumbnail",
+	{
+		label: "Completed Bounty Thumbnail",
 		description: "Set an image to use as thumbnail on completed bounties",
-		modalLabel: "Completed Bounty Thumbnail"
+		payloadProperty: "completedBountyThumbnailURL"
 	},
-	"deleted-bounty-thumbnail": {
-		payloadProperty: "deletedBountyThumbnailURL",
-		messageStub: "deleted bounty thumbnail",
+	{
+		label: "Deleted Bounty Thumbnail",
 		description: "Set an image to use as thumbnail on deleted bounties",
-		modalLabel: "Deleted Bounty Thumbnail"
+		payloadProperty: "deletedBountyThumbnailURL"
 	}
-}));
+];
 module.exports = new CommandWrapper(mainId, "Configure thumbnails shown for Toasts and Bounties (Premium)", PermissionFlagsBits.ManageGuild, true, [InteractionContextType.Guild], 3000,
 	async (interaction, origin, runMode) => {
-		const modalLabelComponents = [];
-		for (const [ imageField, { description, modalLabel } ] of imageFieldToPayloadPropertyAndMessage) {
-			modalLabelComponents.push(new LabelBuilder().setLabel(modalLabel).setDescription(description)
-				.setFileUploadComponent(
-					new FileUploadBuilder().setCustomId(imageField)
-						.setRequired(false)
-				))
-		}
-		const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`).setTitle("Configure User Thumnbails").addLabelComponents(modalLabelComponents);
-		
-		interaction.showModal(modal);
-		const modalInteraction = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") });
-		const updatePayload = {};
-
-		let replyContent = "The following thumbnails have been configured:";
-
-		for (const [ imageField, { payloadProperty, messageStub } ] of imageFieldToPayloadPropertyAndMessage) {
-			const thumbnailCollection = modalInteraction.fields.getUploadedFiles(imageField);
-			if (thumbnailCollection) {
-				const firstAttachment = thumbnailCollection.first();
-				if (firstAttachment) {
-					updatePayload[payloadProperty] = firstAttachment.url;
-					replyContent += `\n- The ${messageStub} was set to <${firstAttachment.url}>.`;
-				}
-			}
-		}
-
-		origin.company.update(updatePayload);
-		modalInteraction.reply({ content: replyContent, flags: MessageFlags.Ephemeral });
+		configCompanyThumbnails("Bounty and Toast Message Thumbnail", thumbnailUpdateData, interaction, origin.company);
 	}
 );

--- a/source/frontend/shared/flows/configCompanyThumbnails.js
+++ b/source/frontend/shared/flows/configCompanyThumbnails.js
@@ -1,0 +1,65 @@
+const { ModalBuilder, LabelBuilder, FileUploadBuilder, ContainerBuilder, Colors, TextDisplayBuilder, MediaGalleryBuilder, MediaGalleryItemBuilder, heading, MessageFlags, ChatInputCommandInteraction } = require("discord.js");
+const { SKIP_INTERACTION_HANDLING } = require("../../../constants");
+const { timeConversion } = require("../../../shared");
+const { Company } = require("../../../database/models");
+
+/**
+ * @param {string} thumbnailSetKind
+ * @param {{ label: string; description: string; payloadProperty: string; }[]} thumbnailUpdateData
+ * @param {ChatInputCommandInteraction} interaction
+ * @param {Company} company
+ */
+async function configCompanyThumbnails(thumbnailSetKind, thumbnailUpdateData, interaction, company) {
+	const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`).setTitle(`Configure ${thumbnailSetKind}s`);
+	for (const { label, description, payloadProperty } of thumbnailUpdateData) {
+		modal.addLabelComponents(
+			new LabelBuilder().setLabel(label).setDescription(description)
+				.setFileUploadComponent(
+					new FileUploadBuilder().setCustomId(payloadProperty)
+						.setRequired(false)
+				)
+		)
+	}
+
+	interaction.showModal(modal);
+	const modalInteraction = await interaction.awaitModalSubmit({ filter: incoming => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") });
+	const updatePayload = {};
+
+	const container = new ContainerBuilder().setAccentColor(Colors.Blurple)
+		.addTextDisplayComponents(new TextDisplayBuilder().setContent(heading(`${thumbnailSetKind} Changes`)))
+
+	const componentsForValidatedImages = [];
+	for (const { label, payloadProperty } of thumbnailUpdateData) {
+		const thumbnailCollection = modalInteraction.fields.getUploadedFiles(payloadProperty);
+		if (thumbnailCollection) {
+			const firstAttachment = thumbnailCollection.first();
+			if (firstAttachment) {
+				updatePayload[payloadProperty] = firstAttachment.url;
+				componentsForValidatedImages.push([
+					new TextDisplayBuilder().setContent(heading(label, 2)),
+					new MediaGalleryBuilder().addItems(new MediaGalleryItemBuilder().setURL(firstAttachment.url))
+				]);
+			}
+		}
+	}
+
+	let resultMessage;
+	if (componentsForValidatedImages.length > 0) {
+		resultMessage = "The following thumbnails were updated:";
+	} else {
+		resultMessage = "No valid thumbnail images were received."
+	}
+	container.addTextDisplayComponents(new TextDisplayBuilder().setContent(resultMessage))
+
+	for (const [textComponent, mediaGalleryComponent] of componentsForValidatedImages) {
+		container.addTextDisplayComponents(textComponent)
+			.addMediaGalleryComponents(mediaGalleryComponent);
+	}
+
+	company.update(updatePayload);
+	modalInteraction.reply({ components: [container], flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2 });
+}
+
+module.exports = {
+	configCompanyThumbnails
+};


### PR DESCRIPTION
Summary
-------
- use Container to show labeled received images in thumbnail config commands

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] `/config-user-thumbnails-premium` shows labeled images in container if received
- [x] `/config-user-thumbnails-premium` shows "no images received" message if none provided
- [x] `/config-server-thumbnails-premium` shows labeled images in container if received
- [x] `/config-server-thumbnails-premium` shows "no images received" message if none provided

Issue
-----
Closes #636