### PR TITLE
fixed items being consumed in some early outs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - The following actions now sends record keeping messages to bounty board threads: showcasing a bounty, adding a thumbnail
 - Fixed several crashes related to missed fetches on the bounty board
 - Fixed Critical Secondings adding the Seconder to the Toast's list of recipients
+- Fixed some items being consumed despite not compeleting due to running into an error mid-usage
 ## BountyBot Version 2.11.1ib:
 - Completing or taking down bounties now cancel the bounty's event if it hasn't been closed already
 - Fixed a crash when attempting to make an event for a bounty while missing permission

--- a/source/frontend/classes/ItemTemplate.js
+++ b/source/frontend/classes/ItemTemplate.js
@@ -19,7 +19,7 @@ class ItemTemplate {
 	 * @param {string} nameInput
 	 * @param {string} descriptionInput
 	 * @param {number} cooldownInMS
-	 * @param {(interaction: CommandInteraction, origin: InteractionOrigin) => Promise<boolean>} effectFunction
+	 * @param {(interaction: CommandInteraction, origin: InteractionOrigin) => Promise<number>} effectFunction
 	 */
 	constructor(nameInput, descriptionInput, cooldownInMS, effectFunction) {
 		this.name = nameInput;

--- a/source/frontend/commands/item.js
+++ b/source/frontend/commands/item.js
@@ -59,9 +59,9 @@ module.exports = new CommandWrapper(mainId, "Get details on a selected item and 
 			}
 			await logicLayer.cooldowns.updateCooldowns(collectedInteration.user.id, cooldownName, now, getItemCooldown(itemName));
 
-			return useItem(itemName, collectedInteration, origin).then(shouldSkipDecrement => {
-				if (!shouldSkipDecrement && runMode === "production") {
-					return logicLayer.items.consume(interaction.user.id, itemName);
+			useItem(itemName, collectedInteration, origin).then(usedCount => {
+				if (usedCount > 0 && runMode === "production") {
+					logicLayer.items.consume(interaction.user.id, itemName, usedCount);
 				}
 			});
 		}).catch(butIgnoreInteractionCollectorErrors).finally(() => {

--- a/source/frontend/items/_item_template.js
+++ b/source/frontend/items/_item_template.js
@@ -9,6 +9,7 @@ module.exports = new ItemTemplateSet(
 		/** specs */
 		async (interaction, origin) => {
 
+			return 1;
 		})
 ).setLogicLinker(logicBlob => {
 	logicLayer = logicBlob;

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -42,9 +42,8 @@ module.exports = new ItemTemplateSet(
 					return 0;
 				}
 
-				const bountyId = modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0];
-				const bounty = await openBounties.find(bounty => bounty.id === bountyId).reload();
-				if (bounty.state !== "open") {
+				const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+				if (!bounty || bounty.state !== "open") {
 					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}
@@ -52,7 +51,7 @@ module.exports = new ItemTemplateSet(
 				bounty.increment("showcaseCount");
 				await bounty.reload();
 				const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-				const embed = bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents));
+				const embed = bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bounty.id), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents));
 				const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
 
 				modalSubmission.reply({ content: `${modalSubmission.member} increased the reward on their bounty!`, embeds: [embed] });

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags, ComponentType, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { timeConversion } = require("../../shared");
-const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, butIgnoreInteractionCollectorErrors, getBountyBoardThread } = require("../shared");
+const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, getBountyBoardThread, isInteractionCollectorError } = require("../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
 
 /** @type {typeof import("../../logic")} */
@@ -14,10 +14,10 @@ module.exports = new ItemTemplateSet(
 			const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 			if (openBounties.length < 1) {
 				interaction.reply({ content: "You don't have any open bounties on this server to showcase.", flags: MessageFlags.Ephemeral });
-				return true;
+				return 0;
 			}
 
-			interaction.reply({
+			return interaction.reply({
 				content: `Showcasing a bounty will repost its embed in this channel and increases the XP awarded to completers. This item has a separate cooldown from ${commandMention("bounty showcase")}.`,
 				components: [
 					new ActionRowBuilder().addComponents(
@@ -31,18 +31,18 @@ module.exports = new ItemTemplateSet(
 			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
 				if (!collectedInteraction.channel.members.has(collectedInteraction.client.user.id)) {
 					collectedInteraction.reply({ content: "BountyBot is not in the selected channel.", flags: MessageFlags.Ephemeral });
-					return;
+					return 0;
 				}
 
 				if (!collectedInteraction.channel.permissionsFor(collectedInteraction.user.id).has(PermissionFlagsBits.ViewChannel & PermissionFlagsBits.SendMessages)) {
 					collectedInteraction.reply({ content: "You must have permission to view and send messages in the selected channel to showcase a bounty in it.", flags: MessageFlags.Ephemeral });
-					return;
+					return 0;
 				}
 
 				const bounty = await openBounties.find(bounty => bounty.id === collectedInteraction.values[0]).reload();
 				if (bounty.state !== "open") {
 					collectedInteraction.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
-					return;
+					return 0;
 				}
 
 				bounty.increment("showcaseCount");
@@ -64,11 +64,18 @@ module.exports = new ItemTemplateSet(
 						bountyThread.send({ content: `${collectedInteraction.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
 					}
 				}
-			}).catch(butIgnoreInteractionCollectorErrors).finally(() => {
+				return 1;
+			}).catch(error => {
+				if (!isInteractionCollectorError(error)) {
+					console.error(error);
+				}
+				return 0;
+			}).finally(() => {
 				// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
 				if (interaction.channel) {
 					interaction.deleteReply();
 				}
+				return 1;
 			})
 		}
 	)

--- a/source/frontend/items/bonus-bounty-showcase.js
+++ b/source/frontend/items/bonus-bounty-showcase.js
@@ -1,8 +1,9 @@
-const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags, ComponentType, PermissionFlagsBits } = require("discord.js");
+const { StringSelectMenuBuilder, MessageFlags, PermissionFlagsBits, LabelBuilder } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { timeConversion } = require("../../shared");
-const { commandMention, selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, getBountyBoardThread, isInteractionCollectorError } = require("../shared");
+const { selectOptionsFromBounties, bountyEmbed, unarchiveAndUnlockThread, getBountyBoardThread, isInteractionCollectorError } = require("../shared");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
+const { ModalBuilder } = require("discord.js");
 
 /** @type {typeof import("../../logic")} */
 let logicLayer;
@@ -17,51 +18,52 @@ module.exports = new ItemTemplateSet(
 				return 0;
 			}
 
-			return interaction.reply({
-				content: `Showcasing a bounty will repost its embed in this channel and increases the XP awarded to completers. This item has a separate cooldown from ${commandMention("bounty showcase")}.`,
-				components: [
-					new ActionRowBuilder().addComponents(
-						new StringSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
-							.setPlaceholder("Select a bounty...")
-							.setOptions(selectOptionsFromBounties(openBounties))
-					)
-				],
-				flags: MessageFlags.Ephemeral,
-				withResponse: true
-			}).then(response => response.resource.message.awaitMessageComponent({ time: 120000, componentType: ComponentType.StringSelect })).then(async collectedInteraction => {
-				if (!collectedInteraction.channel.members.has(collectedInteraction.client.user.id)) {
-					collectedInteraction.reply({ content: "BountyBot is not in the selected channel.", flags: MessageFlags.Ephemeral });
+			const labelIdBountyId = "bounty-id";
+			const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
+				.setTitle("Showcase Your Bounty")
+				.addLabelComponents(
+					new LabelBuilder().setLabel("Bounty")
+						.setDescription("Up a bounty's XP Reward and repost it in this channel. (Separate cooldown from `/bounty showcase`.)")
+						.setStringSelectMenuComponent(
+							new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
+								.setPlaceholder("Select a bounty...")
+								.setOptions(selectOptionsFromBounties(openBounties))
+						)
+				);
+			interaction.showModal(modal);
+			return interaction.awaitModalSubmit({ filter: (incoming) => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
+				if (!modalSubmission.channel.members.has(modalSubmission.client.user.id)) {
+					modalSubmission.reply({ content: "BountyBot is not in the selected channel.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}
 
-				if (!collectedInteraction.channel.permissionsFor(collectedInteraction.user.id).has(PermissionFlagsBits.ViewChannel & PermissionFlagsBits.SendMessages)) {
-					collectedInteraction.reply({ content: "You must have permission to view and send messages in the selected channel to showcase a bounty in it.", flags: MessageFlags.Ephemeral });
+				if (!modalSubmission.channel.permissionsFor(modalSubmission.user.id).has(PermissionFlagsBits.ViewChannel & PermissionFlagsBits.SendMessages)) {
+					modalSubmission.reply({ content: "You must have permission to view and send messages in the selected channel to showcase a bounty in it.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}
 
-				const bounty = await openBounties.find(bounty => bounty.id === collectedInteraction.values[0]).reload();
+				const bountyId = modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0];
+				const bounty = await openBounties.find(bounty => bounty.id === bountyId).reload();
 				if (bounty.state !== "open") {
-					collectedInteraction.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
+					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}
 
 				bounty.increment("showcaseCount");
 				await bounty.reload();
 				const currentPosterLevel = origin.hunter.getLevel(origin.company.xpCoefficient);
-				const embed = bountyEmbed(bounty, collectedInteraction.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(collectedInteraction.values[0]), await bounty.getScheduledEvent(collectedInteraction.guild.scheduledEvents));
-				const bountyThread = await getBountyBoardThread(collectedInteraction.guild, origin.company.bountyBoardId, bounty.postingId);
+				const embed = bountyEmbed(bounty, modalSubmission.member, currentPosterLevel, false, origin.company, await logicLayer.bounties.getHunterIdSet(bountyId), await bounty.getScheduledEvent(modalSubmission.guild.scheduledEvents));
+				const bountyThread = await getBountyBoardThread(modalSubmission.guild, origin.company.bountyBoardId, bounty.postingId);
 
-				// Send new message channel to avoid unloadable message reference in UI
-				collectedInteraction.channel.send({ content: `${collectedInteraction.member} increased the reward on their bounty!`, embeds: [embed] });
-				collectedInteraction.update({ components: [] });
+				modalSubmission.reply({ content: `${modalSubmission.member} increased the reward on their bounty!`, embeds: [embed] });
 
 				if (bountyThread) {
-					if (collectedInteraction.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
+					if (modalSubmission.guild.members.me.permissions.has(PermissionFlagsBits.ManageThreads)) {
 						(await bountyThread.fetchStarterMessage()).edit({ embeds: [embed] });
 						await unarchiveAndUnlockThread(bountyThread, "Bonus Bounty Showcase item used");
 					}
 					if (bountyThread.sendable) {
-						bountyThread.send({ content: `${collectedInteraction.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
+						bountyThread.send({ content: `${modalSubmission.member} increased the reward on this bounty!`, flags: MessageFlags.SuppressNotifications });
 					}
 				}
 				return 1;
@@ -70,12 +72,6 @@ module.exports = new ItemTemplateSet(
 					console.error(error);
 				}
 				return 0;
-			}).finally(() => {
-				// If the hosting channel was deleted before cleaning up `interaction`'s reply, don't crash by attempting to clean up the reply
-				if (interaction.channel) {
-					interaction.deleteReply();
-				}
-				return 1;
 			})
 		}
 	)

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -1,7 +1,7 @@
 const { StringSelectMenuBuilder, ModalBuilder, MessageFlags, LabelBuilder, FileUploadBuilder, channelMention, PermissionFlagsBits } = require("discord.js");
 const { ItemTemplate, ItemTemplateSet } = require("../classes");
 const { SKIP_INTERACTION_HANDLING } = require("../../constants");
-const { selectOptionsFromBounties, butIgnoreInteractionCollectorErrors, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, commandMention } = require("../shared");
+const { selectOptionsFromBounties, getBountyBoardThread, bountyEmbed, unarchiveAndUnlockThread, commandMention, isInteractionCollectorError } = require("../shared");
 const { timeConversion } = require("../../shared");
 
 /** @type {typeof import("../../logic")} */
@@ -14,7 +14,7 @@ module.exports = new ItemTemplateSet(
 			const openBounties = await logicLayer.bounties.findOpenBounties(interaction.user.id, interaction.guild.id);
 			if (openBounties.length < 1) {
 				interaction.reply({ content: "You don't have any open bounties on this server to add a thumbnail to.", flags: MessageFlags.Ephemeral });
-				return true;
+				return 0;
 			}
 			const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 				.setTitle("Add Bounty Thumbnail")
@@ -36,14 +36,14 @@ module.exports = new ItemTemplateSet(
 				const bounty = await openBounties.find(bounty => bounty.id === modalSubmission.fields.getStringSelectValues("bounty-id")[0]).reload();
 				if (bounty?.state !== "open") {
 					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
-					return;
+					return 0;
 				}
 
 				const imageFileCollection = modalSubmission.fields.getUploadedFiles("image", true);
 				const firstAttachment = imageFileCollection.first();
 				if (!firstAttachment) {
 					modalSubmission.reply({ content: "There was an error handling the submitted image.", flags: MessageFlags.Ephemeral });
-					return;
+					return 0;
 				}
 
 				await bounty.update({ thumbnailURL: firstAttachment.url });
@@ -59,7 +59,13 @@ module.exports = new ItemTemplateSet(
 						bountyThread.send({ content: `This bounty's poster used ${commandMention("item")} to add a thumbnail to this bounty.`, flags: MessageFlags.SuppressNotifications });
 					}
 				}
-			}).catch(butIgnoreInteractionCollectorErrors);
+				return 1;
+			}).catch(error => {
+				if (!isInteractionCollectorError(error)) {
+					console.error(error);
+				}
+				return 0;
+			});
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -36,8 +36,8 @@ module.exports = new ItemTemplateSet(
 			interaction.showModal(modal);
 
 			return interaction.awaitModalSubmit({ filter: (incoming) => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
-				const bounty = await openBounties.find(bounty => bounty.id === modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]).reload();
-				if (bounty?.state !== "open") {
+				const bounty = await logicLayer.bounties.findBounty(modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]);
+				if (!bounty || bounty.state !== "open") {
 					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}

--- a/source/frontend/items/bounty-thumbnail.js
+++ b/source/frontend/items/bounty-thumbnail.js
@@ -16,30 +16,33 @@ module.exports = new ItemTemplateSet(
 				interaction.reply({ content: "You don't have any open bounties on this server to add a thumbnail to.", flags: MessageFlags.Ephemeral });
 				return 0;
 			}
+
+			const labelIdBountyId = "bounty-id";
+			const lableIdImage = "image";
 			const modal = new ModalBuilder().setCustomId(`${SKIP_INTERACTION_HANDLING}${interaction.id}`)
 				.setTitle("Add Bounty Thumbnail")
 				.addLabelComponents(
 					new LabelBuilder().setLabel("Bounty")
 						.setStringSelectMenuComponent(
-							new StringSelectMenuBuilder().setCustomId("bounty-id")
+							new StringSelectMenuBuilder().setCustomId(labelIdBountyId)
 								.setPlaceholder("Select a bounty...")
 								.setOptions(selectOptionsFromBounties(openBounties))
 						),
 					new LabelBuilder().setLabel("Image")
 						.setFileUploadComponent(
-							new FileUploadBuilder().setCustomId("image")
+							new FileUploadBuilder().setCustomId(lableIdImage)
 						)
 				);
 			interaction.showModal(modal);
 
 			return interaction.awaitModalSubmit({ filter: (incoming) => incoming.customId === modal.data.custom_id, time: timeConversion(5, "m", "ms") }).then(async modalSubmission => {
-				const bounty = await openBounties.find(bounty => bounty.id === modalSubmission.fields.getStringSelectValues("bounty-id")[0]).reload();
+				const bounty = await openBounties.find(bounty => bounty.id === modalSubmission.fields.getStringSelectValues(labelIdBountyId)[0]).reload();
 				if (bounty?.state !== "open") {
 					modalSubmission.reply({ content: "The selected bounty does not seem to be open.", flags: MessageFlags.Ephemeral });
 					return 0;
 				}
 
-				const imageFileCollection = modalSubmission.fields.getUploadedFiles("image", true);
+				const imageFileCollection = modalSubmission.fields.getUploadedFiles(lableIdImage, true);
 				const firstAttachment = imageFileCollection.first();
 				if (!firstAttachment) {
 					modalSubmission.reply({ content: "There was an error handling the submitted image.", flags: MessageFlags.Ephemeral });

--- a/source/frontend/items/colorizers.js
+++ b/source/frontend/items/colorizers.js
@@ -13,6 +13,7 @@ class Colorizer extends ItemTemplate {
 			async (interaction, origin) => {
 				await logicLayer.hunters.setHunterProfileColor(interaction.user.id, interaction.guild.id, color.replace(/ /g, ""));
 				interaction.reply({ content: `Your profile color has been set to ${color === "Default" ? "black" : color} in this server.`, flags: MessageFlags.Ephemeral });
+				return 1;
 			}
 		);
 	}

--- a/source/frontend/items/goal-initializer.js
+++ b/source/frontend/items/goal-initializer.js
@@ -12,7 +12,7 @@ module.exports = new ItemTemplateSet(
 			const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guildId);
 			if (!!goal) {
 				interaction.reply({ content: "This server already has a Server Goal running.", flags: MessageFlags.Ephemeral });
-				return true;
+				return 0;
 			}
 
 			const eligibleTypes = ["bounties", "toasts", "secondings"];
@@ -22,6 +22,7 @@ module.exports = new ItemTemplateSet(
 			const requiredGP = Math.max(activeHunters * 20, 60);
 			await logicLayer.goals.createGoal(interaction.guildId, goalType, requiredGP);
 			interaction.channel.send(addCompanyAnnouncementPrefix(origin.company, { content: `${interaction.member} has started a Server Goal! Completing bounties, raising toasts, and seconding toasts on this server contributes Goal Points (GP) toward completing the goal.\n\nThis time, ${bold(`${goalType} are worth double GP`)}!` }));
+			return 1;
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/loot-box.js
+++ b/source/frontend/items/loot-box.js
@@ -17,6 +17,7 @@ module.exports = new ItemTemplateSet(
 				}
 			}
 			interaction.reply({ content: `Inside the Loot Box was ${sentenceListEN(rolledItems)}! Use one with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
+			return 1;
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/progress-in-a-can.js
+++ b/source/frontend/items/progress-in-a-can.js
@@ -12,7 +12,7 @@ module.exports = new ItemTemplateSet(
 			const goal = await logicLayer.goals.findCurrentServerGoal(interaction.guild.id);
 			if (!goal) {
 				interaction.reply({ content: "There isn't currently a Server Goal running.", flags: MessageFlags.Ephemeral });
-				return true;
+				return 0;
 			}
 			const [season] = await logicLayer.seasons.findOrCreateCurrentSeason(interaction.guildId);
 			const { goalProgress } = await logicLayer.goals.progressGoal(origin.company, goal.type, origin.hunter, season);
@@ -21,6 +21,7 @@ module.exports = new ItemTemplateSet(
 				resultPayload.embeds = [goalCompletionEmbed(goalProgress.contributorIds)];
 			}
 			interaction.channel.send(resultPayload);
+			return 1;
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/unidentified-item.js
+++ b/source/frontend/items/unidentified-item.js
@@ -11,6 +11,7 @@ module.exports = new ItemTemplateSet(
 		async (interaction, origin) => {
 			const [itemRow] = await logicLayer.items.rollItemForHunter(1, origin.hunter);
 			interaction.reply({ content: `The unidentified item was a ${bold(itemRow.itemName)}! Use it with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
+			return 1;
 		}
 	)
 ).setLogicLinker(logicBlob => {

--- a/source/frontend/items/xp-boosts.js
+++ b/source/frontend/items/xp-boosts.js
@@ -43,6 +43,7 @@ class XPBoost extends ItemTemplate {
 				} else {
 					refreshReferenceChannelScoreboardOverall(origin.company, interaction.guild, hunterMap, goalProgress);
 				}
+				return 1;
 			}
 		)
 	}

--- a/source/logic/items.js
+++ b/source/logic/items.js
@@ -102,7 +102,7 @@ async function rollItemForHunter(dropRate, hunter) {
 	}
 	if (!droppedItem) return [null, false];
 
-	return [ await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true ];
+	return [await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true];
 }
 
 /** *Finds the count of the specified Items of User*
@@ -113,14 +113,17 @@ function countUserCopies(userId, itemName) {
 	return db.models.Item.count({ where: { userId, itemName, used: false } });
 }
 
-/** *Sets the oldest of the specified Items of User to used*
- * Assumes item is extent
+/** *Sets the oldest `count` of the specified Items of User to used*
  * @param {string} userId
  * @param {string} itemName
+ * @param {number} count validation for sufficient existing item count is assumed to already have been done
  */
-async function consume(userId, itemName) {
-	const dbRow = await db.models.Item.findOne({ where: { userId, itemName, used: false }, order: [["createdAt", "ASC"]] });
-	return dbRow.update("used", true);
+async function consume(userId, itemName, count) {
+	const rows = await db.models.Item.findAll({ where: { userId, itemName, used: false }, order: [["createdAt", "ASC"]], limit: count });
+	for (const row of rows) {
+		await row.update("used", true);
+	}
+	return rows;
 }
 
 /** Destroy used items to reduce table size and obfuscate id generation */


### PR DESCRIPTION
Summary
-------
- refactored item procedures to return the count of items to consume (usually 0 or 1, but may later make self-combining items that consume more than 1)
- pruned unused return data in item flow
- refactored Bonus Bounty Showcase to use modal instead of in-message select to avoid manual ephemeral message handling

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)
- [x] Bonus Bounty Showcase completes critical path after refactor