### PR TITLE
item drop fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 - The following actions now sends record keeping messages to bounty board threads: showcasing a bounty, adding a thumbnail
 - Fixed several crashes related to missed fetches on the bounty board
 - Fixed Critical Secondings adding the Seconder to the Toast's list of recipients
+- Fixed a bug where only the lowest rarity tier was being rolled on for items
+- Fixed Undentified Items and Loot Boxes consuming Item Find Boosts
 ## BountyBot Version 2.11.1ib:
 - Completing or taking down bounties now cancel the bounty's event if it hasn't been closed already
 - Fixed a crash when attempting to make an event for a bounty while missing permission

--- a/source/frontend/items/loot-box.js
+++ b/source/frontend/items/loot-box.js
@@ -11,7 +11,7 @@ module.exports = new ItemTemplateSet(
 		async (interaction, origin) => {
 			const rolledItems = [];
 			for (let i = 0; i < 2; i++) {
-				const [itemRow] = await logicLayer.items.createRandomItem(origin.hunter);
+				const itemRow = await logicLayer.items.createRandomItem(origin.hunter);
 				rolledItems.push(`a ${bold(itemRow.itemName)}`);
 			}
 			interaction.reply({ content: `Inside the Loot Box was ${sentenceListEN(rolledItems)}! Use one with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });

--- a/source/frontend/items/loot-box.js
+++ b/source/frontend/items/loot-box.js
@@ -11,10 +11,8 @@ module.exports = new ItemTemplateSet(
 		async (interaction, origin) => {
 			const rolledItems = [];
 			for (let i = 0; i < 2; i++) {
-				const [itemRow] = await logicLayer.items.rollItemForHunter(1, origin.hunter);
-				if (itemRow) {
-					rolledItems.push(`a ${bold(itemRow.itemName)}`);
-				}
+				const [itemRow] = await logicLayer.items.createRandomItem(origin.hunter);
+				rolledItems.push(`a ${bold(itemRow.itemName)}`);
 			}
 			interaction.reply({ content: `Inside the Loot Box was ${sentenceListEN(rolledItems)}! Use one with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
 		}

--- a/source/frontend/items/unidentified-item.js
+++ b/source/frontend/items/unidentified-item.js
@@ -9,7 +9,7 @@ const itemName = "Unidentified Item";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Rolls as a random item!", 3000,
 		async (interaction, origin) => {
-			const [itemRow] = await logicLayer.items.createRandomItem(origin.hunter);
+			const itemRow = await logicLayer.items.createRandomItem(origin.hunter);
 			interaction.reply({ content: `The unidentified item was a ${bold(itemRow.itemName)}! Use it with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
 		}
 	)

--- a/source/frontend/items/unidentified-item.js
+++ b/source/frontend/items/unidentified-item.js
@@ -9,7 +9,7 @@ const itemName = "Unidentified Item";
 module.exports = new ItemTemplateSet(
 	new ItemTemplate(itemName, "Rolls as a random item!", 3000,
 		async (interaction, origin) => {
-			const [itemRow] = await logicLayer.items.rollItemForHunter(1, origin.hunter);
+			const [itemRow] = await logicLayer.items.createRandomItem(origin.hunter);
 			interaction.reply({ content: `The unidentified item was a ${bold(itemRow.itemName)}! Use it with ${commandMention("item")}?`, flags: MessageFlags.Ephemeral });
 		}
 	)

--- a/source/logic/bounties.js
+++ b/source/logic/bounties.js
@@ -161,8 +161,8 @@ async function completeBounty(bounty, poster, validatedHunters, season, company)
 		if (currentHunterLevel > previousHunterLevel) {
 			hunterReceipt.levelUp = { achievedLevel: currentHunterLevel, previousLevel: previousHunterLevel };
 		}
-		const [itemRow, wasCreated] = await rollItemForHunter(1 / 8, hunter);
-		if (wasCreated) {
+		const itemRow = await rollItemForHunter(1 / 8, hunter);
+		if (itemRow) {
 			hunterReceipt.item = itemRow.itemName;
 		}
 		const [participation, participationCreated] = await db.models.Participation.findOrCreate({ where: { companyId: bounty.companyId, userId: hunterId, seasonId: season.id }, defaults: { xp: bountyValue } });
@@ -182,8 +182,8 @@ async function completeBounty(bounty, poster, validatedHunters, season, company)
 	if (currentPosterLevel > previousPosterLevel) {
 		posterReceipt.levelUp = { achievedLevel: currentPosterLevel, previousLevel: previousPosterLevel };
 	}
-	const [itemRow, wasCreated] = await rollItemForHunter(1 / 4, poster);
-	if (wasCreated) {
+	const itemRow = await rollItemForHunter(1 / 4, poster);
+	if (itemRow) {
 		posterReceipt.item = itemRow.itemName;
 	}
 	hunterReceipts.set(poster.userId, posterReceipt);

--- a/source/logic/items.js
+++ b/source/logic/items.js
@@ -78,8 +78,8 @@ async function getDropsAvailable(hunterId) {
 	return itemCutoff - itemsDropped;
 }
 
-/** *Grants the User 1 copy of a random Item at a rate of dropRate*
- * @param {number} dropRate a decimal representing the probability
+/** *If `dropRate` (decimal probability) succeeds, grants `hunter` 1 copy of a random Item*
+ * @param {number} dropRate
  * @param {Hunter} hunter
  * @returns {Promise<[itemRow: Item | null, wasCreated: boolean]>}
  */
@@ -97,12 +97,29 @@ async function rollItemForHunter(dropRate, hunter) {
 			if (poolRandomNumber > threshold) {
 				const pool = DROP_TABLE[threshold];
 				droppedItem = pool[Math.floor(Math.random() * pool.length)];
+				break;
 			}
 		}
 	}
 	if (!droppedItem) return [null, false];
 
-	return [ await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true ];
+	return [await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true];
+}
+
+/** *Grants the User 1 copy of a random Item at a rate of dropRate*
+ * @param {Hunter} hunter
+ * @returns {Promise<[itemRow: Item, wasCreated: boolean]>}
+ */
+async function createRandomItem(hunter) {
+	const poolRandomNumber = Math.random() * 120;
+	let pool = [];
+	for (const [threshold, poolCandidate] of Object.entries(DROP_TABLE)) {
+		if (poolRandomNumber > parseFloat(threshold)) {
+			pool = poolCandidate;
+			break;
+		}
+	}
+	return [await db.Items.create({ userId: hunter.userId, itemName: pool[Math.floor(Math.random() * pool.length)] }), true];
 }
 
 /** *Finds the count of the specified Items of User*
@@ -133,6 +150,7 @@ module.exports = {
 	getInventory,
 	getDropsAvailable,
 	rollItemForHunter,
+	createRandomItem,
 	countUserCopies,
 	consume,
 	sweepUsed

--- a/source/logic/items.js
+++ b/source/logic/items.js
@@ -81,7 +81,7 @@ async function getDropsAvailable(hunterId) {
 /** *If `dropRate` (decimal probability) succeeds, grants `hunter` 1 copy of a random Item*
  * @param {number} dropRate
  * @param {Hunter} hunter
- * @returns {Promise<[itemRow: Item | null, wasCreated: boolean]>}
+ * @returns {Promise<Item | null>}
  */
 async function rollItemForHunter(dropRate, hunter) {
 	if (hunter.itemFindBoost) {
@@ -101,16 +101,16 @@ async function rollItemForHunter(dropRate, hunter) {
 			}
 		}
 	}
-	if (!droppedItem) return [null, false];
+	if (!droppedItem) return null;
 
-	return [await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true];
+	return db.models.Item.create({ userId: hunter.userId, itemName: droppedItem });
 }
 
 /** *Grants the User 1 copy of a random Item without consuming itemFindBoost*
  * @param {Hunter} hunter
- * @returns {Promise<[itemRow: Item, wasCreated: boolean]>}
+ * @returns {Promise<Item>}
  */
-async function createRandomItem(hunter) {
+function createRandomItem(hunter) {
 	const poolRandomNumber = Math.random() * 120;
 	let pool = [];
 	for (const [threshold, poolCandidate] of Object.entries(DROP_TABLE)) {
@@ -119,7 +119,7 @@ async function createRandomItem(hunter) {
 			break;
 		}
 	}
-	return [await db.Items.create({ userId: hunter.userId, itemName: pool[Math.floor(Math.random() * pool.length)] }), true];
+	return db.Items.create({ userId: hunter.userId, itemName: pool[Math.floor(Math.random() * pool.length)] });
 }
 
 /** *Finds the count of the specified Items of User*

--- a/source/logic/items.js
+++ b/source/logic/items.js
@@ -106,7 +106,7 @@ async function rollItemForHunter(dropRate, hunter) {
 	return [await db.models.Item.create({ userId: hunter.userId, itemName: droppedItem }), true];
 }
 
-/** *Grants the User 1 copy of a random Item at a rate of dropRate*
+/** *Grants the User 1 copy of a random Item without consuming itemFindBoost*
  * @param {Hunter} hunter
  * @returns {Promise<[itemRow: Item, wasCreated: boolean]>}
  */


### PR DESCRIPTION
Summary
-------
- fix drops always rolling on most common pool
- fix Unidentified Item and Loot Box consuming Item Find Boost
- remove redundant data from return of `rollItemForHunter`

Local Tests Performed
---------------------
- [x] bot still turns on (no build errors, circular dependencies, or start-up errors)