### PR TITLE
fix: include BypassSlowmode in bot invite permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 BountyBot is a Discord bot that facilitates community interaction by allowing users to create server-wide quests and rewarding active server particpation.
 
 ## Adding BountyBot to your Server
-[Click here](https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=2252135156869168&integration_type=0&scope=bot) to add BountyBot to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
+[Click here](https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=6755734784239664&integration_type=0&scope=bot) to add BountyBot to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
 
 ### Permissions
 Here are the permissions BountyBot asks for and a summary of what it uses each for:
@@ -13,6 +13,7 @@ Here are the permissions BountyBot asks for and a summary of what it uses each f
 - Create Events: Bounties created with start and end timestamps automatically create Discord events
 - Manage Events: Discord events created for bounties with are updated when their bounty is
 - Send Messages: BountyBot responds to commands in text channels, announces festival starts, etc
+- Bypass Slowmode: BountyBot can continue sending command responses, bounty updates, and moderation notices promptly in channels where slowmode is enabled
 - Create Public Threads: BountyBot can create a bounty board forum where each bounty gets a thread for discussion and organization
 - Send Messages in Threads: In bounty threads, BountyBot records updates or participation in bounties
 - Manage Messages: BountyBot edits the scoreboard message when Bounty Hunters earn XP, edits messages in bounty threads for updates, etc.

--- a/source/constants.js
+++ b/source/constants.js
@@ -27,7 +27,7 @@ module.exports = {
 
 	// Internal Constants
 	bountyBotIconURL: "https://cdn.discordapp.com/attachments/618523876187570187/1138968614364528791/BountyBotIcon.jpg",
-	BOUNTYBOT_INVITE_URL: "https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=2252135156869168&integration_type=0&scope=bot",
+	BOUNTYBOT_INVITE_URL: "https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=6755734784239664&integration_type=0&scope=bot",
 	SAFE_DELIMITER: "→",
 	SKIP_INTERACTION_HANDLING: "❌",
 	COMPANY_XP_COEFFICIENT: 3,


### PR DESCRIPTION
## Summary
- Updates the BountyBot invite URL permission integer to include Discord's `BypassSlowmode` permission.
- Keeps the existing requested permissions unchanged and only ORs in the missing `BypassSlowmode` bit.

## Test Plan
- `npm ci`
- Ran a local Node verification script using `discord.js` `PermissionFlagsBits.BypassSlowmode` to confirm the updated invite permissions include bit `4503599627370496`.

Closes #565
