### PR TITLE
back-ported type fixes from TypeScript port

### DIFF
--- a/source/frontend/classes/InteractionWrapper.js
+++ b/source/frontend/classes/InteractionWrapper.js
@@ -111,7 +111,7 @@ class MessageContextMenuWrapper extends ContextMenuWrapper {
 	 */
 	constructor(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction) {
 		super(mainIdInput, defaultMemberPermission, isPremiumCommand, contextEnums, cooldownInMS, executeFunction);
-		this.builder = this.builder.setType(ApplicationCommandType.User);
+		this.builder = this.builder.setType(ApplicationCommandType.Message);
 	}
 };
 

--- a/source/frontend/context_menus/_contextMenuDictionary.js
+++ b/source/frontend/context_menus/_contextMenuDictionary.js
@@ -1,4 +1,4 @@
-const { ContextMenuWrapper } = require("../classes");
+const { ContextMenuWrapper, BuildError } = require("../classes");
 
 /** @type {string[]} */
 exports.contextMenuFiles = [

--- a/source/index.js
+++ b/source/index.js
@@ -109,7 +109,7 @@ dAPIClient.on(Events.ClientReady, () => {
 	if (runMode === "production") {
 		(() => {
 			try {
-				new REST({ version: 10 }).setToken(require(authPath).token).put(
+				new REST({ version: "10" }).setToken(require(authPath).token).put(
 					Routes.applicationCommands(dAPIClient.user.id),
 					{ body: [...slashData, ...contextMenuData] }
 				).then(commands => {

--- a/source/index.js
+++ b/source/index.js
@@ -50,7 +50,6 @@ const dbConnection = new Sequelize(require(__dirname + '/../config/config.json')
 const models = {};
 
 const dAPIClient = new Client({
-	retryLimit: 5,
 	presence: {
 		activities: [{
 			type: ActivityType.Custom,
@@ -133,7 +132,7 @@ dAPIClient.on(Events.ClientReady, () => {
 					return;
 				}
 
-				latestVersionChangesEmbed(dAPIClient.user.displayAvatarURL()).then(embed => {
+				latestVersionChangesEmbed().then(embed => {
 					dAPIClient.guilds.fetch(testGuildId).then(guild => {
 						guild.channels.fetch(announcementsChannelId).then(announcementsChannel => {
 							announcementsChannel.send({ embeds: [embed] }).then(message => {


### PR DESCRIPTION
Summary
-------
Found during #260
- prune deprecated `retryLimit` property from `ClientOptions`
- fix providing a parameter to `latestVersionChangesEmbed`, when it doesn't need any
- fix type dAPI version property (was number, should be string)
- fix crash in context menu dictionary on BuildError not being imported
- fix MessageContextMenuWrapper builder having wrong type enum

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)