### PR TITLE
fix: request BypassSlowmode permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 BountyBot is a Discord bot that facilitates community interaction by allowing users to create server-wide quests and rewarding active server particpation.
 
 ## Adding BountyBot to your Server
-[Click here](https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=2252135156869168&integration_type=0&scope=bot) to add BountyBot to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
+[Click here](https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=6755734784239664&integration_type=0&scope=bot) to add BountyBot to your server! The bot will be managable by anyone who has a role above the bot's roles, so make sure to check role order when the bot joins!
 
 ### Permissions
 Here are the permissions BountyBot asks for and a summary of what it uses each for:
@@ -13,6 +13,7 @@ Here are the permissions BountyBot asks for and a summary of what it uses each f
 - Create Events: Bounties created with start and end timestamps automatically create Discord events
 - Manage Events: Discord events created for bounties with are updated when their bounty is
 - Send Messages: BountyBot responds to commands in text channels, announces festival starts, etc
+- Bypass Slowmode: BountyBot can post bounty showcases, announcements, and other bot-managed updates in channels or threads that have slowmode enabled
 - Create Public Threads: BountyBot can create a bounty board forum where each bounty gets a thread for discussion and organization
 - Send Messages in Threads: In bounty threads, BountyBot records updates or participation in bounties
 - Manage Messages: BountyBot edits the scoreboard message when Bounty Hunters earn XP, edits messages in bounty threads for updates, etc.

--- a/source/constants.js
+++ b/source/constants.js
@@ -27,7 +27,7 @@ module.exports = {
 
 	// Internal Constants
 	bountyBotIconURL: "https://cdn.discordapp.com/attachments/618523876187570187/1138968614364528791/BountyBotIcon.jpg",
-	BOUNTYBOT_INVITE_URL: "https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=2252135156869168&integration_type=0&scope=bot",
+	BOUNTYBOT_INVITE_URL: "https://discord.com/oauth2/authorize?client_id=536330483852771348&permissions=6755734784239664&integration_type=0&scope=bot",
 	SAFE_DELIMITER: "→",
 	SKIP_INTERACTION_HANDLING: "❌",
 	COMPANY_XP_COEFFICIENT: 3,

--- a/wiki/Data-Policy.md
+++ b/wiki/Data-Policy.md
@@ -8,6 +8,7 @@ Here are the permissions BountyBot asks for and a summary of what it uses each f
 - Create Events: Bounties created with start and end timestamps automatically create Discord events
 - Manage Events: Discord events created for bounties with are updated when their bounty is
 - Send Messages: BountyBot responds to commands in text channels, announces festival starts, etc
+- Bypass Slowmode: BountyBot can post bounty showcases, announcements, and other bot-managed updates in channels or threads that have slowmode enabled
 - Create Public Threads: BountyBot can create a bounty board forum where each bounty gets a thread for discussion and organization
 - Send Messages in Threads: In bounty threads, BountyBot records updates or participation in bounties
 - Manage Messages: BountyBot edits the scoreboard message when Bounty Hunters earn XP, edits messages in bounty threads for updates, etc.


### PR DESCRIPTION
## Summary
- add the `BypassSlowmode` permission to BountyBot's invite URL
- document why the permission is needed in the README
- mirror the permission explanation in the data policy page

## Why
Discord split `BypassSlowmode` out from `ManageChannels`, and BountyBot posts bot-managed updates like bounty showcases and announcements into channels/threads that may have slowmode enabled. The current invite URL does not request that permission.

Closes #565
